### PR TITLE
Add a CLI option --use-gas-used-for-receipts-root

### DIFF
--- a/evm/evm-data-service/src/data-source/setup.ts
+++ b/evm/evm-data-service/src/data-source/setup.ts
@@ -26,6 +26,7 @@ export interface DataSourceOptions {
     verifyTxRoot?: boolean
     verifyReceiptsRoot?: boolean
     verifyLogsBloom?: boolean
+    useGasUsedForReceiptsRoot?: boolean
 }
 
 
@@ -46,7 +47,8 @@ export function createDataSource(options: DataSourceOptions): DataSource<Block> 
         verifyTxRoot: options.verifyTxRoot,
         verifyTxSender: options.verifyTxSender,
         verifyReceiptsRoot: options.verifyReceiptsRoot,
-        verifyLogsBloom: options.verifyLogsBloom
+        verifyLogsBloom: options.verifyLogsBloom,
+        useGasUsedForReceiptsRoot: options.useGasUsedForReceiptsRoot
     })
     let rpcSource = new EvmRpcDataSource({
         rpc: httpRpc,

--- a/evm/evm-data-service/src/main.ts
+++ b/evm/evm-data-service/src/main.ts
@@ -34,6 +34,7 @@ runProgram(async () => {
     program.option('--verify-tx-root', 'Verify block transactions against transactions root')
     program.option('--verify-receipts-root', 'Verify block receipts against receipts root')
     program.option('--verify-logs-bloom', 'Verify block logs against logs bloom')
+    program.option('--use-gas-used-for-receipts-root', 'Use gasUsed instead of cumulativeGasUsed for receipts root calculation')
     program.parse()
 
     let args = program.opts() as {
@@ -56,6 +57,7 @@ runProgram(async () => {
         verifyTxRoot?: boolean
         verifyReceiptsRoot?: boolean
         verifyLogsBloom?: boolean
+        useGasUsedForReceiptsRoot?: boolean
     }
 
     let dataSourceOptions: DataSourceOptions = {
@@ -75,7 +77,8 @@ runProgram(async () => {
         verifyTxSender: args.verifyTxSender,
         verifyTxRoot: args.verifyTxRoot,
         verifyReceiptsRoot: args.verifyReceiptsRoot,
-        verifyLogsBloom: args.verifyLogsBloom
+        verifyLogsBloom: args.verifyLogsBloom,
+        useGasUsedForReceiptsRoot: args.useGasUsedForReceiptsRoot
     }
 
     let mainWorker = new WorkerClient(dataSourceOptions)

--- a/evm/evm-dump/src/dumper.ts
+++ b/evm/evm-dump/src/dumper.ts
@@ -16,6 +16,7 @@ interface Options extends DumperOptions {
     verifyTxRoot?: boolean
     verifyReceiptsRoot?: boolean
     verifyLogsBloom?: boolean
+    useGasUsedForReceiptsRoot?: boolean
 }
 
 
@@ -33,6 +34,7 @@ export class EvmDumper extends Dumper<RawBlock, Options> {
         program.option('--verify-tx-root', 'Verify block transactions against transactions root')
         program.option('--verify-receipts-root', 'Verify block receipts against receipts root')
         program.option('--verify-logs-bloom', 'Verify block logs against logs bloom')
+        program.option('--use-gas-used-for-receipts-root', 'Use gasUsed instead of cumulativeGasUsed for receipts root calculation')
     }
 
     protected getLoggingNamespace(): string {
@@ -57,7 +59,8 @@ export class EvmDumper extends Dumper<RawBlock, Options> {
                 verifyTxSender: this.options().verifyTxSender,
                 verifyTxRoot: this.options().verifyTxRoot,
                 verifyReceiptsRoot: this.options().verifyReceiptsRoot,
-                verifyLogsBloom: this.options().verifyLogsBloom
+                verifyLogsBloom: this.options().verifyLogsBloom,
+                useGasUsedForReceiptsRoot: this.options().useGasUsedForReceiptsRoot,
             }),
             req: {
                 transactions: true,

--- a/evm/evm-rpc/src/chain-utils.ts
+++ b/evm/evm-rpc/src/chain-utils.ts
@@ -13,23 +13,28 @@ import {
 import {getTxHash} from './util'
 
 
+export interface ChainUtilsOptions {
+    useGasUsedForReceiptsRoot?: boolean
+}
+
+
 export class ChainUtils {
     public isPolygonMainnet: boolean
     public isHyperliquidMainnet: boolean
     public isHyperliquidTestnet: boolean
-    public isStable: boolean
     public isTempo: boolean
+    public useGasUsedForReceiptsRoot: boolean
 
-    constructor(chainId: Qty) {
+    constructor(chainId: Qty, options?: ChainUtilsOptions) {
         this.isPolygonMainnet = chainId == '0x89'
         this.isHyperliquidMainnet = chainId == '0x3e7'
         this.isHyperliquidTestnet = chainId == '0x3e6'
-        this.isStable = chainId == '0x3dc' || chainId == '0x899' // Chain ID 988 (mainnet) or 2201 (testnet)
         // Tempo mainnet (4217), Moderato testnet (42431), Andantino testnet (42429)
         // https://drpc.org/chainlist/tempo-mainnet-rpc
         // https://drpc.org/chainlist/tempo-moderato-testnet-rpc
         // https://drpc.org/chainlist/tempo-testnet-rpc
         this.isTempo = chainId == '0x1079' || chainId == '0xa5bf' || chainId == '0xa5bd'
+        this.useGasUsedForReceiptsRoot = options?.useGasUsedForReceiptsRoot ?? false
     }
 
     calculateBlockHash(block: GetBlock) {
@@ -99,8 +104,7 @@ export class ChainUtils {
             receipts = receipts.filter(receipt => !isHyperliquidSystemReceipt(receipt))
         }
 
-        // Stable chain uses gasUsed instead of cumulativeGasUsed in receipts root
-        if (this.isStable) {
+        if (this.useGasUsedForReceiptsRoot) {
             return receiptsRoot(receipts, {useGasUsed: true})
         }
 

--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -39,6 +39,7 @@ export interface RpcOptions {
     verifyTxRoot?: boolean
     verifyReceiptsRoot?: boolean
     verifyLogsBloom?: boolean
+    useGasUsedForReceiptsRoot?: boolean
 }
 
 
@@ -50,6 +51,7 @@ export class Rpc {
     private verifyTxRoot?: boolean
     private verifyReceiptsRoot?: boolean
     private verifyLogsBloom?: boolean
+    private useGasUsedForReceiptsRoot?: boolean
     private log: Logger
     private receiptsMethod?: GetReceiptsMethod
     private chainUtils?: ChainUtils
@@ -62,6 +64,7 @@ export class Rpc {
         this.verifyTxRoot = options.verifyTxRoot
         this.verifyReceiptsRoot = options.verifyReceiptsRoot
         this.verifyLogsBloom = options.verifyLogsBloom
+        this.useGasUsedForReceiptsRoot = options.useGasUsedForReceiptsRoot
         this.log = createLogger('sqd:evm-rpc')
     }
 
@@ -659,7 +662,9 @@ export class Rpc {
     private async getChainUtils(): Promise<ChainUtils> {
         if (this.chainUtils) return this.chainUtils
         let chainId: Qty = await this.call('eth_chainId')
-        return this.chainUtils = new ChainUtils(chainId)
+        return this.chainUtils = new ChainUtils(chainId, {
+            useGasUsedForReceiptsRoot: this.useGasUsedForReceiptsRoot
+        })
     }
 
     isRetryableError(err: any): boolean {

--- a/evm/evm-rpc/src/verification.ts
+++ b/evm/evm-rpc/src/verification.ts
@@ -552,8 +552,8 @@ function decodeLogs(logs: Log[]) {
 export interface ReceiptEncodingOptions {
     /**
      * Use gasUsed instead of cumulativeGasUsed when encoding receipts.
-     * This is needed for chains like Stable (chain ID 988) that deviate from
-     * the Ethereum standard by using per-transaction gas instead of cumulative.
+     * Some RPC providers (Cosmos EVM) deviate from the Ethereum standard by using
+     * per-transaction gas instead of cumulative.
      */
     useGasUsed?: boolean
 }
@@ -562,7 +562,6 @@ export interface ReceiptEncodingOptions {
 function encodeReceipt(receipt: Receipt, options?: ReceiptEncodingOptions): Buffer {
     let type = receipt.type == '0x0' ? Buffer.alloc(0) : RLP.encode(qty2Int(receipt.type))
     let payload: Uint8Array
-    // Use gasUsed instead of cumulativeGasUsed for certain chains (e.g., Stable)
     let gasField = options?.useGasUsed ? receipt.gasUsed : receipt.cumulativeGasUsed
     if (receipt.type == '0x7e') {
         // https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#deposit-receipt


### PR DESCRIPTION
It turned out not to be adherent to the Stable network. Something changed on Dwellir's side, and this fixed behaviour started to fail while the default one continued working correctly.