### PR TITLE
fix debug trace validation

### DIFF
--- a/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
+++ b/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@subsquid/evm-processor",
-      "comment": "fix debug trace validation",
+      "comment": "fix debug trace validation for failed `CREATE` case",
       "type": "minor"
     }
   ],

--- a/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
+++ b/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-processor",
+      "comment": "fix debug trace validation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-processor"
+}

--- a/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
+++ b/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@subsquid/evm-processor",
-      "comment": "fix debug trace validation for failed `CREATE` case",
+      "comment": "fix debug trace validation for failed `CREATE` case and make `EvmTraceCreateResult.address` non-optional again",
       "type": "minor"
     }
   ],

--- a/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
+++ b/common/changes/@subsquid/evm-processor/master_2024-02-28-05-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@subsquid/evm-processor",
       "comment": "fix debug trace validation",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@subsquid/evm-processor"

--- a/evm/evm-processor/src/ds-rpc/schema.ts
+++ b/evm/evm-processor/src/ds-rpc/schema.ts
@@ -116,7 +116,7 @@ function getDebugFrameValidator(fields: FieldSelection['trace']) {
             input: BYTES,
             gasUsed: QTY,
             output: withDefault('0x', BYTES),
-            to: option(BYTES)
+            to: withDefault('0x0000000000000000000000000000000000000000', BYTES)
         })
     })
 

--- a/evm/evm-processor/src/ds-rpc/schema.ts
+++ b/evm/evm-processor/src/ds-rpc/schema.ts
@@ -116,7 +116,7 @@ function getDebugFrameValidator(fields: FieldSelection['trace']) {
             input: BYTES,
             gasUsed: QTY,
             output: withDefault('0x', BYTES),
-            to: BYTES
+            to: option(BYTES)
         })
     })
 

--- a/evm/evm-processor/src/interfaces/evm.ts
+++ b/evm/evm-processor/src/interfaces/evm.ts
@@ -101,7 +101,7 @@ export interface EvmTraceCreateAction {
 export interface EvmTraceCreateResult {
     gasUsed: bigint
     code: Bytes
-    address?: Bytes20
+    address: Bytes20
 }
 
 

--- a/evm/evm-processor/src/mapping/schema.ts
+++ b/evm/evm-processor/src/mapping/schema.ts
@@ -126,7 +126,7 @@ export function getTraceFrameValidator(fields: FieldSelection['trace'], forArchi
     }, {
         gasUsed: QTY,
         code: withDefault('0x', BYTES),
-        address: option(BYTES)
+        address: withDefault('0x0000000000000000000000000000000000000000', BYTES)
     })
 
     let TraceCreate = object({


### PR DESCRIPTION
without this patch processor fails on that trace:
```
{
    "error": "contract creation code storage out of gas",
    "from": "0x777777c338d93e2c7adf08d102d45ca7cc4ed021",
    "gas": "0xdd8d",
    "gasUsed": "0xdd8d",
    "input": "0x...",
    "type": "CREATE",
    "value": "0x0"
}
```