### PR TITLE
[WIP] Support ESM targets, add BCH support

### DIFF
--- a/bch/bch-processor/README.md
+++ b/bch/bch-processor/README.md
@@ -1,0 +1,3 @@
+# @subsquid/bch-processor
+
+Data fetcher and mappings executor for BitcoinCash chain.

--- a/bch/bch-processor/package.json
+++ b/bch/bch-processor/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@subsquid/bch-processor",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Data fetcher and mappings executor for BitcoinCash chain",
+  "license": "GPL-3.0-or-later",
+  "repository": "git@github.com:subsquid/squid.git",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "main": "lib/index.js",
+  "dependencies": {
+    "@bitauth/libauth": "^3.0.0",
+    "@subsquid/http-client": "^1.6.0",
+    "@subsquid/logger": "^1.3.3",
+    "@subsquid/rpc-client": "^4.11.0",
+    "@subsquid/util-internal": "^3.2.0",
+    "@subsquid/util-internal-archive-client": "^0.1.2",
+    "@subsquid/util-internal-hex": "^1.2.2",
+    "@subsquid/util-internal-ingest-tools": "^1.1.4",
+    "@subsquid/util-internal-processor-tools": "^4.1.1",
+    "@subsquid/util-internal-range": "^0.3.0",
+    "@subsquid/util-internal-validation": "^0.7.0",
+    "@subsquid/util-timeout": "^2.3.2",
+    "bitcoin-minimal": "^1.1.7",
+    "lru-cache": "^11.0.2",
+    "p2p-cash": "^1.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^18.18.14",
+    "typescript": "~5.5.4"
+  },
+  "scripts": {
+    "build": "rm -rf lib && tsc"
+  }
+}

--- a/bch/bch-processor/src/ds-archive/client.ts
+++ b/bch/bch-processor/src/ds-archive/client.ts
@@ -1,0 +1,90 @@
+import {addErrorContext} from '@subsquid/util-internal'
+import {ArchiveClient} from '@subsquid/util-internal-archive-client'
+import {archiveIngest} from '@subsquid/util-internal-ingest-tools'
+import {Batch, DataSource} from '@subsquid/util-internal-processor-tools'
+import {getRequestAt, RangeRequest} from '@subsquid/util-internal-range'
+import {cast} from '@subsquid/util-internal-validation'
+import assert from 'assert'
+import {Bytes32} from '../interfaces/base.js'
+import {FieldSelection} from '../interfaces/data.js'
+import {DataRequest} from '../interfaces/data-request.js'
+import {
+    Block,
+    BlockHeader,
+    Transaction
+} from '../mapping/entities.js'
+import {setUpRelations} from '../mapping/relations.js'
+import {getBlockValidator} from './schema.js'
+
+
+const NO_FIELDS = {}
+
+
+export class BchArchive implements DataSource<Block, DataRequest> {
+    constructor(private client: ArchiveClient) {}
+
+    getFinalizedHeight(): Promise<number> {
+        return this.client.getHeight()
+    }
+
+    async getBlockHash(height: number): Promise<Bytes32> {
+        let blocks = await this.client.query({
+            fromBlock: height,
+            toBlock: height,
+            includeAllBlocks: true
+        })
+        assert(blocks.length == 1)
+        return blocks[0].header.hash
+    }
+
+    async *getFinalizedBlocks(requests: RangeRequest<DataRequest>[], stopOnHead?: boolean | undefined): AsyncIterable<Batch<Block>> {
+        for await (let batch of archiveIngest({
+            requests,
+            client: this.client,
+            stopOnHead
+        })) {
+            let fields = getRequestAt(requests, batch.blocks[0].header.number)?.fields || NO_FIELDS
+
+            let blocks = batch.blocks.map(b => {
+                try {
+                    return this.mapBlock(b, fields)
+                } catch(err: any) {
+                    throw addErrorContext(err, {
+                        blockHeight: b.header.number,
+                        blockHash: b.header.hash
+                    })
+                }
+            })
+
+            yield {blocks, isHead: batch.isHead, mempoolTransactions: []}
+        }
+    }
+
+    private mapBlock(rawBlock: unknown, fields: FieldSelection): Block {
+        let validator = getBlockValidator(fields)
+
+        let src = cast(validator, rawBlock)
+
+        let {height, hash, parentHash, ...hdr} = src.header
+        if (hdr.timestamp) {
+            hdr.timestamp = hdr.timestamp * 1000 // convert to ms
+        }
+
+        let header = new BlockHeader(height, hash, parentHash)
+        Object.assign(header, hdr)
+
+        let block = new Block(header)
+
+        if (src.transactions) {
+            for (let {...props} of src.transactions) {
+                let tx = new Transaction(header, 0)
+                Object.assign(tx, props)
+                block.transactions.push(tx)
+            }
+        }
+
+        setUpRelations(block)
+
+        return block
+    }
+}

--- a/bch/bch-processor/src/ds-archive/schema.ts
+++ b/bch/bch-processor/src/ds-archive/schema.ts
@@ -1,0 +1,22 @@
+import {weakMemo} from '@subsquid/util-internal'
+import {array, BYTES, object, option} from '@subsquid/util-internal-validation'
+import {FieldSelection} from '../interfaces/data.js'
+import {
+    getBlockHeaderProps,
+    getTxProps,
+} from '../mapping/schema.js'
+
+
+export const getBlockValidator = weakMemo((fields: FieldSelection) => {
+    let BlockHeader = object(getBlockHeaderProps(fields.block, true))
+
+    let Transaction = object({
+        hash: fields.transaction?.hash ? BYTES : undefined,
+        ...getTxProps(fields.transaction, true),
+    })
+
+    return object({
+        header: BlockHeader,
+        transactions: option(array(Transaction)),
+    })
+})

--- a/bch/bch-processor/src/ds-rpc/client.ts
+++ b/bch/bch-processor/src/ds-rpc/client.ts
@@ -1,0 +1,269 @@
+import {Logger, LogLevel} from '@subsquid/logger'
+import {RpcClient} from '@subsquid/rpc-client'
+import {AsyncQueue, ensureError, last, maybeLast, Throttler, wait} from '@subsquid/util-internal'
+import {
+    BlockConsistencyError,
+    BlockHeader as Head,
+    BlockRef,
+    coldIngest,
+    HashAndHeight,
+    HotProcessor,
+    isDataConsistencyError
+} from '@subsquid/util-internal-ingest-tools'
+import {Batch, HotDatabaseState, HotDataSource, HotUpdate} from '@subsquid/util-internal-processor-tools'
+import {
+    getRequestAt,
+    mapRangeRequestList,
+    rangeEnd,
+    RangeRequest,
+    RangeRequestList,
+    splitRange,
+    splitRangeByRequest,
+    SplitRequest
+} from '@subsquid/util-internal-range'
+import {cast, NAT, object} from '@subsquid/util-internal-validation'
+import {addTimeout, TimeoutError} from '@subsquid/util-timeout'
+import assert from 'assert'
+import {Bytes32} from '../interfaces/base.js'
+import {DataRequest} from '../interfaces/data-request.js'
+import {Block} from '../mapping/entities.js'
+import {mapBlock} from './mapping.js'
+import {MappingRequest, toMappingRequest} from './request.js'
+import {Rpc, RpcValidationFlags} from './rpc.js'
+import { HEX } from './rpc-data.js'
+
+
+const NO_REQUEST = toMappingRequest()
+
+
+export interface BchRpcDataSourceOptions {
+    rpc: RpcClient
+    p2pEndpoint?: string // endpoint in format "ip:port"
+    finalityConfirmation: number
+    newHeadTimeout?: number
+    headPollInterval?: number
+    log?: Logger
+    validationFlags?: RpcValidationFlags
+}
+
+export class BchRpcDataSource implements HotDataSource<Block, DataRequest> {
+    public rpc: Rpc
+    private finalityConfirmation: number
+    private headPollInterval: number
+    private newHeadTimeout: number
+
+    private log?: Logger
+
+    constructor(options: BchRpcDataSourceOptions) {
+        this.log = options.log
+        this.rpc = new Rpc(options.rpc, this.log, options.validationFlags, 0, {p2pEndpoint: options.p2pEndpoint })
+        this.finalityConfirmation = options.finalityConfirmation
+        this.headPollInterval = options.headPollInterval || 5_000
+        this.newHeadTimeout = options.newHeadTimeout || 0
+    }
+
+    async getFinalizedHeight(): Promise<number> {
+        let height = await this.rpc.getHeight()
+        return Math.max(0, height - this.finalityConfirmation)
+    }
+
+    getBlockHash(height: number): Promise<Bytes32 | undefined> {
+        return this.rpc.getBlockHash(height)
+    }
+
+    getFinalizedBlocks(
+        requests: RangeRequest<DataRequest>[],
+        stopOnHead?: boolean
+    ): AsyncIterable<Batch<Block>> {
+        return coldIngest({
+            getFinalizedHeight: () => this.getFinalizedHeight(),
+            getSplit: req => this._getColdSplit(req),
+            requests: mapRangeRequestList(requests, req => this.toMappingRequest(req)),
+            splitSize: 10,
+            concurrency: Math.min(5, this.rpc.client.getConcurrency()),
+            stopOnHead,
+            headPollInterval: this.headPollInterval
+        })
+    }
+
+    private async _getColdSplit(req: SplitRequest<MappingRequest>): Promise<Block[]> {
+        let rpc = this.rpc.withPriority(req.range.from)
+        let blocks = await rpc.getColdSplit(req).catch(err => {
+            if (isDataConsistencyError(err)) {
+                err.message += '. Perhaps finality confirmation was not large enough'
+            }
+            throw err
+        })
+        await rpc.cleanupRpc()
+        return blocks.map(b => mapBlock(b, req.request))
+    }
+
+    private toMappingRequest(req?: DataRequest): MappingRequest {
+        let r = toMappingRequest(req)
+        return r
+    }
+
+    async processHotBlocks(
+        requests: RangeRequestList<DataRequest>,
+        state: HotDatabaseState,
+        cb: (upd: HotUpdate<Block>) => Promise<void>
+    ): Promise<void> {
+        if (requests.length == 0) return
+
+        let mappingRequests = mapRangeRequestList(requests, req => this.toMappingRequest(req))
+
+        let self = this
+
+        let proc = new HotProcessor<Block>(state, {
+            process: cb,
+            getBlock: async ref => {
+                let req = getRequestAt(mappingRequests, ref.height) || NO_REQUEST
+                let block = await this.rpc.getColdBlock(ref.hash, req, proc.getFinalizedHeight())
+                return mapBlock(block, req)
+            },
+            async *getBlockRange(from: number, to: BlockRef): AsyncIterable<Block[]> {
+                assert(to.height != null)
+                if (from > to.height) {
+                    from = to.height
+                }
+                for (let split of splitRangeByRequest(mappingRequests, {from, to: to.height})) {
+                    let request = split.request || NO_REQUEST
+                    for (let range of splitRange(10, split.range)) {
+                        let rpcBlocks = await self.rpc.getHotSplit({
+                            range,
+                            request,
+                            finalizedHeight: proc.getFinalizedHeight()
+                        })
+                        let blocks = rpcBlocks.map(b => mapBlock(b, request))
+                        let lastBlock = maybeLast(blocks)?.header.height ?? range.from - 1
+                        yield blocks
+                        if (lastBlock < range.to) {
+                            throw new BlockConsistencyError({height: lastBlock + 1})
+                        }
+                    }
+                }
+            },
+            getHeader(block) {
+                return block.header
+            }
+        })
+
+        let isEnd = () => proc.getFinalizedHeight() >= rangeEnd(last(requests).range)
+
+        let navigate = (head: {height: number, hash?: Bytes32}): Promise<void> => {
+            return proc.goto({
+                best: head,
+                finalized: {
+                    height: Math.max(head.height - this.finalityConfirmation, 0)
+                }
+            })
+        }
+
+        if (this.rpc.client.supportsNotifications()) {
+            return this.subscription(navigate, isEnd)
+        } else {
+            return this.polling(navigate, isEnd)
+        }
+    }
+
+    async processMempool(
+        requests: RangeRequestList<DataRequest>,
+        state: HotDatabaseState,
+        cb: (upd: HotUpdate<Block>) => Promise<void>
+    ): Promise<() => Promise<void>> {
+        return await this.rpc.watchMempool(requests as any, state, cb as any);
+    }
+
+    private async polling(cb: (head: {height: number}) => Promise<void>, isEnd: () => boolean): Promise<void> {
+        let prev = -1
+        let height = new Throttler(() => this.rpc.getHeight(), this.headPollInterval)
+        while (!isEnd()) {
+            let next = await height.call()
+            if (next <= prev) continue
+            prev = next
+            for (let i = 0; i < 100; i++) {
+                try {
+                    await cb({height: next})
+                    break
+                } catch(err: any) {
+                    if (isDataConsistencyError(err)) {
+                        this.log?.write(
+                            i > 0 ? LogLevel.WARN : LogLevel.DEBUG,
+                            err.message
+                        )
+                        await wait(100)
+                    } else {
+                        throw err
+                    }
+                }
+            }
+        }
+    }
+
+    private async subscription(cb: (head: HashAndHeight) => Promise<void>, isEnd: () => boolean): Promise<void> {
+        let lastHead: HashAndHeight = {height: -1, hash: '0x'}
+        let heads = await this.subscribeNewHeads()
+        try {
+            while (!isEnd()) {
+                let next = await addTimeout(heads.take(), this.newHeadTimeout).catch(ensureError)
+                assert(next)
+                if (next instanceof TimeoutError) {
+                    this.log?.warn(`resetting RPC connection, because we haven't seen a new head for ${this.newHeadTimeout} ms`)
+                    this.rpc.client.reset()
+                } else if (next instanceof Error) {
+                    throw next
+                } else if (next.height >= lastHead.height) {
+                    lastHead = next
+                    for (let i = 0; i < 3; i++) {
+                        try {
+                            await cb(next)
+                            break
+                        } catch(err: any) {
+                            if (isDataConsistencyError(err)) {
+                                this.log?.write(
+                                    i > 0 ? LogLevel.WARN : LogLevel.DEBUG,
+                                    err.message
+                                )
+                                await wait(100)
+                                if (heads.peek()) break
+                            } else {
+                                throw err
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+            heads.close()
+        }
+    }
+
+    private async subscribeNewHeads(): Promise<AsyncQueue<Head | Error>> {
+        let queue = new AsyncQueue<Head | Error>(1)
+
+        const unsubscribe = await this.rpc.watchNewBlocks(async (head) => {
+            try {
+                let {height, hash, parentHash} = cast(NewHeadMessage, head)
+                queue.forcePut({
+                    height,
+                    hash,
+                    parentHash
+                })
+            } catch(err: any) {
+                queue.forcePut(ensureError(err))
+                queue.close()
+            }
+        })
+
+        queue.addCloseListener(async () => await unsubscribe())
+
+        return queue
+    }
+}
+
+
+const NewHeadMessage = object({
+    height: NAT,
+    hash: HEX,
+    parentHash: HEX
+})

--- a/bch/bch-processor/src/ds-rpc/filter.ts
+++ b/bch/bch-processor/src/ds-rpc/filter.ts
@@ -1,0 +1,55 @@
+import {weakMemo} from '@subsquid/util-internal'
+import {EntityFilter, FilterBuilder} from '@subsquid/util-internal-processor-tools'
+import {Block, Transaction} from '../mapping/entities.js'
+import {DataRequest} from '../interfaces/data-request.js'
+
+
+function buildTransactionFilter(dataRequest: DataRequest): EntityFilter<Transaction, {
+}> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.transactions || []) {
+        let {
+            // address, tokenId
+            ...relations} = req
+        let filter = new FilterBuilder<Transaction>()
+        // filter.propIn('address', address)
+        // filter.propIn('tokenId', tokenId)
+        items.add(filter, relations)
+    }
+    return items
+}
+
+
+const getItemFilter = weakMemo((dataRequest: DataRequest) => {
+    return {
+        transactions: buildTransactionFilter(dataRequest),
+    }
+})
+
+
+class IncludeSet {
+    transactions = new Set<Transaction>()
+    addTransaction(tx?: Transaction): void {
+        if (tx) this.transactions.add(tx)
+    }
+}
+
+
+export function filterBlock(block: Block, dataRequest: DataRequest): void {
+    let items = getItemFilter(dataRequest)
+
+    let include = new IncludeSet()
+    
+    if (items.transactions.present()) {
+        for (let tx of block.transactions) {
+            let rel = items.transactions.match(tx)
+            if (rel == null) continue
+            include.addTransaction(tx)
+        }
+    }
+
+    block.transactions = block.transactions.filter(tx => {
+        if (!include.transactions.has(tx)) return false
+        return true
+    })
+}

--- a/bch/bch-processor/src/ds-rpc/mapping.ts
+++ b/bch/bch-processor/src/ds-rpc/mapping.ts
@@ -1,0 +1,60 @@
+import {addErrorContext} from '@subsquid/util-internal'
+import {cast} from '@subsquid/util-internal-validation'
+import {
+    Block,
+    BlockHeader,
+    Transaction
+} from '../mapping/entities.js'
+import {setUpRelations} from '../mapping/relations.js'
+import {filterBlock} from './filter.js'
+import {MappingRequest} from './request.js'
+import {Block as RpcBlock} from './rpc-data.js'
+import {getBlockValidator} from './schema.js'
+
+
+export function mapBlock(rpcBlock: RpcBlock, req: MappingRequest): Block {
+    try {
+        return tryMapBlock(rpcBlock, req)
+    } catch(err: any) {
+        throw addErrorContext(err, {
+            blockHash: rpcBlock.hash,
+            blockHeight: rpcBlock.height
+        })
+    }
+}
+
+
+function tryMapBlock(rpcBlock: RpcBlock, req: MappingRequest): Block {
+    let src = cast(getBlockValidator(req), rpcBlock)
+
+    let {height, hash, parentHash, transactions, ...headerProps} = src.block
+    if (headerProps.timestamp) {
+        headerProps.timestamp = headerProps.timestamp * 1000 // convert to ms
+    }
+
+    let header = new BlockHeader(height, hash, parentHash)
+    Object.assign(header, headerProps)
+
+    let block = new Block(header)
+
+    if (req.transactionList) {
+        for (let i = 0; i < transactions.length; i++) {
+            let stx = transactions[i]
+            let tx = new Transaction(header, i)
+            if (typeof stx == 'string') {
+                if (req.fields.transaction?.hash) {
+                    tx.hash = stx
+                }
+            } else {
+                let {...props} = stx
+                Object.assign(tx, props)
+            }
+            block.transactions.push(tx)
+        }
+    }
+
+    setUpRelations(block)
+    filterBlock(block, req.dataRequest)
+
+    return block
+}

--- a/bch/bch-processor/src/ds-rpc/request.ts
+++ b/bch/bch-processor/src/ds-rpc/request.ts
@@ -1,0 +1,50 @@
+import {FieldSelection} from '../interfaces/data.js'
+import {DataRequest} from '../interfaces/data-request.js'
+import {BchTransaction} from '../interfaces/bch.js'
+import {DataRequest as RpcDataRequest} from './rpc-data.js'
+
+
+export interface MappingRequest extends RpcDataRequest {
+    fields: FieldSelection
+    transactionList: boolean
+    dataRequest: DataRequest
+}
+
+
+export function toMappingRequest(req?: DataRequest): MappingRequest {
+    let txs = transactionsRequested(req)
+    return {
+        fields: req?.fields || {},
+        transactionList: txs,
+        transactions: !!req?.transactions?.length || txs && isRequested(TX_FIELDS, req?.fields?.transaction),
+        dataRequest: req || {}
+    }
+}
+
+
+function transactionsRequested(req?: DataRequest): boolean {
+    if (req == null) return false
+    if (req.transactions?.length) return true
+    return false
+}
+
+
+const TX_FIELDS: {[K in Exclude<keyof BchTransaction, 'hash'>]: true} = {
+    inputs: true,
+    locktime: true,
+    outputs: true,
+    size: true,
+    sourceOutputs: true,
+    transactionIndex: true,
+    version: true,
+    fee: true,
+}
+
+
+function isRequested(set: Record<string, boolean>, selection?: Record<string, boolean>): boolean {
+    if (selection == null) return false
+    for (let key in selection) {
+        if (set[key] && selection[key]) return true
+    }
+    return false
+}

--- a/bch/bch-processor/src/ds-rpc/rpc-data.ts
+++ b/bch/bch-processor/src/ds-rpc/rpc-data.ts
@@ -1,0 +1,181 @@
+import {
+    array,
+    GetSrcType,
+    NAT,
+    object,
+    option,
+    STRING,
+    ValidationFailure,
+    Validator} from '@subsquid/util-internal-validation'
+import {Bytes, Bytes32} from '../interfaces/base.js'
+
+export class ValidationFailureEx extends ValidationFailure {
+    toString(): string {
+        let msg = this.message
+        if (msg.includes('{value}')) {
+            msg = msg.replace('{value}', JSON.stringify(this.value))
+        }
+        if (this.path.length) {
+            msg = `invalid value at ${this.getPathString()}: ${msg}`
+        }
+        return msg
+    }
+}
+
+/**
+ * Hex encoded binary string or natural number without 0x prefix
+ */
+type Hex = string
+
+
+function isHex(value: unknown): value is Hex {
+    return typeof value == 'string' && /^[0-9a-fA-F]*$/.test(value)
+}
+
+/**
+ * Hex encoded binary string without 0x prefix
+ */
+export const HEX: Validator<Hex> = {
+    cast(value: unknown): Hex | ValidationFailureEx {
+        return this.validate(value) || (value as Hex).toLowerCase()
+    },
+    validate(value: unknown): ValidationFailureEx | undefined {
+        if (isHex(value)) return
+        return new ValidationFailureEx(value, `{value} is not a hex encoded binary string`)
+    },
+    phantom(): Hex {
+        return ''
+    }
+}
+
+function isBigint(value: unknown): value is bigint {
+    return typeof value == 'bigint';
+}
+
+/**
+ * Hex encoded binary string without 0x prefix
+ */
+export const BIGINT: Validator<bigint> = {
+    cast(value: unknown): bigint | ValidationFailureEx {
+        return this.validate(value) || (value as bigint)
+    },
+    validate(value: unknown): ValidationFailureEx | undefined {
+        if (isBigint(value)) return
+        return new ValidationFailureEx(value, `{value} is not a bigint`)
+    },
+    phantom(): bigint {
+        return 0n
+    }
+}
+
+export interface RpcBlock {
+    hash: string,
+    confirmations: number,
+    size: number,
+    height: number,
+    version: number,
+    tx: string[],
+    time: number,
+    nonce: number,
+    difficulty: number,
+    nTx: number,
+    previousblockhash: string,
+}
+
+export interface DataRequest {
+    transactions?: boolean
+    sourceOutputs?: boolean
+    fee?: boolean
+}
+
+
+export interface Block {
+    height: number
+    hash: Bytes32
+    block: GetBlock
+    _isInvalid?: boolean
+    _errorMessage?: string
+}
+
+
+const Transaction = object({
+    blockNumber: NAT,
+    blockHash: HEX,
+    transactionIndex: NAT,
+    size: NAT,
+    hash: HEX,
+    sourceOutputs: option(array(object({
+        lockingBytecode: HEX,
+        token: option(object({
+            amount: BIGINT,
+            category: HEX,
+            nft: option(object({
+                capability: STRING,
+                commitment: HEX,
+            })),
+        })),
+        valueSatoshis: BIGINT,
+        address: STRING,
+    }))),
+    inputs: array(object({
+        outpointIndex: NAT,
+        outpointTransactionHash: HEX,
+        sequenceNumber: NAT,
+        unlockingBytecode: HEX,
+    })),
+    outputs: array(object({
+        lockingBytecode: HEX,
+        token: option(object({
+            amount: BIGINT,
+            category: HEX,
+            nft: option(object({
+                capability: STRING,
+                commitment: HEX,
+            })),
+        })),
+        valueSatoshis: BIGINT,
+        address: STRING,
+    })),
+    locktime: NAT,
+    version: NAT,
+    fee: option(NAT),
+})
+
+
+export type Transaction = GetSrcType<typeof Transaction>
+
+
+export const GetBlockWithTransactions = object({
+    height: NAT,
+    hash: HEX,
+    parentHash: HEX,
+    transactions: array(Transaction),
+    difficulty: NAT,
+    size: NAT,
+    timestamp: NAT,
+    nonce: NAT,
+})
+
+
+export const GetBlockNoTransactions = object({
+    height: NAT,
+    hash: HEX,
+    parentHash: HEX,
+    transactions: array(HEX),
+    difficulty: NAT,
+    size: NAT,
+    timestamp: NAT,
+    nonce: NAT,
+})
+
+
+export interface GetBlock {
+    height: number
+    hash: Bytes32
+    parentHash: Bytes32
+    transactions: Bytes[] | Transaction[]
+    difficulty: number
+    size: number
+    timestamp: number
+    nonce: number
+}

--- a/bch/bch-processor/src/ds-rpc/rpc.ts
+++ b/bch/bch-processor/src/ds-rpc/rpc.ts
@@ -1,0 +1,724 @@
+import {createLogger, Logger} from '@subsquid/logger'
+import {CallOptions, RpcClient, RpcError} from '@subsquid/rpc-client'
+import {assertIsValid, BlockConsistencyError, BlockHeader, trimInvalid} from '@subsquid/util-internal-ingest-tools'
+import {RangeRequestList, rangeToArray, SplitRequest} from '@subsquid/util-internal-range'
+import {DataValidationError, GetSrcType, nullable, Validator} from '@subsquid/util-internal-validation'
+import {Bytes, Bytes32} from '../interfaces/base.js'
+import {
+    Block,
+    DataRequest,
+    GetBlock,
+    GetBlockNoTransactions,
+    GetBlockWithTransactions,
+    RpcBlock,
+    Transaction,
+} from './rpc-data.js'
+import { assertSuccess, binToHex, CashAddressNetworkPrefix, CashAddressType, decodeTransaction, encodeCashAddress, hash160, hash256, hexToBin, Input, lockingBytecodeToAddressContents, Output, TransactionCommon } from '@bitauth/libauth'
+import { LRUCache } from 'lru-cache'
+import { Peer } from 'p2p-cash'
+import { Block as P2pBlock } from 'bitcoin-minimal'
+import { HotDatabaseState, HotUpdate } from '@subsquid/util-internal-processor-tools'
+import { Graph } from './util.js'
+
+const ZERO_HASH = "00".repeat(32)
+
+function getResultValidator<V extends Validator>(validator: V, transformer?: (input: any) => any): (result: unknown) => GetSrcType<V> {
+    return function(result: unknown) {
+        if (transformer) {
+            result = transformer(result)
+        }
+        let err = validator.validate(result)
+        if (err) {
+            throw new DataValidationError(`server returned unexpected result: ${err.toString()}`)
+        } else {
+            return result as any
+        }
+    }
+}
+
+
+export interface RpcValidationFlags {
+}
+
+type TransactionBCH = TransactionCommon<Input<string,string>, Output<string,string,bigint>>
+
+export type TransactionBCHWithAddress = TransactionBCH & {
+    outputs: (TransactionBCH['outputs'][0] & {
+        address: string
+    })[]
+}
+
+const transactionCache = new LRUCache<string, TransactionBCHWithAddress>({
+    max: 1000,
+})
+
+const addressCache = new LRUCache<Uint8Array, string>({
+    max: 1000,
+})
+
+// A composite class to get data from ElectrumX server (tip, historical transactions) and from p2p network layer (blocks, mempool)
+// A variant of this class could be implemented to fetch data from a BCH node's RPC instead of ElectrumX
+export class Rpc {
+    private props: RpcProps
+    private p2pEndpoint: string
+    private p2p!: Peer
+    private mempoolWatchCancel?: () => Promise<void>
+    private newBlocksWatchCancel?: () => Promise<void>
+
+    constructor(
+        public readonly client: RpcClient,
+        private log?: Logger,
+        private validation: RpcValidationFlags = {},
+        private priority: number = 0,
+        props?: RpcProps,
+    ) {
+        this.props = props ?? {}
+        this.p2pEndpoint = this.props.p2pEndpoint ?? '3.142.98.179:8333'
+
+        this.log = createLogger('sqd:processor:rpc', {rpcUrl: this.client.url, p2pEndpoint: this.p2pEndpoint});
+    }
+
+    private setupP2P() {
+        const [ip, port] = this.p2pEndpoint.split(':')
+        const peer = new Peer({
+            ticker: "BCH",
+            node: ip,
+            port: Number(port),
+            validate: false,
+            magic: Buffer.from("e3e1f3e8", "hex"),
+            userAgent: "/subsquid/",
+            version: 70012,
+            listenRelay: true,
+            timeoutConnect: 60 * 1000,
+            reconnectTimeout: 100,
+            autoReconnectWait: 100,
+            autoReconnect: true,
+            DEBUG_LOG: false,
+            logger: this.log,
+        })
+
+        peer.on('connected', () => {
+            this.log?.debug(
+                `P2p peer: connected to node`
+            )
+        })
+
+        peer.connect().catch(() => {});
+        return peer
+    }
+    public async cleanupRpc() {
+        await this.mempoolWatchCancel?.()
+        this.p2p.disconnect(false)
+    }
+
+    private async p2pReady() {
+        this.p2p = this.setupP2P()
+        if (!this.p2p.connected) {
+            await new Promise<void>(async (resolve) => {
+                while (!this.p2p.connected) {
+                    await new Promise(resolve => setTimeout(resolve, 5000))
+                }
+                resolve()
+            })
+        }
+    }
+
+    withPriority(priority: number): Rpc {
+        return new Rpc(this.client, this.log, this.validation, priority, this.props)
+    }
+
+    async call<T=any>(method: string, params?: any[], options?: CallOptions<T>): Promise<T> {
+        if (method == 'blockchain.block.get') {
+            await this.p2pReady()
+
+            if (typeof params?.[0] === "number") {
+                const result = await this.getBlockByHeightInternal(params[0], params[1]) as T
+                return options?.validateResult ? options.validateResult(result, undefined as any) : result
+            } else if (typeof params?.[0] === "string") {
+                const result = await this.getBlockByHashInternal(params[0], params[1], params[2]) as T
+                return options?.validateResult ? options.validateResult(result, undefined as any) : result
+            }
+        }
+
+        return this.client.call(method, params, {priority: this.priority, ...options})
+    }
+
+    async batchCall<T=any>(batch: {method: string, params?: any[]}[], options?: CallOptions<T>): Promise<T[]> {
+        const indices: number[] = []
+
+        const [blockBatchHeights, blockBatchHashes, otherBatches] = batch.reduce((acc, b) => {
+            if (b.method === 'blockchain.block.get' && typeof b.params?.[0] === "number") {
+                indices.push(0)
+                acc[0].push(b)
+            } else if (b.method === 'blockchain.block.get' && typeof b.params?.[0] === "string") {
+                indices.push(1)
+                acc[1].push(b)
+            } else {
+                indices.push(2)
+                acc[2].push(b)
+            }
+            return acc
+        }, [[], [], []] as [{method: string, params?: any[]}[], {method: string, params?: any[]}[], {method: string, params?: any[]}[]])
+
+        if (blockBatchHashes.length || blockBatchHeights.length) {
+            await this.p2pReady()
+        }
+
+        // allow rpc client to be blocked by priority
+        const otherResults = await this.client.batchCall(otherBatches, {priority: this.priority, ...options})
+
+        const blockResultHeights = await this.getBlockByHeightInternalBatch(blockBatchHeights.map(b => b.params![0] as number), blockBatchHeights.map(b => b.params![1] as number)) as T[]
+        const blockResultHashes = await this.getBlockByHashInternalBatch(blockBatchHashes.map(b => b.params![0] as string), blockBatchHashes.map(b => b.params![1] as number), blockBatchHeights.map(b => b.params![0] as number)) as T[]
+
+        const blockResultHeightsMaybeValidated = options?.validateResult ? blockResultHeights.map((r) => options.validateResult!(r, undefined as any)) : blockResultHeights
+        const blockResultHashesMaybeValidated = options?.validateResult ? blockResultHashes.map((r) => options.validateResult!(r, undefined as any)) : blockResultHashes
+
+        // restore the original order
+        return indices.map((i) => {
+            if (i === 0) {
+                return blockResultHeightsMaybeValidated.shift()!
+            } else if (i === 1) {
+                return blockResultHashesMaybeValidated.shift()!
+            } else {
+                return otherResults.shift()!
+            }
+        })
+    }
+
+    async watchMempool(
+        requests: RangeRequestList<DataRequest>,
+        state: HotDatabaseState,
+        cb: (upd: HotUpdate<Block>) => Promise<void>
+    ): Promise<() => Promise<void>> {
+        await this.p2pReady()
+
+        await this.mempoolWatchCancel?.()
+
+        const process = async (rawMempoolHashes: Buffer[]) => {
+            const rawMempool = await this.p2p.getRawTransactions(rawMempoolHashes)
+            const transactions = rawMempool.map((tx, index) => transformTransaction(tx as unknown as Uint8Array, -1, {
+                hash: ZERO_HASH,
+                height: -1,
+            } as RpcBlock, rawMempoolHashes[index].toString('hex')))
+
+            const graph = new Graph()
+            for (const tx of transactions) {
+                for (const input of tx.inputs) {
+                    graph.addEdge(input.outpointTransactionHash, tx.hash)
+                }
+            }
+
+            const sortedTxHashes = graph.topologicalSort()
+            const orderedTransactions: typeof transactions = sortedTxHashes.map(txHash => transactions.find(tx => tx.hash === txHash)).filter(tx => tx !== undefined)
+
+            if (requests.some(req => req.request.sourceOutputs || (req.request as any).fields?.transaction?.sourceOutputs)) {
+                await this.addSourceOutputs([{
+                    height: -1, hash: ZERO_HASH,
+                    block: {transactions: orderedTransactions},
+                }] as Block[])
+
+                if (requests.some(req => req.request.fee || (req.request as any).fields?.transaction?.fee)) {
+                    await this.addFees([{
+                        height: -1, hash: ZERO_HASH,
+                        block: {transactions: orderedTransactions},
+                    }] as Block[])
+                }
+            }
+
+            await cb({
+                blocks: [],
+                baseHead: {hash: ZERO_HASH, height: -1},
+                finalizedHead: {hash: ZERO_HASH, height: -1},
+                mempoolTransactions: orderedTransactions
+            })
+        }
+
+        const rawMempoolHashes = await this.p2p.getMempool()
+        await process(rawMempoolHashes)
+
+        const watchCancel = this.p2p.watchMempoolTransactionHashes(async (txHash: Buffer) => {
+            const rawMempoolHashes = [txHash]
+            await process(rawMempoolHashes)
+        })
+
+        this.mempoolWatchCancel = async () => {
+            watchCancel()
+            this.mempoolWatchCancel = undefined
+        }
+
+        return this.mempoolWatchCancel
+    }
+
+    async watchNewBlocks(
+        cb: (head: BlockHeader) => Promise<void>
+    ): Promise<() => Promise<void>> {
+        await this.p2pReady()
+
+        await this.newBlocksWatchCancel?.()
+
+        const watchCancel = this.p2p.watchNewBlocks(async (blockHash: Buffer) => {
+            const block = await this.p2p.getBlock(blockHash)
+            cb({
+                hash: block.getHash().toString("hex"),
+                height: block.getHeight(),
+                parentHash: block.header!.prevHash.toString("hex"),
+            })
+        })
+
+        this.mempoolWatchCancel = async () => {
+            watchCancel()
+            this.mempoolWatchCancel = undefined
+        }
+
+        return this.mempoolWatchCancel
+    }
+
+    getBlockByNumber(height: number, withTransactions: boolean): Promise<GetBlock | null> {
+        return this.call('blockchain.block.get', [
+            height,
+            withTransactions ? 1.5 : 1
+        ], {
+            validateResult: getResultValidator(
+                withTransactions ? nullable(GetBlockWithTransactions) : nullable(GetBlockNoTransactions),
+                transformBlock(withTransactions),
+            )
+        })
+    }
+
+    getBlockByHash(hash: Bytes, withTransactions: boolean): Promise<GetBlock | null> {
+        return this.call('blockchain.block.get', [hash, withTransactions ? 1.5 : 1], {
+            validateResult: getResultValidator(
+                withTransactions ? nullable(GetBlockWithTransactions) : nullable(GetBlockNoTransactions),
+                transformBlock(withTransactions),
+            )
+        })
+    }
+
+    getRawTransaction(hash: Bytes): Promise<string> {
+        return this.call('blockchain.transaction.get', [hash, false])
+    }
+
+    async getTransaction(hash: Bytes): Promise<TransactionBCHWithAddress> {
+        if (transactionCache.has(hash)) {
+            return transactionCache.get(hash)!
+        }
+
+        const tx: TransactionBCHWithAddress = fromLibauthTransaction(assertSuccess(decodeTransaction(hexToBin(await this.getRawTransaction(hash)))))
+
+        transactionCache.set(hash, tx)
+        return tx;
+    }
+
+    async getBlockHash(height: number): Promise<Bytes | undefined> {
+        let block = await this.getBlockByNumber(height, false)
+        return block?.hash
+    }
+
+    async getHeight(): Promise<number> {
+        let { height } = await this.call<{height: number}>('blockchain.headers.get_tip')
+        return height
+    }
+
+    async getColdBlock(blockHash: Bytes32, req?: DataRequest, finalizedHeight?: number): Promise<Block> {
+        let block = await this.getBlockByHash(blockHash, req?.transactions || false).then(toBlock)
+        if (block == null) throw new BlockConsistencyError({hash: blockHash})
+        if (req) {
+            await this.addRequestedData([block], req, finalizedHeight)
+        }
+        if (block._isInvalid) throw new BlockConsistencyError(block, block._errorMessage)
+        return block
+    }
+
+    async getColdSplit(req: SplitRequest<DataRequest>): Promise<Block[]> {
+        let blocks = await this.getColdBlockBatch(
+            rangeToArray(req.range),
+            req.request.transactions ?? false,
+            1
+        )
+        return this.addColdRequestedData(blocks, req.request, 1)
+    }
+
+    private async addColdRequestedData(blocks: Block[], req: DataRequest, depth: number): Promise<Block[]> {
+        let result = blocks.map(b => ({...b}))
+
+        await this.addRequestedData(result, req)
+
+        if (depth > 9) {
+            assertIsValid(result)
+            return result
+        }
+
+        let missing: number[] = []
+        for (let i = 0; i < result.length; i++) {
+            if (result[i]._isInvalid) {
+                missing.push(i)
+            }
+        }
+
+        if (missing.length == 0) return result
+
+        let missed = await this.addColdRequestedData(
+            missing.map(i => blocks[i]),
+            req,
+            depth + 1
+        )
+
+        for (let i = 0; i < missing.length; i++) {
+            result[missing[i]] = missed[i]
+        }
+
+        return result
+    }
+
+    private async getColdBlockBatch(numbers: number[], withTransactions: boolean, depth: number): Promise<Block[]> {
+        let result = await this.getBlockBatch(numbers, withTransactions)
+        let missing: number[] = []
+        for (let i = 0; i < result.length; i++) {
+            if (result[i] == null) {
+                missing.push(i)
+            }
+        }
+
+        if (missing.length == 0) return result as Block[]
+
+        if (depth > 9) throw new BlockConsistencyError({
+            height: numbers[missing[0]]
+        }, `failed to get finalized block after ${depth} attempts`)
+
+        let missed = await this.getColdBlockBatch(
+            missing.map(i => numbers[i]),
+            withTransactions,
+            depth + 1
+        )
+
+        for (let i = 0; i < missing.length; i++) {
+            result[missing[i]] = missed[i]
+        }
+
+        return result as Block[]
+    }
+
+    async getHotSplit(req: SplitRequest<DataRequest> & {finalizedHeight: number}): Promise<Block[]> {
+        let blocks = await this.getBlockBatch(rangeToArray(req.range), req.request.transactions ?? false)
+
+        let chain: Block[] = []
+
+        for (let i = 0; i < blocks.length; i++) {
+            let block = blocks[i]
+            if (block == null) break
+            if (i > 0 && chain[i - 1].hash !== block.block.parentHash) break
+            chain.push(block)
+        }
+
+        await this.addRequestedData(chain, req.request, req.finalizedHeight)
+
+        return trimInvalid(chain)
+    }
+
+    private async getBlockBatch(numbers: number[], withTransactions: boolean): Promise<(Block | undefined)[]> {
+        let call = numbers.map(height => {
+            return {
+                method: 'blockchain.block.get',
+                params: [height, withTransactions ? 1.5 : 1]
+            }
+        })
+        let blocks = await this.batchCall(call, {
+            validateResult: getResultValidator(
+                withTransactions ? nullable(GetBlockWithTransactions) : nullable(GetBlockNoTransactions),
+                transformBlock(withTransactions),
+            ),
+            validateError: info => {
+                // Avalanche
+                if (/cannot query unfinalized data/i.test(info.message)) return null
+                throw new RpcError(info)
+            }
+        })
+        return blocks.map(toBlock)
+    }
+
+    private async addRequestedData(blocks: Block[], req: DataRequest, finalizedHeight?: number): Promise<void> {
+        if (blocks.length == 0) return
+        let subtasks: any[] = []
+
+        if (req.sourceOutputs || (req as any).fields?.transaction?.sourceOutputs) {
+            subtasks.push(this.addSourceOutputs(blocks))
+            if (req.fee || (req as any).fields?.transaction?.fee) {
+                subtasks.at(-1).then(() => this.addFees(blocks))
+            }
+        }
+
+        await Promise.all(subtasks)
+    }
+
+    private async addSourceOutputs(blocks: Block[]): Promise<void> {
+        if (blocks.length == 0) return
+        if (blocks.some((block => block.block.transactions.some(tx => typeof tx === "string")))) {
+            return
+        }
+
+        // get all unique prevout txIds excluding the coinbase tx
+        const txIds = [...new Set<string>(
+            blocks.map(block => block.block.transactions.map(tx => (tx as Transaction).inputs.map(input => input.outpointTransactionHash))).flat(3)
+        )].filter(txId => txId !== ZERO_HASH && !transactionCache.has(txId, {updateAgeOnHas: true}))
+
+        console.log(`addSourceOutputs for blocks: ${blocks.map(b => b.height).join(', ')}. txIds: ${txIds.length}`)
+        console.time(`addSourceOutputs for blocks: ${blocks.map(b => b.height).join(', ')}. txIds: ${txIds.length}`)
+
+        if (true) {
+            // batched to reduce network overhead
+            const txIdsToFetch = txIds.filter(txId => !transactionCache.has(txId))
+            const rawTxs = await this.batchCall(txIdsToFetch.map(txId => ({
+                method: 'blockchain.transaction.get',
+                params: [txId, false]
+            })))
+
+            rawTxs.map((rawTx, index) => {
+                const tx: TransactionBCHWithAddress = fromLibauthTransaction(assertSuccess(decodeTransaction(hexToBin(rawTx))))
+
+                transactionCache.set(txIdsToFetch[index], tx)
+            })
+        } else {
+            // sequential to avoid batch limiting
+            await Promise.all(txIds.map(async (txId) => {
+                if (transactionCache.has(txId)) {
+                    return
+                }
+
+                const tx: TransactionBCHWithAddress = fromLibauthTransaction(assertSuccess(decodeTransaction(hexToBin(await this.getRawTransaction(txId)))))
+
+                transactionCache.set(txId, tx)
+            }))
+        }
+        for (const block of blocks) {
+            for (const transaction of block.block.transactions) {
+                const tx = transaction as Transaction
+
+                if (tx.transactionIndex === 0) {
+                    tx.sourceOutputs = undefined
+                } else {
+                    const txIdsToFetch = tx.inputs.filter(input => !transactionCache.has(input.outpointTransactionHash)).map(input => input.outpointTransactionHash)
+                    const rawTxs = await this.batchCall(txIdsToFetch.map(txId => ({
+                        method: 'blockchain.transaction.get',
+                        params: [txId, false]
+                    })))
+
+                    rawTxs.map((rawTx, index) => {
+                        const tx: TransactionBCHWithAddress = fromLibauthTransaction(assertSuccess(decodeTransaction(hexToBin(rawTx))))
+
+                        transactionCache.set(txIdsToFetch[index], tx)
+                    })
+
+                    tx.sourceOutputs = await Promise.all(tx.inputs.map(async (input) => {
+                        const txId = input.outpointTransactionHash
+                        let cachedTx = transactionCache.get(txId);
+                        if (!cachedTx) {
+                            console.error(txId, "not found in cache");
+                            // const tx = assertSuccess(decodeTransaction(hexToBin(await this.getRawTransaction(txId)))) as TransactionBCHWithAddress;
+                            // transactionCache.set(txId, tx);
+                            // cachedTx = tx;
+                        }
+
+                        return cachedTx!.outputs[input.outpointIndex]
+                    }))
+                }
+            }
+        }
+        console.timeEnd(`addSourceOutputs for blocks: ${blocks.map(b => b.height).join(', ')}. txIds: ${txIds.length}`)
+    }
+
+    private async addFees(blocks: Block[]): Promise<void> {
+        if (blocks.length == 0) return
+        if (blocks.some((block => block.block.transactions.some(tx => typeof tx === "string")))) {
+            return
+        }
+        this.log?.debug(`addFees for blocks: ${blocks.map(b => b.height).join(', ')}`)
+
+        for (const block of blocks) {
+            for (const transaction of block.block.transactions) {
+                const tx = transaction as Transaction
+
+                if (tx.transactionIndex === 0) {
+                    tx.fee = 0
+                } else {
+                    const sumInputs = tx.sourceOutputs!.reduce((acc, input) => acc + input.valueSatoshis, 0n)
+                    const sumOutputs = tx.outputs.reduce((acc, output) => acc + output.valueSatoshis, 0n)
+
+                    tx.fee = Number(sumInputs - sumOutputs)
+                }
+            }
+        }
+    }
+
+    private async getBlockByHeightInternal(blockHeight: number, verbosity: number): Promise<RpcBlock | string | null> {
+      const { height, hex } = await this.call("blockchain.header.get", [blockHeight])
+      const hash = binToHex(hash256(hexToBin(hex)).reverse())
+
+      return await this.getBlockByHashInternal(hash, verbosity, height)
+    }
+
+    private async getBlockByHeightInternalBatch(blockHeights: number[], verbosities: number[]): Promise<(RpcBlock | string | null)[]> {
+        if (blockHeights.length === 0) return []
+
+        const batch = blockHeights.map((blockHeight) => {
+            return {
+                method: 'blockchain.header.get',
+                params: [blockHeight]
+            }
+        })
+        const result = await this.batchCall<{ height: number, hex: string }>(batch)
+
+        return await this.getBlockByHashInternalBatch(
+            result.map(({hex}) => binToHex(hash256(hexToBin(hex)).reverse())),
+            verbosities,
+            result.map(({height}) => height)
+        )
+    }
+
+    private async getBlockHeightByHashInternal(blockHash: string): Promise<number> {
+      const { height } = await this.call("blockchain.header.get", [blockHash])
+      return height
+    }
+
+    private async mapToRpcBlock(blockHash: string, block: P2pBlock, verbosity: number, height?: number): Promise<RpcBlock | string | null> {
+        if (!verbosity || Number(verbosity) === 0) {
+            const result = block.toBuffer().toString("hex")
+            return result
+        } else if (Number(verbosity === 1) || Number(verbosity === 1.5)) {
+            height = height ?? (() => {
+                try {
+                    return block.getHeight()
+                } catch (e) {
+                    return undefined
+                }
+                })() ?? await this.getBlockHeightByHashInternal(blockHash)
+            const result = {
+                hash: block.getHash().toString("hex"),
+                confirmations: -1,
+                size: block.size,
+                height: height,
+                version: block.header!.version.slice().readUint32BE(0),
+                versionHex: block.header!.version.toString("hex"),
+                merkleroot: block.header!.merkleRoot.toString("hex"),
+                tx: [] as string[],
+                time: block.header!.time,
+                mediantime: 0,
+                nonce: block.header!.nonce,
+                bits: block.header!.bits.toString("hex"),
+                difficulty: 0,
+                nTx: block.txCount,
+                previousblockhash: block.header!.prevHash.toString("hex"),
+                nextblockhash: "",
+            }
+
+            const rawTransactions = block.getRawTransactions()
+            if (Number(verbosity === 1)) {
+                result.tx = rawTransactions.map(tx => binToHex(hash256(tx as unknown as Uint8Array).reverse()))
+            } else {
+                result.tx = rawTransactions.map(tx => tx.toString("hex"))
+            }
+            return result as RpcBlock
+        }
+
+        return null
+    }
+
+    private async getBlockByHashInternalBatch(blockHashes: string[], verbosities: number[], heights?: number[]): Promise<(RpcBlock | string | null)[]> {
+        if (blockHashes.length === 0) return []
+        const blocks = await this.p2p.getBlocks(blockHashes.map(blockHash => Buffer.from(blockHash, "hex")))
+
+        return await Promise.all(blocks.map((block, index) => this.mapToRpcBlock(blockHashes[index], block, verbosities[index], heights?.[index])))
+    }
+
+    private async getBlockByHashInternal(blockHash: string, verbosity: number, height?: number): Promise<RpcBlock | string | null> {
+        const block = await this.p2p.getBlock(Buffer.from(blockHash, "hex"))
+
+        return await this.mapToRpcBlock(blockHash, block, verbosity, height)
+    }
+}
+
+
+interface RpcProps {
+    p2pEndpoint?: string; // endpoint in format "ip:port"
+}
+
+function toBlock(getBlock: GetBlock): Block
+function toBlock(getBlock?: null): undefined
+function toBlock(getBlock?: GetBlock | null): Block | undefined
+function toBlock(getBlock?: GetBlock | null): Block | undefined {
+    if (getBlock == null) return
+    return {
+        height: getBlock.height,
+        hash: getBlock.hash,
+        block: getBlock
+    }
+}
+
+const transformBlock = (withTransactions: boolean) => (rpcBlock: RpcBlock | null): GetBlock | null => {
+    if (rpcBlock === null) return null
+    return {
+        height: rpcBlock.height,
+        hash: rpcBlock.hash,
+        parentHash: rpcBlock.previousblockhash,
+        transactions: (withTransactions ? rpcBlock.tx.map((txHex, index) => transformTransaction(txHex, index, rpcBlock)) : rpcBlock.tx) as Transaction[] | string[],
+        difficulty: rpcBlock.difficulty,
+        size: rpcBlock.size,
+        timestamp: rpcBlock.time,
+        nonce: rpcBlock.nonce,
+    }
+}
+
+const fromLibauthTransaction = (tx: TransactionCommon): TransactionBCHWithAddress => {
+    return {
+        ...tx,
+        inputs: tx.inputs.map(input => ({
+            ...input,
+            outpointTransactionHash: binToHex(input.outpointTransactionHash),
+            unlockingBytecode: binToHex(input.unlockingBytecode),
+        })),
+        outputs: tx.outputs.map(output => ({
+            ...output,
+            address: getAddress(output.lockingBytecode),
+            lockingBytecode: binToHex(output.lockingBytecode),
+            token: output.token ? {
+                category: binToHex(output.token.category),
+                amount: output.token.amount,
+                nft: output.token.nft ? {
+                    commitment: binToHex(output.token.nft.commitment),
+                    capability: output.token.nft.capability,
+                } : undefined,
+            } : undefined,
+        }))
+    }
+}
+
+const getAddress = (lockingBytecode: Uint8Array): string => {
+    if (addressCache.has(lockingBytecode)) {
+        return addressCache.get(lockingBytecode)!
+    }
+
+    const contents = lockingBytecodeToAddressContents(lockingBytecode)
+
+    const encodeResult = encodeCashAddress({
+        prefix: process.env.BCH_PREFIX as CashAddressNetworkPrefix,
+        type: contents.type.toLowerCase() as CashAddressType,
+        payload: contents.type === 'P2PK' ? hash160(contents.payload) : contents.payload,
+        throwErrors: false
+    })
+    return typeof encodeResult === "string" ? binToHex(contents.payload) : encodeResult.address
+}
+
+const transformTransaction = (txHexOrBin: string | Uint8Array, txIndex: number, rpcBlock: RpcBlock, txHash?: string): Transaction => {
+    const rawTx = typeof txHexOrBin === "string" ? hexToBin(txHexOrBin) : txHexOrBin
+    const tx = fromLibauthTransaction(assertSuccess(decodeTransaction(rawTx)))
+    txHash ??= binToHex(hash256(rawTx).reverse())
+    transactionCache.set(txHash, tx)
+
+    return {
+        hash: txHash,
+        blockHash: rpcBlock.hash,
+        blockNumber: rpcBlock.height,
+        transactionIndex: txIndex,
+        size: rawTx.length,
+        ...tx
+    }
+}

--- a/bch/bch-processor/src/ds-rpc/schema.ts
+++ b/bch/bch-processor/src/ds-rpc/schema.ts
@@ -1,0 +1,36 @@
+import {weakMemo} from '@subsquid/util-internal'
+import {
+    array,
+    NAT,
+    object,
+} from '@subsquid/util-internal-validation'
+import {
+    getBlockHeaderProps,
+    getTxProps} from '../mapping/schema.js'
+import {MappingRequest} from './request.js'
+import {
+    HEX,
+} from './rpc-data.js'
+
+// Here we must be careful to include all fields,
+// that can potentially be used in item filters
+// (no matter what field selection is telling us to omit)
+export const getBlockValidator = weakMemo((req: MappingRequest) => {
+    let Transaction = req.transactions
+        ? object({
+            ...getTxProps(req.fields.transaction, false),
+            hash: HEX,
+        })
+        : HEX
+
+    let GetBlock = object({
+        ...getBlockHeaderProps(req.fields.block, false),
+        transactions: array(Transaction)
+    })
+
+    return object({
+        height: NAT,
+        hash: HEX,
+        block: GetBlock,
+    })
+})

--- a/bch/bch-processor/src/ds-rpc/util.ts
+++ b/bch/bch-processor/src/ds-rpc/util.ts
@@ -1,0 +1,57 @@
+import assert from 'assert'
+import {Bytes32, Qty} from '../interfaces/base.js'
+
+
+export function qty2Int(qty: Qty): number {
+    let i = parseInt(qty, 16)
+    assert(Number.isSafeInteger(i))
+    return i
+}
+
+
+export function toQty(i: number): Qty {
+    return '0x' + i.toString(16)
+}
+
+
+export function getTxHash(tx: Bytes32 | {hash: Bytes32}): Bytes32 {
+    if (typeof tx == 'string') {
+        return tx
+    } else {
+        return tx.hash
+    }
+}
+
+export class Graph {
+    public graph: Map<string, string[]>;
+
+    constructor() {
+        this.graph = new Map();
+    }
+    addEdge(u: string, v: string) {
+        if (!this.graph.has(u)) {
+            this.graph.set(u, []);
+        }
+        this.graph.get(u)!.push(v);
+    }
+    topologicalSortUtil(v: string, visited: Set<string>, stack: Array<string>) {
+        visited.add(v);
+        const neighbors = this.graph.get(v) || [];
+        for (const neighbor of neighbors) {
+            if (!visited.has(neighbor)) {
+                this.topologicalSortUtil(neighbor, visited, stack);
+            }
+        }
+        stack.push(v);
+    }
+    topologicalSort() {
+        const visited = new Set<string>();
+        const stack: string[] = [];
+        for (const vertex of this.graph.keys()) {
+            if (!visited.has(vertex)) {
+                this.topologicalSortUtil(vertex, visited, stack);
+            }
+        }
+        return stack.reverse();
+    }
+  }

--- a/bch/bch-processor/src/index.ts
+++ b/bch/bch-processor/src/index.ts
@@ -1,0 +1,4 @@
+export {assertNotNull} from '@subsquid/util-internal'
+export {toHex, decodeHex} from '@subsquid/util-internal-hex'
+export * from './processor.js'
+export * from './interfaces/data.js'

--- a/bch/bch-processor/src/interfaces/base.ts
+++ b/bch/bch-processor/src/interfaces/base.ts
@@ -1,0 +1,5 @@
+export type Bytes = string
+export type Bytes8 = string
+export type Bytes20 = string
+export type Bytes32 = string
+export type Qty = string

--- a/bch/bch-processor/src/interfaces/bch.ts
+++ b/bch/bch-processor/src/interfaces/bch.ts
@@ -1,0 +1,26 @@
+import { Input, Output, TransactionCommon } from '@bitauth/libauth'
+import {Bytes32} from './base.js'
+
+
+export interface BchBlockHeader {
+    height: number
+    hash: Bytes32
+    parentHash: Bytes32
+    nonce: number
+    difficulty: number
+    size: number
+    timestamp: number
+}
+
+type TransactionBCH = TransactionCommon<Input<string,string>, Output<string,string,bigint>>
+
+export type OutputWithAddress = TransactionBCH["outputs"][0] & { address: string }
+
+export interface BchTransaction extends TransactionBCH {
+    hash: string
+    transactionIndex: number
+    size: number
+    outputs: OutputWithAddress[]
+    sourceOutputs: OutputWithAddress[]
+    fee: number
+}

--- a/bch/bch-processor/src/interfaces/chain.ts
+++ b/bch/bch-processor/src/interfaces/chain.ts
@@ -1,0 +1,14 @@
+import { TransactionBCHWithAddress } from "../ds-rpc/rpc.js"
+import { Bytes } from "./base.js"
+
+export interface RpcClient {
+    call<T=any>(method: string, params?: unknown[]): Promise<T>
+    batchCall(batch: {method: string, params?: unknown[]}[]): Promise<any[]>
+    getRawTransaction(hash: Bytes): Promise<string>
+    getTransaction(hash: Bytes): Promise<TransactionBCHWithAddress>
+}
+
+
+export interface Chain {
+    readonly client: RpcClient
+}

--- a/bch/bch-processor/src/interfaces/data-request.ts
+++ b/bch/bch-processor/src/interfaces/data-request.ts
@@ -1,0 +1,14 @@
+import {FieldSelection} from './data.js'
+
+export interface DataRequest {
+    fields?: FieldSelection
+    includeAllBlocks?: boolean
+    transactions?: TransactionRequest[]
+    sourceOutputs?: boolean
+    fee?: boolean
+}
+
+export interface TransactionRequest {
+    // address?: string
+    // token?: string
+}

--- a/bch/bch-processor/src/interfaces/data.ts
+++ b/bch/bch-processor/src/interfaces/data.ts
@@ -1,0 +1,112 @@
+import {
+    BchBlockHeader,
+    BchTransaction
+} from './bch.js'
+
+
+type Simplify<T> = {
+    [K in keyof T]: T[K]
+} & {}
+
+
+type Selector<Props extends string, Exclusion> = {
+    [P in Exclude<Props, Exclusion>]?: boolean
+}
+
+export type BlockRequiredFields = 'height' | 'hash' | 'parentHash'
+export type TransactionRequiredFields = 'transactionIndex'
+
+
+export interface FieldSelection {
+    block?: Selector<keyof BchBlockHeader, BlockRequiredFields>
+    transaction?: Selector<keyof BchTransaction, TransactionRequiredFields>
+}
+
+
+export const DEFAULT_FIELDS = {
+    block: {
+        timestamp: true,
+        size: true,
+    },
+    transaction: {
+        hash: true,
+        size: true,
+        inputs: true,
+        outputs: true,
+        version: true,
+        locktime: true,
+    },
+} as const
+
+
+type DefaultFields = typeof DEFAULT_FIELDS
+
+
+type ExcludeUndefined<T> = {
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K]
+} & {}
+
+
+type MergeDefault<T, D> = Simplify<
+    undefined extends T ? D : Omit<D, keyof ExcludeUndefined<T>> & ExcludeUndefined<T>
+>
+
+
+type TrueFields<F> = keyof {
+    [K in keyof F as true extends F[K] ? K : never]: true
+}
+
+
+type GetFields<F extends FieldSelection, P extends keyof DefaultFields>
+    = TrueFields<MergeDefault<F[P], DefaultFields[P]>>
+
+
+type Select<T, F> = T extends any ? Simplify<Pick<T, Extract<keyof T, F>>> : never
+
+
+export type BlockHeader<F extends FieldSelection = {}> = Simplify<
+    {id: string} &
+    Pick<BchBlockHeader, BlockRequiredFields> &
+    Select<BchBlockHeader, GetFields<F, 'block'>>
+>
+
+
+export type Transaction<F extends FieldSelection = {}> = Simplify<
+    {id: string} &
+    Pick<BchTransaction, TransactionRequiredFields> &
+    Select<BchTransaction, GetFields<F, 'transaction'>> &
+    {
+        block: BlockHeader<F>
+    }
+>
+
+type RemovePrefix<Prefix extends string, T>
+    = T extends `${Prefix}${infer S}`
+        ? Uncapitalize<S>
+        : never
+
+
+
+
+type RemoveEmptyObjects<T> = {
+    [K in keyof T as {} extends T[K] ? never : K]: T[K]
+}
+
+
+
+
+export type BlockData<F extends FieldSelection = {}> = {
+    header: BlockHeader<F>
+    transactions: Transaction<F>[]
+}
+
+
+export type AllFields = {
+    block: Trues<FieldSelection['block']>
+    transaction: Trues<FieldSelection['transaction']>
+}
+
+
+type Trues<T> = {
+    [K in keyof Exclude<T, undefined>]-?: true
+}

--- a/bch/bch-processor/src/mapping/entities.ts
+++ b/bch/bch-processor/src/mapping/entities.ts
@@ -1,0 +1,67 @@
+import {formatId} from '@subsquid/util-internal-processor-tools'
+import {Bytes20, Bytes32, Bytes8} from '../interfaces/base.js'
+import {
+    OutputWithAddress
+} from '../interfaces/bch.js'
+import { TransactionBCH } from '@bitauth/libauth'
+
+
+export class Block {
+    header: BlockHeader
+    transactions: Transaction[] = []
+
+    constructor(header: BlockHeader) {
+        this.header = header
+    }
+}
+
+
+export class BlockHeader {
+    id: string
+    height: number
+    hash: Bytes32
+    parentHash: Bytes32
+    nonce?: Bytes8
+    difficulty?: bigint
+    size?: bigint
+    timestamp?: number
+
+    constructor(
+        height: number,
+        hash: Bytes20,
+        parentHash: Bytes20
+    ) {
+        this.id = formatId({height, hash})
+        this.height = height
+        this.hash = hash
+        this.parentHash = parentHash
+    }
+}
+
+
+export class Transaction {
+    id: string
+    transactionIndex: number
+    hash?: string
+    size?: number
+    sourceOutputs?: OutputWithAddress[]
+    inputs?: TransactionBCH["inputs"]
+    locktime?: number
+    outputs?: OutputWithAddress[]
+    version?: number
+
+    #block: BlockHeader
+
+    constructor(
+        block: BlockHeader,
+        transactionIndex: number
+    ) {
+        this.id = formatId(block, transactionIndex)
+        this.transactionIndex = transactionIndex
+        this.#block = block
+    }
+
+    get block(): BlockHeader {
+        return this.#block
+    }
+}

--- a/bch/bch-processor/src/mapping/relations.ts
+++ b/bch/bch-processor/src/mapping/relations.ts
@@ -1,0 +1,12 @@
+import {maybeLast} from '@subsquid/util-internal'
+import {Block, Transaction} from './entities.js'
+
+
+export function setUpRelations(block: Block): void {
+    block.transactions.sort((a, b) => a.transactionIndex - b.transactionIndex)
+
+    let txs: (Transaction | undefined)[] = new Array((maybeLast(block.transactions)?.transactionIndex ?? -1) + 1)
+    for (let tx of block.transactions) {
+        txs[tx.transactionIndex] = tx
+    }
+}

--- a/bch/bch-processor/src/mapping/schema.ts
+++ b/bch/bch-processor/src/mapping/schema.ts
@@ -1,0 +1,100 @@
+import { BIGINT, HEX } from '../ds-rpc/rpc-data.js'
+import {FieldSelection} from '../interfaces/data.js'
+import {
+    array,
+    NAT,
+    object,
+    option,
+    SMALL_QTY,
+    STRING,
+    withSentinel
+} from '@subsquid/util-internal-validation'
+
+
+export function getBlockHeaderProps(fields: FieldSelection['block'], forArchive: boolean) {
+    let natural = forArchive ? NAT : SMALL_QTY
+    return {
+        height: NAT,
+        hash: HEX,
+        parentHash: HEX,
+        ...project(fields, {
+            nonce: withSentinel('BlockHeader.nonce', 0, NAT),
+            difficulty: withSentinel('BlockHeader.difficulty', 0, NAT),
+            size: withSentinel('BlockHeader.size', 0, NAT),
+            timestamp: withSentinel('BlockHeader.timestamp', 0, NAT),
+    })
+    }
+}
+
+
+export function getTxProps(fields: FieldSelection['transaction'], forArchive: boolean) {
+    // let natural = forArchive ? NAT : SMALL_QTY
+    return {
+        transactionIndex: NAT,
+        ...project(fields, {
+            hash: HEX,
+            size: NAT,
+            sourceOutputs: option(array(object({
+                lockingBytecode: HEX,
+                token: option(object({
+                    amount: BIGINT,
+                    category: HEX,
+                    nft: option(object({
+                        capability: STRING,
+                        commitment: HEX,
+                    })),
+                })),
+                valueSatoshis: BIGINT,
+                address: STRING,
+            }))),
+            inputs: array(object({
+                outpointIndex: NAT,
+                outpointTransactionHash: HEX,
+                sequenceNumber: NAT,
+                unlockingBytecode: HEX,
+            })),
+            outputs: array(object({
+                lockingBytecode: HEX,
+                token: option(object({
+                    amount: BIGINT,
+                    category: HEX,
+                    nft: option(object({
+                        capability: STRING,
+                        commitment: HEX,
+                    })),
+                })),
+                valueSatoshis: BIGINT,
+                address: STRING,
+            })),
+            locktime: NAT,
+            version: NAT,
+        })
+    }
+}
+
+
+export function project<T extends object, F extends {[K in keyof T]?: boolean}>(
+    fields: F | undefined,
+    obj: T
+): Partial<T> {
+    if (fields == null) return {}
+    let result: Partial<T> = {}
+    let key: keyof T
+    for (key in obj) {
+        if (fields[key]) {
+            result[key] = obj[key]
+        }
+    }
+    return result
+}
+
+
+export function isEmpty(obj: object): boolean {
+    for (let _ in obj) {
+        return false
+    }
+    return true
+}
+
+
+export function assertAssignable<A, B extends A>(): void {}

--- a/bch/bch-processor/src/mapping/selection.ts
+++ b/bch/bch-processor/src/mapping/selection.ts
@@ -1,0 +1,42 @@
+import {FieldSelection} from '../interfaces/data.js'
+import {object, option, BOOLEAN} from '@subsquid/util-internal-validation'
+
+
+type GetFieldSelectionSchema<T> = {[K in keyof T]-?: typeof FIELD}
+
+
+const FIELD = option(BOOLEAN)
+
+
+export function getBlockHeaderSelectionValidator() {
+    let fields: GetFieldSelectionSchema<FieldSelection['block']> = {
+        nonce: FIELD,
+        difficulty: FIELD,
+        size: FIELD,
+        timestamp: FIELD,
+    }
+    return object(fields)
+}
+
+
+export function getTxSelectionValidator() {
+    let fields: GetFieldSelectionSchema<FieldSelection['transaction']> = {
+        hash: FIELD,
+        inputs: FIELD,
+        locktime: FIELD,
+        outputs: FIELD,
+        version: FIELD,
+        size: FIELD,
+        sourceOutputs: FIELD,
+        fee: FIELD,
+    }
+    return object(fields)
+}
+
+
+export function getFieldSelectionValidator() {
+    return object({
+        block: option(getBlockHeaderSelectionValidator()),
+        transaction: option(getTxSelectionValidator()),
+    })
+}

--- a/bch/bch-processor/src/processor.ts
+++ b/bch/bch-processor/src/processor.ts
@@ -1,0 +1,620 @@
+import {HttpAgent, HttpClient} from '@subsquid/http-client'
+import {createLogger, Logger} from '@subsquid/logger'
+import {RpcClient} from '@subsquid/rpc-client'
+import {assertNotNull, def, runProgram} from '@subsquid/util-internal'
+import {ArchiveClient} from '@subsquid/util-internal-archive-client'
+import {Database, getOrGenerateSquidId, PrometheusServer, Runner} from '@subsquid/util-internal-processor-tools'
+import {applyRangeBound, mergeRangeRequests, Range, RangeRequest} from '@subsquid/util-internal-range'
+import {cast} from '@subsquid/util-internal-validation'
+import assert from 'assert'
+import {BchArchive} from './ds-archive/client.js'
+import {BchRpcDataSource} from './ds-rpc/client.js'
+import {Chain} from './interfaces/chain.js'
+import {BlockData, DEFAULT_FIELDS, FieldSelection, Transaction} from './interfaces/data.js'
+import {DataRequest,
+    TransactionRequest} from './interfaces/data-request.js'
+import {getFieldSelectionValidator} from './mapping/selection.js'
+import {RpcValidationFlags} from './ds-rpc/rpc.js'
+
+
+export interface RpcEndpointSettings {
+    /**
+     * RPC endpoint URL (either http(s) or ws(s))
+     */
+    url: string
+    /**
+     * Maximum number of ongoing concurrent requests
+     */
+    capacity?: number
+    /**
+     * Maximum number of requests per second
+     */
+    rateLimit?: number
+    /**
+     * Request timeout in `ms`
+     */
+    requestTimeout?: number
+    /**
+     * Maximum number of retry attempts.
+     *
+     * By default, retries all "retryable" errors indefinitely. 
+     */
+    retryAttempts?: number
+    /**
+     * Maximum number of requests in a single batch call
+     */
+    maxBatchCallSize?: number
+    /**
+     * HTTP headers
+     */
+    headers?: Record<string, string>
+}
+
+
+export interface RpcDataIngestionSettings {
+    /**
+     * Poll interval for new blocks in `ms`
+     *
+     * Poll mechanism is used to get new blocks via HTTP connection.
+     */
+    headPollInterval?: number
+    /**
+     * When websocket subscription is used to get new blocks,
+     * this setting specifies timeout in `ms` after which connection
+     * will be reset and subscription re-initiated if no new block where received.
+     */
+    newHeadTimeout?: number
+    /**
+     * Disable RPC data ingestion entirely
+     */
+    disabled?: boolean
+
+    /**
+     * Flags to switch off the data consistency checks
+     */
+    validationFlags?: RpcValidationFlags
+}
+
+
+export interface GatewaySettings {
+    /**
+     * Subsquid Network Gateway url
+     */
+    url: string
+    /**
+     * Request timeout in ms
+     */
+    requestTimeout?: number
+}
+
+
+/**
+ * @deprecated
+ */
+export type ArchiveSettings = GatewaySettings
+
+
+/**
+ * @deprecated
+ */
+export type DataSource = ArchiveDataSource | ChainDataSource
+
+
+
+interface ArchiveDataSource {
+    /**
+     * Subsquid evm archive endpoint URL
+     */
+    archive: string | GatewaySettings
+    /**
+     * Chain node RPC endpoint URL
+     */
+    chain?: string | RpcEndpointSettings
+}
+
+
+interface ChainDataSource {
+    archive?: undefined
+    /**
+     * Chain node RPC endpoint URL
+     */
+    chain: string | RpcEndpointSettings
+}
+
+
+interface BlockRange {
+    /**
+     * Block range
+     */
+    range?: Range
+}
+
+
+/**
+ * API and data that is passed to the data handler
+ */
+export interface DataHandlerContext<Store, F extends FieldSelection = {}> {
+    /**
+     * @internal
+     */
+    _chain: Chain
+    /**
+     * An instance of a structured logger.
+     */
+    log: Logger
+    /**
+     * Storage interface provided by the database
+     */
+    store: Store
+    /**
+     * List of blocks to map and process
+     */
+    blocks: BlockData<F>[]
+    /**
+     * List of mempool transactions to process
+     */
+    mempoolTransactions: Transaction<F>[]
+    /**
+     * Signals, that the processor reached the head of a chain.
+     *
+     * The head block is always included in `.blocks`.
+     */
+    isHead: boolean
+}
+
+
+export type BchBatchProcessorFields<T> = T extends BchBatchProcessor<infer F> ? F : never
+
+
+/**
+ * Provides methods to configure and launch data processing.
+ */
+export class BchBatchProcessor<F extends FieldSelection = {}> {
+    private requests: RangeRequest<DataRequest>[] = []
+    private blockRange?: Range
+    private fields?: FieldSelection
+    private finalityConfirmation?: number
+    private archive?: GatewaySettings
+    private rpcIngestSettings?: RpcDataIngestionSettings
+    private rpcEndpoint?: RpcEndpointSettings
+    private p2pEndpoint?: string // endpoint in format "ip:port"
+    private running = false
+
+    private hotDataSource!: BchRpcDataSource
+
+    /**
+     * @deprecated Use {@link .setGateway()}
+     */
+    setArchive(url: string | GatewaySettings): this {
+        return this.setGateway(url)
+    }
+
+    /**
+     * Set Subsquid Network Gateway endpoint (ex Archive).
+     *
+     * Subsquid Network allows to get data from finalized blocks up to
+     * infinite times faster and more efficient than via regular RPC.
+     *
+     * @example
+     * processor.setGateway('https://v2.archive.subsquid.io/network/ethereum-mainnet')
+     */
+    setGateway(url: string | GatewaySettings): this {
+        this.assertNotRunning()
+        if (typeof url == 'string') {
+            this.archive = {url}
+        } else {
+            this.archive = url
+        }
+        return this
+    }
+
+    /**
+     * Set chain RPC endpoint
+     *
+     * @example
+     * // just pass a URL
+     * processor.setRpcEndpoint('https://eth-mainnet.public.blastapi.io')
+     *
+     * // adjust some connection options
+     * processor.setRpcEndpoint({
+     *     url: 'https://eth-mainnet.public.blastapi.io',
+     *     rateLimit: 10
+     * })
+     */
+    setRpcEndpoint(url: string | RpcEndpointSettings | undefined): this {
+        this.assertNotRunning()
+        if (typeof url == 'string') {
+            this.rpcEndpoint = {url}
+        } else {
+            this.rpcEndpoint = url
+        }
+        return this
+    }
+
+    /**
+     * Optionaly set chain p2p endpoint, which is used to fetch blocks, monitor mempool, etc. Will default to a hardcoded one
+     *
+     * @example
+     * // just pass a an 'ip:port' string, see https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/blob/master/src/chainparamsseeds.h
+     * processor.setP2pEndpoint('3.142.98.179:8333')
+     *
+     */
+    setP2pEndpoint(url: string): this {
+        this.assertNotRunning()
+        this.p2pEndpoint = url
+        return this
+    }
+
+    /**
+     * Sets blockchain data source.
+     *
+     * @example
+     * processor.setDataSource({
+     *     archive: 'https://v2.archive.subsquid.io/network/ethereum-mainnet',
+     *     chain: 'https://eth-mainnet.public.blastapi.io'
+     * })
+     *
+     * @deprecated Use separate {@link .setGateway()} and {@link .setRpcEndpoint()} methods
+     * to specify data sources.
+     */
+    setDataSource(src: DataSource): this {
+        this.assertNotRunning()
+        if (src.archive) {
+            this.setGateway(src.archive)
+        } else {
+            this.archive = undefined
+        }
+        if (src.chain) {
+            this.setRpcEndpoint(src.chain)
+        } else {
+            this.rpcEndpoint = undefined
+        }
+        return this
+    }
+
+    /**
+     * Set up RPC data ingestion settings
+     */
+    setRpcDataIngestionSettings(settings: RpcDataIngestionSettings): this {
+        this.assertNotRunning()
+        this.rpcIngestSettings = settings
+        return this
+    }
+
+    /**
+     * @deprecated Use {@link .setRpcDataIngestionSettings()} instead
+     */
+    setChainPollInterval(ms: number): this {
+        assert(ms >= 0)
+        this.assertNotRunning()
+        this.rpcIngestSettings = {...this.rpcIngestSettings, headPollInterval: ms}
+        return this
+    }
+
+    /**
+     * Never use RPC endpoint for data ingestion.
+     *
+     * @deprecated This is the same as `.setRpcDataIngestionSettings({disabled: true})`
+     */
+    useArchiveOnly(yes?: boolean): this {
+        this.assertNotRunning()
+        this.rpcIngestSettings = {...this.rpcIngestSettings, disabled: yes !== false}
+        return this
+    }
+
+    /**
+     * Distance from the head block behind which all blocks are considered to be finalized.
+     */
+    setFinalityConfirmation(nBlocks: number): this {
+        this.assertNotRunning()
+        this.finalityConfirmation = nBlocks
+        return this
+    }
+
+    /**
+     * Configure a set of fetched fields
+     */
+    setFields<T extends FieldSelection>(fields: T): BchBatchProcessor<T> {
+        this.assertNotRunning()
+        let validator = getFieldSelectionValidator()
+        this.fields = cast(validator, fields)
+
+        if (this.fields?.transaction?.sourceOutputs) {
+            this.add({sourceOutputs: true}, {from: this.requests.sort((a, b) => a.range.from - b.range.from)[0].range.from})
+        }
+
+        if (this.fields?.transaction?.fee) {
+            if (!this.fields?.transaction?.sourceOutputs) {
+                throw new Error('Fee calculation requires sourceOutputs')
+            }
+            this.add({fee: true}, {from: this.requests.sort((a, b) => a.range.from - b.range.from)[0].range.from})
+        }
+
+        return this as any
+    }
+
+    private add(request: DataRequest, range?: Range): void {
+        this.requests.push({
+            range: range || {from: 0},
+            request
+        })
+    }
+
+    /**
+     * By default, the processor will fetch only blocks
+     * which contain requested items. This method
+     * modifies such behaviour to fetch all chain blocks.
+     *
+     * Optionally a range of blocks can be specified
+     * for which the setting should be effective.
+     */
+    includeAllBlocks(range?: Range): this {
+        this.assertNotRunning()
+        this.add({includeAllBlocks: true}, range)
+        return this
+    }
+
+    addTransaction(options: TransactionRequest & BlockRange): this {
+        this.assertNotRunning()
+        this.add({
+            transactions: [mapRequest(options)]
+        }, options.range)
+        return this
+    }
+
+    /**
+     * Limits the range of blocks to be processed.
+     *
+     * When the upper bound is specified,
+     * the processor will terminate with exit code 0 once it reaches it.
+     */
+    setBlockRange(range?: Range): this {
+        this.assertNotRunning()
+        this.blockRange = range
+        return this
+    }
+
+    /**
+     * Sets the port for a built-in prometheus metrics server.
+     *
+     * By default, the value of `PROMETHEUS_PORT` environment
+     * variable is used. When it is not set,
+     * the processor will pick up an ephemeral port.
+     */
+    setPrometheusPort(port: number | string): this {
+        this.assertNotRunning()
+        this.getPrometheusServer().setPort(port)
+        return this
+    }
+
+    private assertNotRunning(): void {
+        if (this.running) {
+            throw new Error('Settings modifications are not allowed after start of processing')
+        }
+    }
+
+    @def
+    private getLogger(): Logger {
+        return createLogger('sqd:processor')
+    }
+
+    @def
+    private getSquidId(): string {
+        return getOrGenerateSquidId()
+    }
+
+    @def
+    private getPrometheusServer(): PrometheusServer {
+        return new PrometheusServer()
+    }
+
+    @def
+    private getChainRpcClient(): RpcClient {
+        if (this.rpcEndpoint == null) {
+            throw new Error(`use .setRpcEndpoint() to specify chain RPC endpoint`)
+        }
+        let client = new RpcClient({
+            url: this.rpcEndpoint.url,
+            headers: this.rpcEndpoint.headers,
+            maxBatchCallSize: this.rpcEndpoint.maxBatchCallSize ?? 25,
+            requestTimeout:  this.rpcEndpoint.requestTimeout ?? 10_000,
+            capacity: this.rpcEndpoint.capacity ?? 2,
+            rateLimit: this.rpcEndpoint.rateLimit,
+            retryAttempts: this.rpcEndpoint.retryAttempts ?? Number.MAX_SAFE_INTEGER,
+            log: this.getLogger().child('rpc', {rpcUrl: this.rpcEndpoint.url})
+        })
+        this.getPrometheusServer().addChainRpcMetrics(() => client.getMetrics())
+        return client
+    }
+
+    @def
+    private getChain(): Chain {
+        let self = this
+        return {
+            get client() {
+                return self.getHotDataSource().rpc
+            }
+        }
+    }
+
+    @def
+    private getHotDataSource(): BchRpcDataSource {
+        if (this.finalityConfirmation == null) {
+            throw new Error(`use .setFinalityConfirmation() to specify number of children required to confirm block's finality`)
+        }
+
+        if (!this.hotDataSource) {
+            this.hotDataSource = new BchRpcDataSource({
+                rpc: this.getChainRpcClient(),
+                p2pEndpoint: this.p2pEndpoint,
+                finalityConfirmation: this.finalityConfirmation,
+                headPollInterval: this.rpcIngestSettings?.headPollInterval,
+                newHeadTimeout: this.rpcIngestSettings?.newHeadTimeout,
+                validationFlags: this.rpcIngestSettings?.validationFlags,
+                log: this.getLogger().child('rpc', {rpcUrl: this.getChainRpcClient().url})
+            })
+        }
+
+        return this.hotDataSource
+    }
+
+    @def
+    private getArchiveDataSource(): BchArchive {
+        let archive = assertNotNull(this.archive)
+
+        let log = this.getLogger().child('archive')
+
+        let http = new HttpClient({
+            headers: {
+                'x-squid-id': this.getSquidId()
+            },
+            agent: new HttpAgent({
+                keepAlive: true
+            }),
+            log
+        })
+
+        return new BchArchive(
+            new ArchiveClient({
+                http,
+                url: archive.url,
+                queryTimeout: archive.requestTimeout,
+                log
+            })
+        )
+    }
+
+    @def
+    private getBatchRequests(): RangeRequest<DataRequest>[] {
+        let requests = mergeRangeRequests(this.requests, function merge(a: DataRequest, b: DataRequest) {
+            let res: DataRequest = {}
+            if (a.includeAllBlocks || b.includeAllBlocks) {
+                res.includeAllBlocks = true
+            }
+            res.transactions = concatRequestLists(a.transactions, b.transactions)
+            // res.logs = concatRequestLists(a.logs, b.logs)
+            // res.traces = concatRequestLists(a.traces, b.traces)
+            // res.stateDiffs = concatRequestLists(a.stateDiffs, b.stateDiffs)
+            return res
+        })
+
+        let fields = addDefaultFields(this.fields)
+        for (let req of requests) {
+            req.request.fields = fields
+        }
+
+        return applyRangeBound(requests, this.blockRange)
+    }
+
+    /**
+     * Run data processing.
+     *
+     * This method assumes full control over the current OS process as
+     * it terminates the entire program in case of error or
+     * at the end of data processing.
+     *
+     * @param database - database is responsible for providing storage to data handlers
+     * and persisting mapping progress and status.
+     *
+     * @param handler - The data handler, see {@link DataHandlerContext} for an API available to the handler.
+     */
+    run<Store>(database: Database<Store>, handler: (ctx: DataHandlerContext<Store, F>) => Promise<void>): void {
+        this.assertNotRunning()
+        this.running = true
+        let log = this.getLogger()
+
+        runProgram(async () => {
+            let chain = this.getChain()
+            let mappingLog = log.child('mapping')
+
+            if (this.archive == null && this.rpcEndpoint == null) {
+                throw new Error(
+                    'No data source where specified. ' +
+                    'Use .setArchive() to specify Subsquid Archive and/or .setRpcEndpoint() to specify RPC endpoint.'
+                )
+            }
+
+            if (this.archive == null && this.rpcIngestSettings?.disabled) {
+                throw new Error('Subsquid Archive is required when RPC data ingestion is disabled')
+            }
+
+            return new Runner({
+                database,
+                requests: this.getBatchRequests(),
+                archive: this.archive ? this.getArchiveDataSource() : undefined,
+                hotDataSource: this.rpcEndpoint && !this.rpcIngestSettings?.disabled
+                    ? this.getHotDataSource()
+                    : undefined,
+                allBlocksAreFinal: this.finalityConfirmation === 0,
+                prometheus: this.getPrometheusServer(),
+                log,
+                watchMempool: true,
+                process(store, batch) {
+                    return handler({
+                        _chain: chain,
+                        log: mappingLog,
+                        store,
+                        blocks: batch.blocks as any,
+                        mempoolTransactions: batch.mempoolTransactions ?? [],
+                        isHead: batch.isHead
+                    })
+                }
+            }).run()
+        }, err => log.fatal(err))
+    }
+}
+
+
+function mapRequest<T extends BlockRange>(options: T): Omit<T, 'range'> {
+    let {range, ...req} = options
+    for (let key in req) {
+        let val = (req as any)[key]
+        if (Array.isArray(val)) {
+            (req as any)[key] = val.map(s => s.toLowerCase())
+        }
+    }
+    return req
+}
+
+
+function concatRequestLists<T extends object>(a?: T[], b?: T[]): T[] | undefined {
+    let result: T[] = []
+    if (a) {
+        result.push(...a)
+    }
+    if (b) {
+        result.push(...b)
+    }
+    return result.length == 0 ? undefined : result
+}
+
+
+function addDefaultFields(fields?: FieldSelection): FieldSelection {
+    return {
+        block: mergeDefaultFields(DEFAULT_FIELDS.block, fields?.block),
+        transaction: mergeDefaultFields(DEFAULT_FIELDS.transaction, fields?.transaction),
+    }
+}
+
+
+type Selector<Props extends string> = {
+    [P in Props]?: boolean
+}
+
+
+function mergeDefaultFields<Props extends string>(
+    defaults: Selector<Props>,
+    selection?: Selector<Props>
+): Selector<Props> {
+    let result: Selector<Props> = {...defaults}
+    for (let key in selection) {
+        if (selection[key] != null) {
+            if (selection[key]) {
+                result[key] = true
+            } else {
+                delete result[key]
+            }
+        }
+    }
+    return result
+}

--- a/bch/bch-processor/tsconfig.json
+++ b/bch/bch-processor/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "lib",
+    "rootDir": "src",
+    "allowJs": true,
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@aws-sdk/client-s3':
     specifier: ^3.462.0
     version: 3.462.0
+  '@bitauth/libauth':
+    specifier: ^3.0.0
+    version: 3.0.0
   '@coral-xyz/anchor':
     specifier: ^0.29.0
     version: 0.29.0
@@ -44,6 +47,9 @@ dependencies:
   '@rush-temp/batch-processor':
     specifier: file:./projects/batch-processor.tgz
     version: file:projects/batch-processor.tgz
+  '@rush-temp/bch-processor':
+    specifier: file:./projects/bch-processor.tgz
+    version: file:projects/bch-processor.tgz
   '@rush-temp/big-decimal':
     specifier: file:./projects/big-decimal.tgz
     version: file:projects/big-decimal.tgz
@@ -398,6 +404,9 @@ dependencies:
   big.js:
     specifier: ~6.2.1
     version: 6.2.1
+  bitcoin-minimal:
+    specifier: ^1.1.7
+    version: 1.1.7
   blake2b:
     specifier: ^2.1.4
     version: 2.1.4
@@ -455,12 +464,18 @@ dependencies:
   latest-version:
     specifier: ^5.1.0
     version: 5.1.0
+  lru-cache:
+    specifier: ^11.0.2
+    version: 11.0.2
   mocha:
     specifier: ^10.7.0
     version: 10.7.3
   node-fetch:
     specifier: ^3.3.2
     version: 3.3.2
+  p2p-cash:
+    specifier: ^1.1.12
+    version: 1.1.12
   pg:
     specifier: ^8.11.3
     version: 8.11.3
@@ -1276,6 +1291,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+    dev: false
+
+  /@bitauth/libauth@3.0.0:
+    resolution: {integrity: sha512-3yoL31XpnhAnf5nDVMFk4xPqebxDwXrgYAwpa31ARJnV5A/eXWlpNYvCd6FTZPFM4VvKfjCBi+jRCrw1hOZ0Jg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
   /@coral-xyz/anchor-errors@0.30.1:
@@ -2657,6 +2677,15 @@ packages:
       '@subsquid/util-internal-binary-heap': 1.0.0
     dev: false
 
+  /@subsquid/util-internal-validation@0.6.0:
+    resolution: {integrity: sha512-OjrtBS9oJQApNa/ar9IMB0l2+IIydxLKIlxpJsyHgI0buK+aWofDq1aPaPh3XtCKrHzLDkrM9KAqkt8fQirifQ==}
+    peerDependencies:
+      '@subsquid/logger': ^1.3.3
+    peerDependenciesMeta:
+      '@subsquid/logger':
+        optional: true
+    dev: false
+
   /@subsquid/util-internal@2.5.2:
     resolution: {integrity: sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg==}
     dev: false
@@ -3288,6 +3317,14 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: false
 
+  /async-mutex@0.4.1:
+    resolution: {integrity: sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==}
+    requiresBuild: true
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+    optional: true
+
   /async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
     dependencies:
@@ -3360,6 +3397,11 @@ packages:
 
   /bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+    dev: false
+
+  /bitcoin-minimal@1.1.7:
+    resolution: {integrity: sha512-Rs3MOO0rApYhWWl+M2QT+jCEAsz47h2+iRrUibToM/xFQrlhgfC1k/ufxzvXwlcBMTO2krOcn0+4pmiFCGeGFQ==}
+    engines: {node: '>=12.0.0'}
     dev: false
 
   /blake2b-wasm@2.4.0:
@@ -4825,6 +4867,16 @@ packages:
       ws: 7.5.10
     dev: false
 
+  /isomorphic-ws@5.0.0(ws@8.17.1):
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    requiresBuild: true
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    dev: false
+    optional: true
+
   /isows@1.0.4(ws@8.17.1):
     resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
     peerDependencies:
@@ -5074,6 +5126,11 @@ packages:
   /lru-cache@10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
+    dev: false
+
+  /lru-cache@11.0.2:
+    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
+    engines: {node: 20 || >=22}
     dev: false
 
   /lru-cache@6.0.0:
@@ -5405,6 +5462,19 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
+    dev: false
+
+  /p2p-cash@1.1.12:
+    resolution: {integrity: sha512-26Fngsyp+SEtd7zU/Zv40Om2jvOr3qQI9xmmlv94y7DMYsKggOjBiDsV8fWqAgmC5piarsObr+kC1/mKNiZZwg==}
+    dependencies:
+      bitcoin-minimal: 1.1.7
+    optionalDependencies:
+      async-mutex: 0.4.1
+      isomorphic-ws: 5.0.0(ws@8.17.1)
+      ws: 8.17.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: false
 
   /package-json@6.5.0:
@@ -6943,6 +7013,23 @@ packages:
       typescript: 5.5.4
     dev: false
 
+  file:projects/bch-processor.tgz:
+    resolution: {integrity: sha512-onnymQyesO8Zu/ABtv7R0GrkvhhIPwGsa2OLwX8LNfAIMfZJUQRU60HZC7lI/2kWRjJiWSq4TZYgfotcAzQ0DQ==, tarball: file:projects/bch-processor.tgz}
+    name: '@rush-temp/bch-processor'
+    version: 0.0.0
+    dependencies:
+      '@bitauth/libauth': 3.0.0
+      '@subsquid/util-internal-validation': 0.6.0
+      '@types/node': 18.19.0
+      bitcoin-minimal: 1.1.7
+      lru-cache: 11.0.2
+      p2p-cash: 1.1.12
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
   file:projects/big-decimal.tgz:
     resolution: {integrity: sha512-/Er4O4+BTjIgMcLL/oy3KUDz5o/97kqUHu1HGrIvixflTucO3M2Dm/GnwE1d81EtsEaCR57yWvZ7u07HLEU3og==, tarball: file:projects/big-decimal.tgz}
     name: '@rush-temp/big-decimal'
@@ -6991,7 +7078,7 @@ packages:
     dev: false
 
   file:projects/data-test.tgz:
-    resolution: {integrity: sha512-vfocRZTAM/R/+T+dR+5OwAzOim5k+JWu+uWq5NqTINBuin6gQ4H6ufbTXjXeAvD3OvAyaUqS2TPYENntSFAHdA==, tarball: file:projects/data-test.tgz}
+    resolution: {integrity: sha512-s+hwonZVmCEShGErXBavkrZKxMnQxPGBIsraWM+8LK74aGUAD1nYqshUh9jh05RlwavSWEilNTo+BbI81fFriw==, tarball: file:projects/data-test.tgz}
     name: '@rush-temp/data-test'
     version: 0.0.0
     dependencies:
@@ -7100,7 +7187,7 @@ packages:
     dev: false
 
   file:projects/evm-processor.tgz:
-    resolution: {integrity: sha512-JEYc/4KCDHotB8lMj+SjVPzNPOPpzsWXWwreQy+hAjZQes/fWnMg4FGQ71NFQOYwZ/zL0k+imKUpvvcTQ69ALw==, tarball: file:projects/evm-processor.tgz}
+    resolution: {integrity: sha512-1s05mLWlR1INC4Qe5exVe+klgXztqZlwPGs/a4V0tUYjdiaxz3IENfOhuyWHWGRYf0CIGFf0KQ0FigGLumYY+A==, tarball: file:projects/evm-processor.tgz}
     name: '@rush-temp/evm-processor'
     version: 0.0.0
     dependencies:
@@ -7109,7 +7196,7 @@ packages:
     dev: false
 
   file:projects/evm-typegen.tgz:
-    resolution: {integrity: sha512-zze/6ha5YyYINCNglygQHh63jV8/nsVqPbKpZeeznnnEldNG2n6/WMajR0vdAnGDRTMR+nmP9/TveOPbDTX+mg==, tarball: file:projects/evm-typegen.tgz}
+    resolution: {integrity: sha512-3DiW6rLdLmAUqUB+P1iYHfRHi9123lAVabeIrJB0klQj16q70mvel+mrY9hCk1nUvxiEVEnPCueay3Ldf2ZQTg==, tarball: file:projects/evm-typegen.tgz}
     name: '@rush-temp/evm-typegen'
     version: 0.0.0
     dependencies:
@@ -7140,7 +7227,7 @@ packages:
     dev: false
 
   file:projects/fuel-data.tgz:
-    resolution: {integrity: sha512-6XW1Dvmzit570V/bEwNjiD5jJ9ZHbvJ3gyNoS6HE2qoR+C2/NPqPjMcev6xhOd/XS2/raaw6y8c6ywT3lTWTUw==, tarball: file:projects/fuel-data.tgz}
+    resolution: {integrity: sha512-LZwxHIPqKJw/590kj/j7tba2SzlHejChA/x2JTnSD9HW1ijOrrmit8TYH9zPf4mcW4gZTM9hcZFFtjIOfPLsCw==, tarball: file:projects/fuel-data.tgz}
     name: '@rush-temp/fuel-data'
     version: 0.0.0
     dependencies:
@@ -7149,7 +7236,7 @@ packages:
     dev: false
 
   file:projects/fuel-dump.tgz:
-    resolution: {integrity: sha512-P93UXjAjSIwTD/ZyemYajxts+j65qTByNGxAApyDXZOWywHdt0K3EPnDyLDz4/gm8LG6OtalcJfOhyPU/iKk2A==, tarball: file:projects/fuel-dump.tgz}
+    resolution: {integrity: sha512-ImKKGnItSKiCytmEqLaz148rhsH0b2kxYWkAMAR+JN3s89/rVDLKcFrqOh6CJHinIeZ1/zcT4ZoFzVXyYIS9mQ==, tarball: file:projects/fuel-dump.tgz}
     name: '@rush-temp/fuel-dump'
     version: 0.0.0
     dependencies:
@@ -7216,7 +7303,7 @@ packages:
     dev: false
 
   file:projects/fuel-stream.tgz:
-    resolution: {integrity: sha512-iEuYdfArMof7F87gKvpnuGx4j/PzsgkMrruS29W2UTx+7FhwkUnujQxqLQx2E2++SuKSb18Ga+eI+GP0lsl07g==, tarball: file:projects/fuel-stream.tgz}
+    resolution: {integrity: sha512-6J2VBe48XWIqSZ3M8lZtBrsHZr+p8zRTofEkolzhhT4kighSSCG/HVPp3tp1ZXc5rPGpQGT/JZeCArOsGo3EhQ==, tarball: file:projects/fuel-stream.tgz}
     name: '@rush-temp/fuel-stream'
     version: 0.0.0
     dependencies:
@@ -7225,7 +7312,7 @@ packages:
     dev: false
 
   file:projects/gql-test-client.tgz(graphql@15.8.0):
-    resolution: {integrity: sha512-JGE+gV8EgQ8u90IfJW06yab+oC1gw+HsJdwvSj6LdzY6dbtlIDXNRFeJMV988eLN8IxLSdDhd98h4YYt6n3suw==, tarball: file:projects/gql-test-client.tgz}
+    resolution: {integrity: sha512-bivyHNQZ2H4YrNdCo4dwEc53cIe+iXpU2UF6vMjBwbgHqiIbrhGpMbtzgKoZLdNAkbqchh0E543pkDQy318iow==, tarball: file:projects/gql-test-client.tgz}
     id: file:projects/gql-test-client.tgz
     name: '@rush-temp/gql-test-client'
     version: 0.0.0
@@ -7404,7 +7491,7 @@ packages:
     dev: false
 
   file:projects/rpc-client.tgz:
-    resolution: {integrity: sha512-B54boDboO5+HelVasKnnBZs/VahkkLvB9ETLN4nlILcTBwv2SZP0UbC4VYNaSRm5n1PtYb52954pqKlNkEecmA==, tarball: file:projects/rpc-client.tgz}
+    resolution: {integrity: sha512-T49gc/C/cmRUB956khwoKu41Izdk4BPYLlFBZAWkPn0xDje0kbmmjb76WyueHTu7mrjvSdjVNqrIkg/RYxGV8Q==, tarball: file:projects/rpc-client.tgz}
     name: '@rush-temp/rpc-client'
     version: 0.0.0
     dependencies:
@@ -7580,7 +7667,7 @@ packages:
     dev: false
 
   file:projects/solana-stream.tgz:
-    resolution: {integrity: sha512-xt4F3+TWZqYkHFwWyxO9FFeCi1ZwfDjgt3AkM9qPwhnxBfyawaGdEeTUwfJtPJsNrxaroMLXmLRFmKp65iXO8w==, tarball: file:projects/solana-stream.tgz}
+    resolution: {integrity: sha512-krZzJP5QBey2MWE6BMGBn4fRnV4P1weoVts3iAyfNNYs+ukKIZLn76qFrzJ8yIpYlZUF4tq49CK0v0jnZ+XHEA==, tarball: file:projects/solana-stream.tgz}
     name: '@rush-temp/solana-stream'
     version: 0.0.0
     dependencies:
@@ -7590,7 +7677,7 @@ packages:
     dev: false
 
   file:projects/solana-typegen.tgz:
-    resolution: {integrity: sha512-Qva321wiPxpOzXBUf6Qj5vlQ2eZILvwFdBCfchCmxQY7EqzLILY+FjMfNcj/VzaA3tTnfp8adYgO1YfoKHdCMw==, tarball: file:projects/solana-typegen.tgz}
+    resolution: {integrity: sha512-P2R//97dE6hHXv65zV5e3SuD+ArfjY1jxt9Ct2j5ckibvec646B47UHZsBRTlu6u9tVJSJIFth4OvWa7CogkYw==, tarball: file:projects/solana-typegen.tgz}
     name: '@rush-temp/solana-typegen'
     version: 0.0.0
     dependencies:
@@ -7687,7 +7774,7 @@ packages:
     dev: false
 
   file:projects/starknet-stream.tgz:
-    resolution: {integrity: sha512-WSp/9Dd2y5+GeN0F01Az1HS5BtnOAjlDQ6o1qwlUptfoYMB6DBf4udXGAA7i2Sj3AijE+t3pAxoRXkX82Y3GmA==, tarball: file:projects/starknet-stream.tgz}
+    resolution: {integrity: sha512-xOStr+km+Cj7Q9yY8YNp0ledJQhcYDzparQYEVgg55Na1fPHHJls2qvHiGb5mqofRjVfQlYsmWkD1QeyXpojUg==, tarball: file:projects/starknet-stream.tgz}
     name: '@rush-temp/starknet-stream'
     version: 0.0.0
     dependencies:
@@ -7760,7 +7847,7 @@ packages:
     dev: false
 
   file:projects/substrate-processor.tgz:
-    resolution: {integrity: sha512-bv9yCssIgRcDJfSIiJqw97p9t03FHIBMk5Qvfs3cQuN9MOOCB4retTUPhzT+yhgtD1czIriXIcAgmGBgcEeOHw==, tarball: file:projects/substrate-processor.tgz}
+    resolution: {integrity: sha512-nvjuzvcpbwWO7Bg5mfDrBT+r5HlkldIxjHBStsgPT3OZXKAMN+hSCkGhdwF5urVNLNcuokPT5QexZq0grc3lDw==, tarball: file:projects/substrate-processor.tgz}
     name: '@rush-temp/substrate-processor'
     version: 0.0.0
     dependencies:
@@ -7782,7 +7869,7 @@ packages:
     dev: false
 
   file:projects/substrate-typegen.tgz:
-    resolution: {integrity: sha512-HDrlRIPga2gKlNtr8I+7jJPb4UMygW8+7BEIBJsIOVjpk/jPBQX5EjWOg6bmuiL6PtODQTN4gDutgrmptMOLZg==, tarball: file:projects/substrate-typegen.tgz}
+    resolution: {integrity: sha512-hYFLl7+BgkKy15M2J31XXmpXDo67jmhmh1/j/C0uJbDPwiTKkLleFaDM9bPBgynB+WF3AmGv9XUkvCGvLawzbQ==, tarball: file:projects/substrate-typegen.tgz}
     name: '@rush-temp/substrate-typegen'
     version: 0.0.0
     dependencies:
@@ -7792,7 +7879,7 @@ packages:
     dev: false
 
   file:projects/tron-data.tgz:
-    resolution: {integrity: sha512-TSoknC0M1/aV4Jg070uz8i/V4YBRBcXkZzrSZwc1SaTQUOYVtQh8UpBdQyJLcRlVTi+K6SZtUM99wsE/VJgB3Q==, tarball: file:projects/tron-data.tgz}
+    resolution: {integrity: sha512-AnZ2mjIhDmxqQ6je661F2AzDRvUJHoZTkdqa0lWo5QScjjvvdEOGv42VAGXqPuYe4n4gY4Dj+K/eFzfeDCAQ+Q==, tarball: file:projects/tron-data.tgz}
     name: '@rush-temp/tron-data'
     version: 0.0.0
     dependencies:
@@ -7840,7 +7927,7 @@ packages:
     dev: false
 
   file:projects/tron-processor.tgz:
-    resolution: {integrity: sha512-jxOST5hrGQAEkbehlZuOZPDQ47SX+nQ1u0vp0UAmaj5XcgxoRm3u9oX807X2YOWxAfgrjX7fBWeIassnFewLVg==, tarball: file:projects/tron-processor.tgz}
+    resolution: {integrity: sha512-hyWAMCO/NbpJPmnw4Jo+CpML5m6wcS1j3gXe+IL7nZYUAjZzvNEa4NCtsaKaVRSNR1qr8kNz1++56Kt2VvQQ1A==, tarball: file:projects/tron-processor.tgz}
     name: '@rush-temp/tron-processor'
     version: 0.0.0
     dependencies:
@@ -7995,7 +8082,7 @@ packages:
     dev: false
 
   file:projects/util-internal-archive-client.tgz:
-    resolution: {integrity: sha512-cq/2eIibQ3DuQCV1bCylf0IPexvdRTf27x7BhOjR4lkGMS6DeqlF0qgVfct9WY4TCHljIey09EMnRwTJzn+7uQ==, tarball: file:projects/util-internal-archive-client.tgz}
+    resolution: {integrity: sha512-aTWT++wNI2gux8EwA+nSZgiaU6tM7Rh+DVnumLCpJF3z44ujTs0ipFTbnktt0pVOtkbN7G7oyTrZUXUMQgjthA==, tarball: file:projects/util-internal-archive-client.tgz}
     name: '@rush-temp/util-internal-archive-client'
     version: 0.0.0
     dependencies:

--- a/graphql/openreader/src/dialect/opencrud/where.ts
+++ b/graphql/openreader/src/dialect/opencrud/where.ts
@@ -125,5 +125,5 @@ const WHERE_KEY_REGEX = (() => {
         "in",
         "not_in",
     ]
-    return new RegExp(`^([^_]*)_(${ops.join('|')})$`)
+    return new RegExp(`^(.*)_(${ops.join('|')})$`)
 })()

--- a/graphql/openreader/src/model.tools.ts
+++ b/graphql/openreader/src/model.tools.ts
@@ -137,8 +137,8 @@ export function validateModel(model: Model) {
 }
 
 
-const TYPE_NAME_REGEX = /^[A-Z][a-zA-Z0-9]*$/
-const PROP_NAME_REGEX = /^[a-z][a-zA-Z0-9]*$/
+const TYPE_NAME_REGEX = /^[A-Z][a-zA-Z0-9_]*$/
+const PROP_NAME_REGEX = /^[a-z][a-zA-Z0-9_]*$/
 
 
 export function validateNames(model: Model) {

--- a/rush.json
+++ b/rush.json
@@ -420,6 +420,12 @@
     //   // "versionPolicyName": ""
     // },
     {
+      "packageName": "@subsquid/bch-processor",
+      "projectFolder": "bch/bch-processor",
+      "shouldPublish": true,
+      "versionPolicyName": "npm"
+    },
+    {
       "packageName": "@subsquid/evm-processor",
       "projectFolder": "evm/evm-processor",
       "shouldPublish": true,

--- a/typeorm/typeorm-codegen/src/codegen.ts
+++ b/typeorm/typeorm-codegen/src/codegen.ts
@@ -32,7 +32,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
     dir.add('marshal.ts', path.resolve(__dirname, '../src/marshal.ts'))
 
     function generateEntity(name: string, entity: Entity): void {
-        index.line(`export * from "./${toCamelCase(name)}.model"`)
+        index.line(`export * from "./${toCamelCase(name)}.model.js"`)
         const out = dir.file(`${toCamelCase(name)}.model.ts`)
         const imports = new ImportRegistry(name)
         imports.useTypeormStore('Entity', 'Column', 'PrimaryColumn')
@@ -80,7 +80,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                             imports.useTypeormStore('OneToOne', 'Index', 'JoinColumn')
                             out.line(`@Index_({unique: true})`)
                             out.line(
-                                `@OneToOne_(() => ${prop.type.entity}, {nullable: true})`
+                                `@OneToOne_('${prop.type.entity}', {nullable: true})`
                             )
                             out.line(`@JoinColumn_()`)
                         } else {
@@ -90,20 +90,20 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                             }
                             // Make foreign entity references always nullable
                             out.line(
-                                `@ManyToOne_(() => ${prop.type.entity}, {nullable: true})`
+                                `@ManyToOne_('${prop.type.entity}', {nullable: true})`
                             )
                         }
                         break
                     case 'lookup':
                         imports.useTypeormStore('OneToOne')
                         out.line(
-                            `@OneToOne_(() => ${prop.type.entity}, e => e.${prop.type.field})`
+                            `@OneToOne_('${prop.type.entity}', '${prop.type.field}')`
                         )
                         break
                     case 'list-lookup':
                         imports.useTypeormStore('OneToMany')
                         out.line(
-                            `@OneToMany_(() => ${prop.type.entity}, e => e.${prop.type.field})`
+                            `@OneToMany_('${prop.type.entity}', '${prop.type.field}')`
                         )
                         break
                     case 'object':
@@ -196,7 +196,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
     }
 
     function generateObject(name: string, object: JsonObject): void {
-        index.line(`export * from "./_${toCamelCase(name)}"`)
+        index.line(`export * from "./_${toCamelCase(name)}.js"`)
         const out = dir.file(`_${toCamelCase(name)}.ts`)
         const imports = new ImportRegistry(name)
         imports.useMarshal()
@@ -352,7 +352,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
     }
 
     function generateUnion(name: string, union: Union): void {
-        index.line(`export * from "./_${toCamelCase(name)}"`)
+        index.line(`export * from "./_${toCamelCase(name)}.js"`)
         const out = dir.file(`_${toCamelCase(name)}.ts`)
         const imports = new ImportRegistry(name)
         out.lazy(() => imports.render(model, out))
@@ -374,7 +374,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
     }
 
     function generateEnum(name: string, e: Enum): void {
-        index.line(`export * from "./_${toCamelCase(name)}"`)
+        index.line(`export * from "./_${toCamelCase(name)}.js"`)
         const out = dir.file(`_${toCamelCase(name)}.ts`)
         out.block(`export enum ${name}`, () => {
             for (const val in e.values) {
@@ -552,13 +552,13 @@ class ImportRegistry {
             out.line(`import {${importList.join(', ')}} from "@subsquid/typeorm-store"`)
         }
         if (this.marshal) {
-            out.line(`import * as marshal from "./marshal"`)
+            out.line(`import * as marshal from "./marshal.js"`)
         }
         for (const name of this.model) {
             switch(model[name].kind) {
                 case 'entity':
                     out.line(
-                        `import {${name}} from "./${toCamelCase(name)}.model"`
+                        `import {type ${name}} from "./${toCamelCase(name)}.model.js"`
                     )
                     break
                 default: {
@@ -567,7 +567,7 @@ class ImportRegistry {
                         names.push('fromJson' + name)
                     }
                     out.line(
-                        `import {${names.join(', ')}} from "./_${toCamelCase(name)}"`
+                        `import {type ${names.join(', ')}} from "./_${toCamelCase(name)}.js"`
                     )
                 }
             }

--- a/typeorm/typeorm-codegen/src/main.ts
+++ b/typeorm/typeorm-codegen/src/main.ts
@@ -28,7 +28,7 @@ and db migrations (if any) at db/migrations.
     generateOrmModels(model, generatedOrm)
     if (!fs.existsSync(orm.path('index.ts'))) {
         let index = orm.file('index.ts')
-        index.line(`export * from "./generated"`)
+        index.line(`export * from "./generated/index.js"`)
         index.write()
     }
 

--- a/typeorm/typeorm-config/src/config.ts
+++ b/typeorm/typeorm-config/src/config.ts
@@ -24,7 +24,7 @@ export function createOrmConfig(options?: OrmOptions): OrmConfig {
     let migrationsDir = path.join(dir, MIGRATIONS_DIR)
     let locations = {
         entities: [model],
-        migrations: [migrationsDir + '/*.js']
+        migrations: [migrationsDir + '/*.?(?)js']
     }
     log.debug(locations, 'typeorm locations')
     return  {

--- a/typeorm/typeorm-migration/src/create.ts
+++ b/typeorm/typeorm-migration/src/create.ts
@@ -3,16 +3,17 @@ import {runProgram} from "@subsquid/util-internal"
 import {OutDir} from "@subsquid/util-internal-code-printer"
 import {program} from "commander"
 
-
 runProgram(async () => {
     program.description('Create template file for a new migration')
     program.option('--name', 'name suffix for new migration', 'Data')
+    program.option('--esm', 'generate esm module', false)
 
     let {name} = program.parse().opts() as {name: string}
+    let {esm} = program.parse().opts() as {esm: boolean}
 
     let dir = new OutDir(MIGRATIONS_DIR)
     let timestamp = Date.now()
-    let out = dir.file(`${timestamp}-${name}.js`)
+    let out = dir.file(`${timestamp}-${name}.${!esm ? 'js' : 'cjs'}`)
     out.block(`module.exports = class ${name}${timestamp}`, () => {
         out.line(`name = '${name}${timestamp}'`)
         out.line()

--- a/typeorm/typeorm-migration/src/generate.ts
+++ b/typeorm/typeorm-migration/src/generate.ts
@@ -12,8 +12,10 @@ import {SqlInMemory} from "typeorm/driver/SqlInMemory"
 runProgram(async () => {
     program.description('Analyze the current database state and generate migration to match the target schema')
     program.option('-n, --name <name>', 'name suffix for new migration', 'Data')
+    program.option('--esm', 'generate esm module', false)
 
     let {name} = program.parse().opts() as {name: string}
+    let {esm} = program.parse().opts() as {esm: boolean}
 
     dotenv.config()
 
@@ -43,7 +45,7 @@ runProgram(async () => {
 
     let dir = new OutDir(MIGRATIONS_DIR)
     let timestamp = Date.now()
-    let out = dir.file(`${timestamp}-${name}.js`)
+    let out = dir.file(`${timestamp}-${name}.${!esm ? 'js' : 'cjs'}`)
     out.block(`module.exports = class ${name}${timestamp}`, () => {
         out.line(`name = '${name}${timestamp}'`)
         out.line()

--- a/util/util-internal-processor-tools/src/database.ts
+++ b/util/util-internal-processor-tools/src/database.ts
@@ -16,6 +16,8 @@ export interface FinalDatabase<S> {
     supportsHotBlocks?: false
     connect(): Promise<HashAndHeight>
     transact(info: FinalTxInfo, cb: (store: S) => Promise<void>): Promise<void>
+    transactMempool(cb: (store: S) => Promise<void>): Promise<void>
+    clearMempool(): Promise<void>
 }
 
 
@@ -39,6 +41,9 @@ export interface HotDatabase<S> {
         info: HotTxInfo,
         cb: (store: S, blockSliceStart: number, blockSliceEnd: number) => Promise<void>
     ): Promise<void>
+
+    transactMempool(cb: (store: S) => Promise<void>): Promise<void>
+    clearMempool(): Promise<void>
 }
 
 

--- a/util/util-internal-processor-tools/src/datasource.ts
+++ b/util/util-internal-processor-tools/src/datasource.ts
@@ -17,6 +17,7 @@ export interface Block {
 export interface Batch<B> {
     blocks: B[]
     isHead: boolean
+    mempoolTransactions?: any[]
 }
 
 
@@ -24,6 +25,7 @@ export interface HotUpdate<B> {
     blocks: B[]
     baseHead: HashAndHeight
     finalizedHead: HashAndHeight
+    mempoolTransactions?: any[]
 }
 
 
@@ -40,4 +42,10 @@ export interface HotDataSource<B, R> extends DataSource<B, R> {
         state: HotDatabaseState,
         cb: (upd: HotUpdate<B>) => Promise<void>
     ): Promise<void>
+
+    processMempool?(
+        requests: RangeRequestList<R>,
+        state: HotDatabaseState,
+        cb: (upd: HotUpdate<B>) => Promise<void>
+    ): Promise<() => Promise<void>>
 }


### PR DESCRIPTION
This PR adds support for BCH blockchain. Its distinct feature is the 0-confirmation of transactions, which means that all transactions included into mempool in-between 10-minute blocks are contributing to the real-time final state of the blockchain.

The mempool tracking and rollback was added to [database](https://github.com/subsquid/squid-sdk/compare/master...mainnet-pat:squid-sdk:bch?expand=1#diff-5a1b0b4211d0a414f3da58dcc7e37b0a221a4b02f62a1e65b4a3e118971ef9b8). In this implementation I treat mempool transactions to be those included in a special hot block with height -2. Mempool tracking kicks-in as soon as hot datasource reaches the blockchain tip ([util/util-internal-processor-tools/src/datasource.ts](https://github.com/subsquid/squid-sdk/compare/master...mainnet-pat:squid-sdk:bch?expand=1#diff-746ac81c4b5bdd458f8b502493560d0af014f2c91a519ccaff6fae5abdb1cb81)). Upon new block arrival we roll back the mempool hot block and reapplying the confirmed transactions again in context of new block. The `Runner` now has an optional `watchMempool` optional to steer this new behaviour.

The newly added `bch-processor` project requires ESM support, so I have updated `typeorm-codegen` to output code compatible both with CJS and ESM targets. Also I have updated `typeorm-migration` to optionally output (steered with `--esm true` option) ESM compatible migration scripts.

The new `bch-processor` was developed on the base of EVM batch processor and mimics its behaviour at large extent. Currently there is no cold ingest possible from squid gateways, so all blocks are ingested from RPC, which makes the squid sync sluggish. Current RPC implementation is based on requests made both to ElectrumX indexing servers (blockchain tip, historical transactions) and from BCH's P2P network layer (raw blocks, raw mempool, mempool notifications).

A sample squid to index BCH native tokens was deployed to demonstrate the new BCH processor at http://squid.pat.mn (self-hosted) and on [SQD cloud platform](https://cced577b-b15c-425c-9701-c88b6d0c47ef.squids.live/bch-cashtokens@v1/api/graphql). Its source code is available at https://github.com/mainnet-pat/bch-cashtokens-subsquid


Looking for your feedback and eager to contribute to enable the BCH Gateway/Portal support.