### PR TITLE
fix: Bitcoin ingest getBlockHeight/getBlockTimestamp

### DIFF
--- a/bitcoin/bitcoin-ingest/src/ingest.ts
+++ b/bitcoin/bitcoin-ingest/src/ingest.ts
@@ -1,4 +1,4 @@
-import { mapRpcBlock } from '@subsquid/bitcoin-normalization'
+import { mapRpcBlock, Block } from '@subsquid/bitcoin-normalization'
 import { addErrorContext } from '@subsquid/util-internal'
 import { Command, Ingest, Range } from '@subsquid/util-internal-ingest-cli'
 import { toJSON } from '@subsquid/util-internal-json'
@@ -38,11 +38,11 @@ export class BitcoinIngest extends Ingest {
         }
     }
 
-    protected getBlockHeight(block: BlockWithTx): number {
-        return block.height
+    protected getBlockHeight(block: Block): number {
+        return block.header.number
     }
 
-    protected getBlockTimestamp(block: BlockWithTx): number {
-        return block.time
+    protected getBlockTimestamp(block: Block): number {
+        return block.header.timestamp
     }
 }


### PR DESCRIPTION
Related issue:
```
{"level":4,"time":1771593360202,"ns":"sqd:bitcoin-ingest:service","err":{"stack":"TypeError: Value is not a valid number: undefined\n    at set (/squid/common/temp/node_modules/.pnpm/prom-client@14.2.0/node_modules/prom-client/lib/gauge.js:144:9)\n    at Gauge.set (/squid/common/temp/node_modules/.pnpm/prom-client@14.2.0/node_modules/prom-client/lib/gauge.js:30:3)\n    at PrometheusServer.setLastReceivedBlock (/squid/util/util-internal-ingest-cli/lib/prometheus.js:37:45)\n    at BitcoinIngest.ingest (/squid/util/util-internal-ingest-cli/lib/ingest.js:110:28)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Object.POST (/squid/util/util-internal-ingest-cli/lib/ingest.js:136:17)"}}
```