### PR TITLE
update evm trace schema definition

### DIFF
--- a/common/changes/@subsquid/evm-processor/fix-schema_2024-02-20-12-33.json
+++ b/common/changes/@subsquid/evm-processor/fix-schema_2024-02-20-12-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-processor",
+      "comment": "update evm trace schema definition",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/evm-processor"
+}

--- a/evm/evm-processor/src/interfaces/evm.ts
+++ b/evm/evm-processor/src/interfaces/evm.ts
@@ -101,7 +101,7 @@ export interface EvmTraceCreateAction {
 export interface EvmTraceCreateResult {
     gasUsed: bigint
     code: Bytes
-    address: Bytes20
+    address?: Bytes20
 }
 
 

--- a/evm/evm-processor/src/mapping/schema.ts
+++ b/evm/evm-processor/src/mapping/schema.ts
@@ -125,8 +125,8 @@ export function getTraceFrameValidator(fields: FieldSelection['trace'], forArchi
         address: fields?.createResultAddress
     }, {
         gasUsed: QTY,
-        code: BYTES,
-        address: BYTES
+        code: withDefault('0x', BYTES),
+        address: option(BYTES)
     })
 
     let TraceCreate = object({
@@ -158,7 +158,7 @@ export function getTraceFrameValidator(fields: FieldSelection['trace'], forArchi
         output: fields?.callResultOutput
     }, {
         gasUsed: QTY,
-        output: BYTES
+        output: withDefault('0x', BYTES)
     })
 
     let TraceCall = object({


### PR DESCRIPTION
`EvmTraceCreateResult.address` can be optional if creation wasn't successful.
```
{
    "debugFrame_": {
        "result": {
            "from": "0x967d458697fb512394740a37d39c3a1ca90b1a30",
            "gas": "0xd34cc",
            "gasUsed": "0xf4240",
            "input": "0x...",
            "error": "contract creation code storage out of gas",
            "value": "0x0",
            "type": "CREATE"
        }
    }
}
```