### PR TITLE
Fix ink-v3-schema: dispatchKey is string type

### DIFF
--- a/substrate/ink-abi/src/metadata/ink-v3-schema.json
+++ b/substrate/ink-abi/src/metadata/ink-v3-schema.json
@@ -215,11 +215,7 @@
       "properties": {
         "dispatchKey": {
           "description": "The key where the discriminant is stored to dispatch the variants.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/LayoutKey"
-            }
-          ]
+          "type": "string"
         },
         "variants": {
           "description": "The variants of the enum.",


### PR DESCRIPTION
Like cell's key, dispatchKey is always string type.