### PR TITLE
Add Request data from ExpressContext to graphql server's Context

### DIFF
--- a/common/changes/@subsquid/graphql-server/lw-add-request-to-context_2022-12-19-11-08.json
+++ b/common/changes/@subsquid/graphql-server/lw-add-request-to-context_2022-12-19-11-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/graphql-server",
+      "comment": "Add Request data from ExpressContext to graphql server's Context object",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/graphql-server"
+}

--- a/common/changes/@subsquid/openreader/lw-add-request-to-context_2022-12-19-11-08.json
+++ b/common/changes/@subsquid/openreader/lw-add-request-to-context_2022-12-19-11-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/openreader",
+      "comment": "Change ApolloOptions type to support ExpressContext argument for ApolloOptions.context function",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/openreader"
+}

--- a/graphql/openreader/src/context.ts
+++ b/graphql/openreader/src/context.ts
@@ -1,9 +1,11 @@
+import { Request } from 'express'
 import {Dialect} from './dialect'
 import {Query} from './sql/query'
 import {Limit} from './util/limit'
 
 
 export interface Context {
+    req: Request
     openreader: OpenreaderContext
 }
 

--- a/graphql/openreader/src/server.ts
+++ b/graphql/openreader/src/server.ts
@@ -1,7 +1,7 @@
 import {Logger} from '@subsquid/logger'
 import {listen, ListeningServer} from '@subsquid/util-internal-http-server'
 import {KeyValueCache, PluginDefinition} from 'apollo-server-core'
-import {ApolloServer} from 'apollo-server-express'
+import {ApolloServer, ExpressContext} from 'apollo-server-express'
 import express from 'express'
 import fs from 'fs'
 import {ExecutionArgs, GraphQLSchema} from 'graphql'
@@ -43,7 +43,7 @@ export async function serve(options: ServerOptions): Promise<ListeningServer> {
 
     let schema = new SchemaBuilder(options).build()
 
-    let context = () => {
+    let context = ({ req }: ExpressContext) => {
         let openreader: OpenreaderContext = new PoolOpenreaderContext(
             dialect,
             connection,
@@ -61,6 +61,7 @@ export async function serve(options: ServerOptions): Promise<ListeningServer> {
         }
 
         return {
+            req,
             openreader
         }
     }
@@ -88,7 +89,7 @@ export type Dispose = () => Promise<void>
 export interface ApolloOptions {
     port: number | string
     disposals: Dispose[]
-    context: () => Context
+    context: (ctx: ExpressContext) => Context
     schema: GraphQLSchema
     plugins?: PluginDefinition[]
     subscriptions?: boolean


### PR DESCRIPTION
Add Request data from ExpressContext to graphql server's Context to allow retrieving useful request data, like client ip, HTTP headers inside custom resolvers, allowing the squid developer to implement authentication, rate limiting etc. for the custom graphql endpoints.

A simple example usage: https://github.com/Lezek123/orion/blob/orion-v2/src/server-extension/resolvers/VideosResolver/index.ts#L47