### PR TITLE
Typos fix

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, caste, color, religion, or sexual
 identity and orientation.
 

--- a/substrate/ink-typegen/README.md
+++ b/substrate/ink-typegen/README.md
@@ -23,7 +23,7 @@ squid-ink-typegen --abi erc20.json --output src/erc20.ts
 ```
 
 ### Decoding
-Generated fuctions allow to decode [scale](https://docs.substrate.io/reference/scale-codec/)-encoded data for 3 different kind of ink! objects:
+Generated functions allow to decode [scale](https://docs.substrate.io/reference/scale-codec/)-encoded data for 3 different kind of ink! objects:
 * `constructor` - it's arguments that the contract receives on instantiation
 * `message` - it's arguments that the contract receives on call execution
 * `event` - it's data that the contract emittes on call execution

--- a/substrate/scale-type-system/CHANGELOG.md
+++ b/substrate/scale-type-system/CHANGELOG.md
@@ -22,7 +22,7 @@ Thu, 28 Sep 2023 20:58:19 GMT
 ### Breaking changes
 
 - change `tuple()` signature from `tuple(...types: Type[])` to `tuple(types: Type[])`
-- update bit sequence presentaion
+- update bit sequence presentation
 
 ### Minor changes
 

--- a/substrate/substrate-processor/CHANGELOG.md
+++ b/substrate/substrate-processor/CHANGELOG.md
@@ -256,7 +256,7 @@ Wed, 30 Nov 2022 19:36:06 GMT
 
 ### Minor changes
 
-- new `ctx._chain` functions for quering storage
+- new `ctx._chain` functions for querying storage
 
 ### Patches
 


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /CODE_OF_CONDUCT.md (Line 9)

"socio-economic" → "socioeconomic"

Corrected typo in /substrate/ink-typegen/README.md (Line 26)

"fuctions" → "functions"

Corrected typo in /substrate/substrate-processor/CHANGELOG.md (Line 259)

"quering" → "querying"

Corrected typo in /substrate/scale-type-system/CHANGELOG.md (Line 25)

"presentaion" → "presentation"

**Purpose**

Improved code accuracy and professionalism by fixing typos.