### PR TITLE
make unique fields nullable

### DIFF
--- a/common/changes/@subsquid/openreader/null-unique_2023-07-04-20-08.json
+++ b/common/changes/@subsquid/openreader/null-unique_2023-07-04-20-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/openreader",
+      "comment": "make unique fields nullable",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/openreader"
+}

--- a/common/changes/@subsquid/typeorm-codegen/null-unique_2023-07-04-20-08.json
+++ b/common/changes/@subsquid/typeorm-codegen/null-unique_2023-07-04-20-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-codegen",
+      "comment": "make unique fk fields always nullable",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-codegen"
+}

--- a/graphql/openreader/src/model.schema.ts
+++ b/graphql/openreader/src/model.schema.ts
@@ -191,9 +191,6 @@ function addEntityOrJsonObjectOrInterface(model: Model, type: GraphQLObjectType 
                                 description
                             }
                         } else {
-                            if (unique && nullable) {
-                                throw new SchemaError(`Unique property ${propName} must be non-nullable`)
-                            }
                             properties[key] = {
                                 type: {
                                     kind: 'fk',

--- a/typeorm/typeorm-codegen/src/codegen.ts
+++ b/typeorm/typeorm-codegen/src/codegen.ts
@@ -103,7 +103,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                             imports.useTypeorm('OneToOne', 'Index', 'JoinColumn')
                             out.line(`@Index_({unique: true})`)
                             out.line(
-                                `@OneToOne_(() => ${prop.type.entity}, {nullable: false})`
+                                `@OneToOne_(() => ${prop.type.entity}, {nullable: true})`
                             )
                             out.line(`@JoinColumn_()`)
                         } else {


### PR DESCRIPTION
Unique fields can contain multiple null values

https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS

> In general, a unique constraint is violated if there is more than one row in the table where the values of all of the columns included in the constraint are equal. By default, two null values are not considered equal in this comparison. That means even in the presence of a unique constraint it is possible to store duplicate rows that contain a null value in at least one of the constrained columns.