### PR TITLE
Allow _ prefix for type and prop

### DIFF
--- a/graphql/openreader/src/model.tools.ts
+++ b/graphql/openreader/src/model.tools.ts
@@ -137,8 +137,8 @@ export function validateModel(model: Model) {
 }
 
 
-const TYPE_NAME_REGEX = /^[A-Z][a-zA-Z0-9]*$/
-const PROP_NAME_REGEX = /^[a-z][a-zA-Z0-9]*$/
+const TYPE_NAME_REGEX = /^_?[A-Z][a-zA-Z0-9]*$/
+const PROP_NAME_REGEX = /^_?[a-z][a-zA-Z0-9]*$/
 
 
 export function validateNames(model: Model) {


### PR DESCRIPTION
Allow _ prefix seems secure.

My case is, on-chain, an NFT item full represent is `(CollectionId, ItemId)`, in squid, the below code will have a conflict

```
type NftExtendInfo @entity {
  id: ID!

  nftItem: NftItem! # It generates a varchar column nft_item_id to the database to store the foreign key, the format would like `${NftCollectionId}-${NftItemId}`
  nftItemId: Int! # This is the pure on-chain NFT item id
}
```

By introducing _ prop prefix, I would like to change it to

```
type NftExtendInfo @entity {
  _id: ID!

  _nftItem: NftItem!
  nftItemId: Int!
}
```

In addition, I also introducing _ prefix for type, I'm not use that, but I think it helpful for some cases