### PR TITLE
feat(typeorm-store): add optionnal head and rollback db hooks for typeorm store

### DIFF
--- a/common/changes/@subsquid/typeorm-store/feat-optional-rollback-and-head-hooks-typeorm-store_2024-10-11-14-39.json
+++ b/common/changes/@subsquid/typeorm-store/feat-optional-rollback-and-head-hooks-typeorm-store_2024-10-11-14-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-store",
+      "comment": "Enable optional hooks on the typeorm store to allow external services relying on subsquid to get notified when a new head, or a rollback happened.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-store"
+}

--- a/typeorm/typeorm-store/src/database.ts
+++ b/typeorm/typeorm-store/src/database.ts
@@ -34,6 +34,7 @@ export class TypeormDatabase {
     private con?: DataSource
     private projectDir: string
     private hooks?: BlockHooks
+    
     public readonly supportsHotBlocks: boolean
 
     constructor(options?: TypeormDatabaseOptions) {

--- a/typeorm/typeorm-store/src/database.ts
+++ b/typeorm/typeorm-store/src/database.ts
@@ -10,8 +10,8 @@ import {Store} from './store'
 export type IsolationLevel = 'SERIALIZABLE' | 'READ COMMITTED' | 'REPEATABLE READ'
 
 export type BlockHooks = {
-    onRollback(ctx: RollbackContext): Promise<void>
-    onHeadChange(block: HashAndHeight): Promise<void>
+    onRollback?(ctx: RollbackContext): Promise<void>
+    onHeadChange?(block: HashAndHeight): Promise<void>
 }
 
 export type RollbackContext = {
@@ -34,7 +34,7 @@ export class TypeormDatabase {
     private con?: DataSource
     private projectDir: string
     private hooks?: BlockHooks
-    
+
     public readonly supportsHotBlocks: boolean
 
     constructor(options?: TypeormDatabaseOptions) {


### PR DESCRIPTION
The goal of this PR is to enable optional hooks on the `typeorm` store to allow external services relying on subsquid to get notified when a new head, or a rollback happened.