### PR TITLE
Deprecated call to a method of Response from 'node-fetch'

### DIFF
--- a/util/util-internal-http-client/src/client.ts
+++ b/util/util-internal-http-client/src/client.ts
@@ -276,7 +276,7 @@ export class HttpClient {
             return res.text()
         }
 
-        let bytes = await res.buffer()
+        let bytes = await res.arrayBuffer()
         if (bytes.length == 0) return undefined
         return bytes
     }


### PR DESCRIPTION
I've got a DeprecationWarning-turned-error when working with the substrate template. Tracing the issue revealed that it comes from `@subsquid/util-internal-http-client`:
```bash
$ node --trace-deprecation -r dotenv/config ./lib/processor.js 
01:25:02 WARN  sqd:processor .setBatchSize() is deprecated and has no effect
01:25:02 INFO  sqd:processor last processed block was 687999
01:25:02 INFO  sqd:processor processing blocks from 688000
01:25:03 INFO  sqd:processor prometheus metrics are served at port 3000
(node:22255) [node-fetch#buffer] DeprecationWarning: Please use 'response.arrayBuffer()' instead of 'response.buffer()'
    at ArchiveClient.handleResponseBody (/tmp/substrate-crust-tutorial/node_modules/@subsquid/util-internal-http-client/lib/client.js:200:31)
    at ArchiveClient.performRequest (/tmp/substrate-crust-tutorial/node_modules/@subsquid/util-internal-http-client/lib/client.js:187:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ArchiveClient.request (/tmp/substrate-crust-tutorial/node_modules/@subsquid/util-internal-http-client/lib/client.js:31:23)
    at async ArchiveClient.graphqlRequest (/tmp/substrate-crust-tutorial/node_modules/@subsquid/util-internal-http-client/lib/client.js:267:19)
    at async /tmp/substrate-crust-tutorial/node_modules/@subsquid/substrate-processor/lib/ingest.js:52:32
```
After replacing the call in the JS code the squid works well. Bringing the fix here.