### PR TITLE
fix: handle missing invoke message for CallDepth error

### DIFF
--- a/solana/solana-normalization/src/mapping.ts
+++ b/solana/solana-normalization/src/mapping.ts
@@ -350,6 +350,9 @@ class InstructionParser {
         return this.logLessTraversal(parentStackHeight, instructions, pos, (ins, pos) => {
             ins.hasDroppedLogMessages = ins.hasDroppedLogMessages || messagesDropped
             if (PROGRAMS_MISSING_INVOKE_LOG.has(ins.programId)) {
+            } else if (this.tx.err &&
+                'InstructionError' in this.tx.err &&
+                (this.tx.err.InstructionError as [number, string])[1] === 'CallDepth') {
             } else {
                 throw this.error(false, pos, 'invoke message is missing')
             }


### PR DESCRIPTION
When processing transactions that fail with "Cross-program invocation call depth too deep" error, the indexer currently throws a "invoke message is missing" error and stops processing. This is because when a transaction fails due to exceeding the call depth limit, it cannot generate complete invoke messages.

Error tx:
https://solscan.io/tx/3twrVLHMYc6v7yFAZLTGmrQ2J1tb6JcAx7Ss821pEKkeGzpBTSTg9UXbGu9Empqbffw375sKpEF6XiEomkXKXPxh

Block range:
```setBlockRange({from: 297875748, to: 297875753})```

Error message:
```
Error: Failed to process transaction 3twrVLHMYc6v7yFAZLTGmrQ2J1tb6JcAx7Ss821pEKkeGzpBTSTg9UXbGu9Empqbffw375sKpEF6XiEomkXKXPxh: stopped at instruction 3, inner instruction 4): invoke message is missing
                                       at <anonymous> (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:282:26)
                                       at logLessTraversal (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:292:17)
                                       at invokeInstruction (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:214:32)
                                       at invokeInstruction (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:214:32)
                                       at invokeInstruction (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:214:32)
                                       at invokeInstruction (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:214:32)
                                       at parse (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:139:32)
                                       at mapRpcTransaction (/Users/paco/workspace/squid/node_modules/@subsquid/solana-normalization/lib/mapping.js:88:125)
                                       blockTransaction: 3twrVLHMYc6v7yFAZLTGmrQ2J1tb6JcAx7Ss821pEKkeGzpBTSTg9UXbGu9Empqbffw375sKpEF6XiEomkXKXPxh
```