### PR TITLE
Fix corrupted message name if abi contains messages with path

### DIFF
--- a/substrate/ink-abi/src/abi-description.ts
+++ b/substrate/ink-abi/src/abi-description.ts
@@ -55,7 +55,7 @@ export class AbiDescription {
             kind: TypeKind.Variant,
             variants: list.map((msg, index) => {
                 return {
-                    name: msg.label,
+                    name: msg.label.replaceAll('::', '_'),
                     index,
                     fields: msg.args.map(arg => {
                         return {


### PR DESCRIPTION
For example, if we use openbrush's PSP22, it will generate
```typescript
export interface Message_PSP22::allowance {
  __kind: 'PSP22::allowance'
  owner: Uint8Array
  spender: Uint8Array
}
```
which is not valid naming in typescript. With this PR, it generates
```typescript
export interface Message_PSP22_allowance {
  __kind: 'PSP22_allowance'
  owner: Uint8Array
  spender: Uint8Array
}
```