### PR TITLE
Add new RpcDataIngestSettings for controlling split size

### DIFF
--- a/evm/evm-processor/src/ds-rpc/client.ts
+++ b/evm/evm-processor/src/ds-rpc/client.ts
@@ -45,6 +45,7 @@ export interface EvmRpcDataSourceOptions {
     debugTraceTimeout?: string
     log?: Logger
     validationFlags?: RpcValidationFlags
+    maxBlocksPerIteration?: number
 }
 
 export class EvmRpcDataSource implements HotDataSource<Block, DataRequest> {
@@ -52,6 +53,7 @@ export class EvmRpcDataSource implements HotDataSource<Block, DataRequest> {
     private finalityConfirmation: number
     private headPollInterval: number
     private newHeadTimeout: number
+    private maxBlocksPerIteration: number
     private preferTraceApi?: boolean
     private useDebugApiForStateDiffs?: boolean
     private debugTraceTimeout?: string
@@ -66,6 +68,7 @@ export class EvmRpcDataSource implements HotDataSource<Block, DataRequest> {
         this.preferTraceApi = options.preferTraceApi
         this.useDebugApiForStateDiffs = options.useDebugApiForStateDiffs
         this.debugTraceTimeout = options.debugTraceTimeout
+        this.maxBlocksPerIteration = Math.max(options.maxBlocksPerIteration || 10, 1)
     }
 
     async getFinalizedHeight(): Promise<number> {
@@ -85,7 +88,7 @@ export class EvmRpcDataSource implements HotDataSource<Block, DataRequest> {
             getFinalizedHeight: () => this.getFinalizedHeight(),
             getSplit: req => this._getColdSplit(req),
             requests: mapRangeRequestList(requests, req => this.toMappingRequest(req)),
-            splitSize: 10,
+            splitSize: this.maxBlocksPerIteration,
             concurrency: Math.min(5, this.rpc.client.getConcurrency()),
             stopOnHead,
             headPollInterval: this.headPollInterval

--- a/evm/evm-processor/src/processor.ts
+++ b/evm/evm-processor/src/processor.ts
@@ -88,7 +88,7 @@ export interface RpcDataIngestionSettings {
     validationFlags?: RpcValidationFlags 
 
     /**
-     * The number of blocks to process at a time.
+     * The maximum number of blocks to process at a time
      */
     maxBlocksPerIteration?: number
 }

--- a/evm/evm-processor/src/processor.ts
+++ b/evm/evm-processor/src/processor.ts
@@ -86,6 +86,11 @@ export interface RpcDataIngestionSettings {
      * Flags to switch off the data consistency checks
      */
     validationFlags?: RpcValidationFlags 
+
+    /**
+     * The number of blocks to process at a time.
+     */
+    maxBlocksPerIteration?: number
 }
 
 
@@ -473,6 +478,7 @@ export class EvmBatchProcessor<F extends FieldSelection = {}> {
             headPollInterval: this.rpcIngestSettings?.headPollInterval,
             newHeadTimeout: this.rpcIngestSettings?.newHeadTimeout,
             validationFlags: this.rpcIngestSettings?.validationFlags,
+            maxBlocksPerIteration: this.rpcIngestSettings?.maxBlocksPerIteration,
             log: this.getLogger().child('rpc', {rpcUrl: this.getChainRpcClient().url})
         })
     }


### PR DESCRIPTION
When fetching blocks from RPC, each iteration will only process 10 blocks. This is set with a magic number [here](https://github.com/subsquid/squid-sdk/blob/master/evm/evm-processor/src/ds-rpc/client.ts#L88).

This PR removes this `splitSize` magic number and instead makes it an `RpcDataIngestSettings` value called `maxBlocksPerIteration`. Users may now pass in an arbitrary non-negative value. If no value is set, then the default is 10 blocks.