### PR TITLE
retry solana blocks if amount of transactions is suspicious

### DIFF
--- a/solana/solana-dump/src/dumper.ts
+++ b/solana/solana-dump/src/dumper.ts
@@ -17,6 +17,7 @@ interface Options extends DumperOptions {
     maxConfirmationAttempts: number
     assertLogMessagesNotNull: boolean
     validateChainContinuity: boolean
+    txThreshold?: number
 }
 
 
@@ -31,6 +32,7 @@ export class SolanaDumper extends Dumper<Block, Options> {
         program.option('--max-confirmation-attempts <N>', 'Maximum number of confirmation attempts', positiveInt, 10)
         program.option('--assert-log-messages-not-null', 'Check if tx.meta.logMessages is not null', false)
         program.option('--validate-chain-continuity', 'Check if block parent hash matches previous block hash', false)
+        program.option('--tx-threshold <N>', 'Retry getBlock call if transactions count is less than threshold')
     }
 
     protected fixUnsafeIntegers(): boolean {
@@ -69,7 +71,8 @@ export class SolanaDumper extends Dumper<Block, Options> {
             url: options.endpoint,
             capacity: Number.MAX_SAFE_INTEGER,
             retryAttempts: Number.MAX_SAFE_INTEGER,
-            requestTimeout: 30_000
+            requestTimeout: 30_000,
+            txThreshold: options.txThreshold,
         })
 
         return new SolanaRpcDataSource({

--- a/solana/solana-rpc/src/rpc-remote.ts
+++ b/solana/solana-rpc/src/rpc-remote.ts
@@ -18,6 +18,7 @@ export type RemoteRpcOptions = Pick<
      * Remove vote transactions from all relevant responses
      */
     noVotes?: boolean
+    txThreshold?: number
 }
 
 

--- a/solana/solana-rpc/src/rpc-worker.ts
+++ b/solana/solana-rpc/src/rpc-worker.ts
@@ -5,12 +5,12 @@ import {Commitment, GetBlockOptions, Rpc} from './rpc'
 import type {RemoteRpcOptions} from './rpc-remote'
 
 
-const {noVotes, ...rpcOptions} = getServerArguments<RemoteRpcOptions>()
+const {noVotes, txThreshold, ...rpcOptions} = getServerArguments<RemoteRpcOptions>()
 
 const rpc = new Rpc(new RpcClient({
     ...rpcOptions,
     fixUnsafeIntegers: true
-}))
+}), txThreshold)
 
 
 getServer()


### PR DESCRIPTION
this change supposed to retry `getBlock` request if amount of transactions is suspiciously small