### PR TITLE
fix: data.v missing; should be oddYParity

### DIFF
--- a/substrate/frontier/src/transaction.ts
+++ b/substrate/frontier/src/transaction.ts
@@ -83,7 +83,7 @@ export function getAsV1(args: any): Transaction {
     const transaction = args.transaction
     const data = transaction.value
     const signature = data.signature || {
-        v: data.v,
+        v: data.oddYParity,
         r: data.r,
         s: data.s,
     }


### PR DESCRIPTION
Substrate call data contains oddYParity, instead of v.