### PR TITLE
Fix for SVM polling crashes

### DIFF
--- a/solana/solana-rpc/src/ingest/poll.ts
+++ b/solana/solana-rpc/src/ingest/poll.ts
@@ -116,7 +116,7 @@ export class PollStream {
                 if (i < missing.length) {
                     this.blocks[missing[i]] = [slots[i], true]
                 }
-            } else if (missing.length >= i) {
+            } else if (missing.length <= i) {
                 this.blocks.push([slots[i], false])
             }
         }


### PR DESCRIPTION
Squids indexing Soon Mainnet, an SVM chain, are crashing with
```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

                                     (0, assert_1.default)(prevSlot == null || prevSlot < block[0])

                                       at PollStream.checkChain (/home/abernatskiy/soon-nft-sale-index/node_modules/@subsquid/solana-rpc/lib/ingest/poll.js:127:38)
                                       at PollStream.trimInvalidTail (/home/abernatskiy/soon-nft-sale-index/node_modules/@subsquid/solana-rpc/lib/ingest/poll.js:110:24)
                                       at PollStream.next (/home/abernatskiy/soon-nft-sale-index/node_modules/@subsquid/solana-rpc/lib/ingest/poll.js:42:18)
                                       at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
                                       at async ColdIngest.serialFetch (/home/abernatskiy/soon-nft-sale-index/node_modules/@subsquid/solana-rpc/lib/ingest/cold.js:116:26)
                                       at async ColdIngest.jobs (/home/abernatskiy/soon-nft-sale-index/node_modules/@subsquid/solana-rpc/lib/ingest/cold.js:98:21)
                                       at async map (/home/abernatskiy/soon-nft-sale-index/node_modules/@subsquid/solana-rpc/node_modules/@subsquid/util-internal/lib/async.js:169:24)
                                       generatedMessage: true
                                       code: ERR_ASSERTION
                                       actual: false
                                       expected: true
                                       operator: ==
```