### PR TITLE
allow to pass multiple config files into `substrate-typegen` command

### DIFF
--- a/common/changes/@subsquid/substrate-typegen/multiconfig-substrate-typegen_2023-02-08-08-18.json
+++ b/common/changes/@subsquid/substrate-typegen/multiconfig-substrate-typegen_2023-02-08-08-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/substrate-typegen",
+      "comment": "allow to pass multiple configs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/substrate-typegen"
+}

--- a/substrate/substrate-typegen/src/main.ts
+++ b/substrate/substrate-typegen/src/main.ts
@@ -28,6 +28,8 @@ Generates TypeScript classes for events, calls and storage items
     program.argument('[config...]', 'JSON file with options')
 
     for (let configFile of program.parse().processedArgs[0]){
+        log.info(`using ${configFile}`)
+
         let config = await readConfig(configFile)
 
         let typesBundle: OldTypesBundle | OldSpecsBundle | undefined

--- a/substrate/substrate-typegen/src/main.ts
+++ b/substrate/substrate-typegen/src/main.ts
@@ -25,34 +25,34 @@ runProgram(async () => {
 Generates TypeScript classes for events, calls and storage items
     `.trim())
 
-    program.argument('config', 'JSON file with options')
+    program.argument('[config...]', 'JSON file with options')
 
-    let configFile = program.parse().args[0]
-    let config = await readConfig(configFile)
+    for (let configFile of program.parse().processedArgs[0]){
+        let config = await readConfig(configFile)
 
-    let typesBundle: OldTypesBundle | OldSpecsBundle | undefined
-    if (config.typesBundle) {
-        typesBundle = getOldTypesBundle(config.typesBundle) || readOldTypesBundle(config.typesBundle)
+        let typesBundle: OldTypesBundle | OldSpecsBundle | undefined
+        if (config.typesBundle) {
+            typesBundle = getOldTypesBundle(config.typesBundle) || readOldTypesBundle(config.typesBundle)
+        }
+
+        let specVersions: SpecVersion[]
+        if (/^https?:\/\//.test(config.specVersions)) {
+            log.info(`downloading spec versions from ${config.specVersions}`)
+            specVersions = await new ArchiveApi(config.specVersions, log.child('archive')).fetchVersions()
+        } else {
+            specVersions = readSpecVersions(config.specVersions)
+        }
+
+        Typegen.generate({
+            outDir: config.outDir,
+            specVersions,
+            typesBundle,
+            events: config.events,
+            calls: config.calls,
+            storage: config.storage,
+            constants: config.constants
+        })
     }
-
-    let specVersions: SpecVersion[]
-    if (/^https?:\/\//.test(config.specVersions)) {
-        log.info(`downloading spec versions from ${config.specVersions}`)
-        specVersions = await new ArchiveApi(config.specVersions, log.child('archive')).fetchVersions()
-    } else {
-        specVersions = readSpecVersions(config.specVersions)
-    }
-
-    Typegen.generate({
-        outDir: config.outDir,
-        specVersions,
-        typesBundle,
-        events: config.events,
-        calls: config.calls,
-        storage: config.storage,
-        constants: config.constants
-    })
-
 }, err => {
     if (err instanceof ConfigError || err instanceof OldTypesBundleError || err instanceof SpecFileError) {
         log.fatal(err.message)

--- a/test/balances/src/types/support.ts
+++ b/test/balances/src/types/support.ts
@@ -114,7 +114,7 @@ export class StorageBase {
     }
 
     protected getKeys(...args: any[]): Promise<any[]> {
-        return this._chain.getKeys(this.blockHash, this.getPrefix(), this.getPrefix(), ...args)
+        return this._chain.getKeys(this.blockHash, this.getPrefix(), this.getName(), ...args)
     }
 
     protected getKeysPaged(pageSize: number, ...args: any[]): AsyncIterable<any[]> {


### PR DESCRIPTION
this will allow to do
```
npx squid-substrate-typegen ./kusama.json ./polkadot.json
```
or
```
npx squid-substrate-typegen ./typegen/*.json
```
in multichain projects instead of writing bash script