### PR TITLE
EVM processor Typescript: Better Object type merging with default provided type

### DIFF
--- a/evm/evm-processor/src/interfaces/data.ts
+++ b/evm/evm-processor/src/interfaces/data.ts
@@ -86,9 +86,10 @@ type ExcludeUndefined<T> = {
 
 
 type MergeDefault<T, D> = Simplify<
-    undefined extends T ? D : Omit<D, keyof ExcludeUndefined<T>> & ExcludeUndefined<T>
->
-
+    T extends Object
+        ? Omit<D, keyof ExcludeUndefined<T>> & T
+        : D
+>;
 
 type TrueFields<F> = keyof {
     [K in keyof F as true extends F[K] ? K : never]: true


### PR DESCRIPTION
fix this issue:

```
import {
  type Transaction as _Transaction,
} from '@subsquid/evm-processor';

export const processor = new EvmBatchProcessor()
  .addTransaction({
    type: [4],
  })
  .setFields({
    log: { transactionHash: true },
    transaction: {
      authorizationList: true,
    },
  });

export type Fields = EvmBatchProcessorFields<typeof processor>;
export type TransactionWithFields = _Transaction<Fields>;

fn(transaction: TransactionWithFields) {
 console.log(transaction.authorizationList) // Type is now correctly inferred
}
```