### PR TITLE
solana: add HashMap and HashSet types support

### DIFF
--- a/common/changes/@subsquid/borsh/borsh-hashmap_2025-01-15-14-29.json
+++ b/common/changes/@subsquid/borsh/borsh-hashmap_2025-01-15-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/borsh",
+      "comment": "implement HashMap and HashSet codecs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/borsh"
+}

--- a/common/changes/@subsquid/solana-typegen/borsh-hashmap_2025-01-15-14-29.json
+++ b/common/changes/@subsquid/solana-typegen/borsh-hashmap_2025-01-15-14-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/solana-typegen",
+      "comment": "add HashMap and HashSet types support",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/solana-typegen"
+}

--- a/solana/borsh/src/codecs/hash-map.ts
+++ b/solana/borsh/src/codecs/hash-map.ts
@@ -1,0 +1,27 @@
+import {Codec} from '../codec'
+import {Sink} from '../sink'
+import {Src} from '../src'
+
+
+export class HashMapCodec<K, V> implements Codec<Map<K, V>> {
+    constructor(public readonly key: Codec<K>, public readonly value: Codec<V>) {}
+
+    encode(sink: Sink, val: Map<K, V>): void {
+        sink.u32(val.size)
+        for (let [key, value] of val) {
+            this.key.encode(sink, key)
+            this.value.encode(sink, value)
+        }
+    }
+
+    decode(src: Src): Map<K, V> {
+        let len = src.u32()
+        let res = new Map<K, V>()
+        for (let i = 0; i < len; i++) {
+            let key = this.key.decode(src)
+            let value = this.value.decode(src)
+            res.set(key, value)
+        }
+        return res
+    }
+}

--- a/solana/borsh/src/codecs/hash-set.ts
+++ b/solana/borsh/src/codecs/hash-set.ts
@@ -1,0 +1,25 @@
+import {Codec} from '../codec'
+import {Sink} from '../sink'
+import {Src} from '../src'
+
+
+export class HashSetCodec<T> implements Codec<Set<T>> {
+    constructor(public readonly item: Codec<T>) {}
+
+    encode(sink: Sink, val: Set<T>): void {
+        sink.u32(val.size)
+        for (let value of val) {
+            this.item.encode(sink, value)
+        }
+    }
+
+    decode(src: Src): Set<T> {
+        let len = src.u32()
+        let res = new Set<T>()
+        for (let i = 0; i < len; i++) {
+            let value = this.item.decode(src)
+            res.add(value)
+        }
+        return res
+    }
+}

--- a/solana/borsh/src/dsl.ts
+++ b/solana/borsh/src/dsl.ts
@@ -1,6 +1,8 @@
 import {Codec, GetCodecType} from './codec'
 import {ArrayCodec, FixedArrayCodec} from './codecs/array'
 import {SumCodec, Variant} from './codecs/enum'
+import {HashMapCodec} from './codecs/hash-map'
+import {HashSetCodec} from './codecs/hash-set'
 import {OptionCodec} from './codecs/option'
 import {RefCodec} from './codecs/ref'
 import {GetStructType, StructCodec} from './codecs/struct'
@@ -29,6 +31,7 @@ export function struct<Props extends Record<string, Codec<any>>>(
     return new StructCodec(props as any)
 }
 
+
 export function tuple(tuple: []): TupleCodec<[]>
 export function tuple<T>(tuple: [T]): TupleCodec<GetTupleType<[T]>>
 export function tuple<T1, T2>(tuple: [T1, T2]): TupleCodec<GetTupleType<[T1, T2]>>
@@ -42,6 +45,17 @@ export function tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(tuple: [T1, T2, T3, T4
 export function tuple<T extends any[]>(tuple: T): TupleCodec<T> {
     return new TupleCodec(tuple as any)
 }
+
+
+export function hashMap<KC extends Codec<any>, VC extends Codec<any>>(key: KC, value: VC): HashMapCodec<GetCodecType<KC>, GetCodecType<VC>> {
+    return new HashMapCodec(key, value)
+}
+
+
+export function hashSet<IC extends Codec<any>>(item: IC): HashSetCodec<GetCodecType<IC>> {
+    return new HashSetCodec(item)
+}
+
 
 export function option<IC extends Codec<any>>(item: IC): OptionCodec<GetCodecType<IC>> {
     return new OptionCodec(item)

--- a/solana/solana-typegen/src/program/anchor/old.spec.ts
+++ b/solana/solana-typegen/src/program/anchor/old.spec.ts
@@ -149,6 +149,8 @@ export type IdlType =
     | IdlTypeCOption
     | IdlTypeVec
     | IdlTypeArray
+    | IdlTypeHashMap
+    | IdlTypeHashSet
 
 export type IdlTypeDefined = {
     defined: string
@@ -169,6 +171,14 @@ export type IdlTypeVec = {
 
 export type IdlTypeArray = {
     array: [idlType: IdlType, size: number]
+}
+
+export type IdlTypeHashMap = {
+    hashMap: [idlType: IdlType, idlType: IdlType]
+}
+
+export type IdlTypeHashSet = {
+    hashSet: IdlType
 }
 
 export type IdlEnumVariant = {
@@ -354,6 +364,17 @@ function fromType(type: IdlType): Type {
         return {
             kind: TypeKind.Array,
             type: fromType(type.vec),
+        }
+    } else if ('hashMap' in type) {
+        return {
+            kind: TypeKind.HashMap,
+            key: fromType(type.hashMap[0]),
+            value: fromType(type.hashMap[1]),
+        }
+    } else if ('hashSet' in type) {
+        return {
+            kind: TypeKind.HashSet,
+            type: fromType(type.hashSet),
         }
     } else if ('defined' in type) {
         return {

--- a/solana/solana-typegen/src/program/anchor/v0.spec.ts
+++ b/solana/solana-typegen/src/program/anchor/v0.spec.ts
@@ -238,6 +238,8 @@ export type IdlType =
     | IdlTypeCOption
     | IdlTypeVec
     | IdlTypeArray
+    | IdlTypeHashMap
+    | IdlTypeHashSet
     | IdlTypeDefined
     | IdlTypeGeneric
 
@@ -256,6 +258,14 @@ export type IdlTypeVec = {
 
 export type IdlTypeArray = {
     array: [idlType: IdlType, size: IdlArrayLen]
+}
+
+export type IdlTypeHashMap = {
+    hashMap: [idlType: IdlType, idlType: IdlType]
+}
+
+export type IdlTypeHashSet = {
+    hashSet: IdlType
 }
 
 export type IdlTypeDefined = {
@@ -394,6 +404,17 @@ function fromType(type: IdlType): Type {
         return {
             kind: TypeKind.Array,
             type: fromType(type.vec),
+        }
+    } else if ('hashMap' in type) {
+        return {
+            kind: TypeKind.HashMap,
+            key: fromType(type.hashMap[0]),
+            value: fromType(type.hashMap[1]),
+        }
+    } else if ('hashSet' in type) {
+        return {
+            kind: TypeKind.HashSet,
+            type: fromType(type.hashSet),
         }
     } else if ('defined' in type) {
         return {

--- a/solana/solana-typegen/src/program/types.ts
+++ b/solana/solana-typegen/src/program/types.ts
@@ -29,6 +29,8 @@ export enum TypeKind {
     Struct,
     Defined,
     Generic,
+    HashMap,
+    HashSet
 }
 
 export interface PrimitiveType {
@@ -50,6 +52,17 @@ export interface FixedArrayType {
 export interface TupleType {
     kind: TypeKind.Tuple
     tuple: Type[]
+}
+
+export interface HashMapType {
+    kind: TypeKind.HashMap
+    key: Type
+    value: Type
+}
+
+export interface HashSetType {
+    kind: TypeKind.HashSet
+    type: Type
 }
 
 export interface StructType {
@@ -114,6 +127,8 @@ export type Type =
     | ArrayType
     | FixedArrayType
     | TupleType
+    | HashMapType
+    | HashSetType
     | StructType
     | EnumType
     | OptionType

--- a/solana/solana-typegen/src/typegen.ts
+++ b/solana/solana-typegen/src/typegen.ts
@@ -222,6 +222,19 @@ export class TypeModuleOutput extends FileOutput {
                 })
                 this.line(`])` + end)
                 break
+            case TypeKind.HashMap:
+                this.borsh.add('hashMap')
+                this.line(start + `hashMap(`)
+                this.indentation(() => {
+                    this.printDsl(``, {type: type.key}, ',')
+                    this.printDsl(``, {type: type.value}, '')
+                })
+                this.line(`)` + end)
+                break
+            case TypeKind.HashSet:
+                this.borsh.add('hashSet')
+                this.printDsl(start + `hashSet(`, {type: type.type}, `)` + end)
+                break
             case TypeKind.Defined:
                 const typeName = toTypeName(type.name)
                 this.types.add(typeName)
@@ -286,6 +299,17 @@ export class TypeModuleOutput extends FileOutput {
                     }
                 })
                 this.line(`]` + end)
+                break
+            case TypeKind.HashMap:
+                this.line(start + `Map<`)
+                this.indentation(() => {
+                    this.printType(``, {type: type.key}, `,`)
+                    this.printType(``, {type: type.value}, ``)
+                })
+                this.line(`>` + end)
+                break
+            case TypeKind.HashSet:
+                this.printType(start + `Set<`, {type: type.type}, `>` + end)
                 break
             case TypeKind.Defined:
                 this.types.add(toTypeName(type.name))


### PR DESCRIPTION
According to borsh spec, hashMap and hashSet values have to be key ordered. However, borsh-js implememtation doesn't follow this. So I think that to simplify, we can omit it as well.

https://github.com/near/borsh-js/blob/63ad2a30f5d682e9bc8ae923446ff584f4b93f69/borsh-ts/serialize.ts#L156
https://github.com/near/borsh-js/blob/63ad2a30f5d682e9bc8ae923446ff584f4b93f69/borsh-ts/serialize.ts#L171