### PR TITLE
fix(evm-typegen): migrate etherscan endpoint to v2

### DIFF
--- a/common/changes/@subsquid/evm-typegen/fix-etherscan-evm-typegen-endpoint_2025-10-03-14-00.json
+++ b/common/changes/@subsquid/evm-typegen/fix-etherscan-evm-typegen-endpoint_2025-10-03-14-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-typegen",
+      "comment": "migrate etherscan endpoint to v2",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-typegen"
+}


### PR DESCRIPTION
Etherscan API `/v1` was deprecated, and endpoints were throwing an error. Migrating to `/v2` fixes the issue.

Also added the `--chain-id` option, that is required in `/v2`, which defaults to Ethereum mainnet (1)