### PR TITLE
SRE acceptance criteria review for evm-dump + RPC error context

### DIFF
--- a/.agents/skills/product-acceptance-criteria/SKILL.md
+++ b/.agents/skills/product-acceptance-criteria/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: product-acceptance-criteria
+description: |
+  **SRE Product Acceptance Criteria for AI-generated code**: Review and enforce production-readiness standards on code that AI (or humans) produce. Covers structured logging, metrics exposure, health checks, graceful shutdown, retry/circuit-breaker patterns, and timeout policies. Use this skill whenever reviewing code for production readiness, writing acceptance criteria for a service, auditing observability of an existing codebase, or when the user says things like "is this production ready", "add logging", "add metrics", "review for SRE", "acceptance criteria", "observability", "production checklist". Trigger even if the user just asks to "review this service" or "make this ready for prod" — those are exactly the moments this skill should activate.
+---
+
+# Product Acceptance Criteria — SRE Checklist for AI-Generated Code
+
+You are reviewing code (or generating new code) that must meet production-readiness standards. Walk through each section below. For every criterion, either confirm the code already satisfies it, or produce the specific changes needed.
+
+When generating new code or reviewing existing code, apply ALL sections. When the user asks about a specific area (e.g., "just check metrics"), focus there but mention other gaps you notice.
+
+---
+
+## 1. Structured Logging
+
+Every log line must be machine-parseable (JSON or structured key-value). Human-readable "print" statements are not acceptable in production paths.
+
+### 1.1 Error Context Requirements
+
+Every error log MUST include enough context to reproduce or triage the issue without looking at other log lines. The goal: an on-call engineer reading a single log line at 3 AM should understand what happened, where, and what was involved.
+
+**For HTTP/API errors (outbound calls):**
+
+Required fields:
+- `method` — HTTP method (GET, POST, etc.)
+- `url` or `path` — the endpoint called (scrub sensitive query params)
+- `status_code` — the HTTP status returned
+- `duration_ms` — how long the call took
+- `request_id` or `correlation_id` — for tracing across services
+- `error_message` — the error description (truncate to reasonable length)
+- `service` — which downstream service was called
+
+**Example (good):**
+```json
+{
+  "level": "error",
+  "message": "downstream API call failed: POST /v1/charges returned 502",
+  "service": "payment-gateway",
+  "method": "POST",
+  "path": "/v1/charges",
+  "status_code": 502,
+  "duration_ms": 3200,
+  "request_id": "req_abc123",
+  "error": "Bad Gateway",
+  "retry_attempt": 2
+}
+```
+
+**Example (bad — don't do this):**
+```
+ERROR: API call failed
+```
+This tells the on-call engineer nothing. Which API? What failed? What was the status? How long did it take?
+
+**For database errors:**
+
+Required fields: `operation` (SELECT/INSERT/UPDATE/DELETE), `table` or `collection`, `duration_ms`, `error_message`. Never log the full query with user data — log the query template or operation type.
+
+**For S3 / object-storage errors:**
+
+Required fields: `operation` (GetObject, PutObject, etc.), `bucket`, `key` (if not sensitive), `duration_ms`, `error_message`, `status_code`.
+
+**For queue/message-broker errors:**
+
+Required fields: `operation` (publish/consume), `queue` or `topic`, `message_id` (if available), `error_message`.
+
+### 1.2 Log Levels
+
+Use log levels consistently:
+- `debug` — verbose development-time information, off in production by default
+- `info` — normal operational events (startup, shutdown, config loaded, request served)
+- `warn` — something unexpected that the system recovered from (retry succeeded, fallback used, deprecated feature called)
+- `error` — something failed that needs attention (request failed, downstream timeout, data inconsistency)
+
+Do not use `error` for expected conditions (e.g., 404 on a user-facing lookup is `warn` or `info`, not `error`).
+
+### 1.3 Sensitive Data
+
+Never log: passwords, tokens, API keys, credit card numbers, SSNs, or PII beyond what's needed for debugging. If you must log a user identifier, use an internal ID, not email/phone. Scrub Authorization headers — log their presence, not their value.
+
+---
+
+## 2. Metrics
+
+If the service does work, that work must be measured. Metrics exist so you can answer "is this service healthy?" from a dashboard without reading logs.
+
+### 2.1 External API / HTTP Client Metrics
+
+Any code that calls an external API (HTTP client, gRPC client, etc.) MUST expose request counters classified by outcome:
+
+**Classification scheme:**
+| Status Code Range | Label        | Meaning                        |
+|-------------------|--------------|--------------------------------|
+| 2xx–3xx           | `success`    | Request completed normally     |
+| 429               | `rate_limited` | Hit rate limit, should back off |
+| 4xx (except 429)  | `client_error` | Our request was bad            |
+| 5xx               | `server_error` | Downstream service failed      |
+| timeout / conn err| `network_error`| Never got a response           |
+
+**Required metrics for each external dependency:**
+
+1. **Request counter** — incremented on every call, labeled by:
+   - `service` (e.g., "payment-api", "user-service")
+   - `method` (GET, POST, etc.)
+   - `status_class` — one of the classification labels above
+
+2. **Request duration** (histogram or summary) — labeled by `service` and `method`, so you can track latency percentiles.
+
+**Example metric names** (adapt to your metrics system):
+```
+http_client_requests_total{service="payment-api", method="POST", status_class="success"}
+http_client_requests_total{service="payment-api", method="POST", status_class="rate_limited"}
+http_client_request_duration_seconds{service="payment-api", method="POST"}
+```
+
+### 2.2 S3 / Object Storage Metrics
+
+Any code that interacts with S3 (or compatible object storage) MUST expose:
+
+1. **Operation counter** — labeled by:
+   - `operation` (GetObject, PutObject, DeleteObject, ListObjects, etc.)
+   - `bucket`
+   - `status_class` (success / client_error / server_error / network_error — same scheme as above)
+
+2. **Operation duration** (histogram) — labeled by `operation` and `bucket`.
+
+3. **Bytes transferred** (counter, when applicable) — labeled by `operation` and `bucket`. Track upload and download sizes for capacity planning.
+
+**Example:**
+```
+s3_requests_total{operation="PutObject", bucket="user-uploads", status_class="success"}
+s3_request_duration_seconds{operation="PutObject", bucket="user-uploads"}
+s3_bytes_transferred_total{operation="PutObject", bucket="user-uploads"}
+```
+
+### 2.3 Database Metrics
+
+If the service queries a database, expose:
+- Query counter by `operation` (select/insert/update/delete) and `status` (success/error)
+- Query duration histogram by `operation`
+- Connection pool metrics (active, idle, waiting) if using a pool
+
+### 2.4 Queue / Message Broker Metrics
+
+If the service produces or consumes messages:
+- Messages published/consumed counter by `topic` and `status`
+- Processing duration histogram
+- Consumer lag (if applicable)
+
+### 2.5 Business Metrics
+
+Expose counters for key business events (user signups, orders placed, payments processed). These often matter more than infrastructure metrics for understanding service health in context.
+
+---
+
+## 3. Health Checks
+
+### 3.1 Liveness (`/healthz` or `/health/live`)
+
+Returns 200 if the process is running and not deadlocked. This should be cheap — no dependency checks. If this fails, the orchestrator should restart the process.
+
+### 3.2 Readiness (`/health/ready` or `/readyz`)
+
+Returns 200 only if the service can handle traffic. Checks that critical dependencies are reachable (database connected, required caches warm, etc.). If this fails, the load balancer should stop sending traffic but NOT restart the process — it might recover.
+
+### 3.3 Startup (`/health/startup`)
+
+For services with slow initialization (loading ML models, warming caches), expose a startup probe. Returns 503 until the service is fully initialized, then 200 forever after. This prevents premature liveness-check kills during startup.
+
+---
+
+## 4. Graceful Shutdown
+
+When the service receives SIGTERM:
+
+1. Stop accepting new requests (close listeners / deregister from service discovery)
+2. Finish in-flight requests (with a deadline — e.g., 30 seconds)
+3. Close connections to dependencies (DB pools, message consumers, HTTP clients)
+4. Flush buffered data (logs, metrics, traces)
+5. Exit with code 0
+
+If the deadline expires before in-flight work completes, force-exit. Log at `warn` level when force-exiting with the count of abandoned requests.
+
+The shutdown timeout should be configurable and shorter than the orchestrator's kill grace period (so the service gets a chance to clean up before SIGKILL).
+
+---
+
+## 5. Retry Policies
+
+### 5.1 When to Retry
+
+Retry only on transient failures:
+- 5xx responses (server errors — the downstream might recover)
+- 429 responses (rate limited — back off and try again)
+- Network errors (timeout, connection reset, DNS failure)
+
+Never retry on:
+- 4xx (except 429) — our request is wrong, retrying won't help
+- Non-idempotent operations without an idempotency key
+
+### 5.2 How to Retry
+
+- **Exponential backoff** with jitter. Fixed delays cause thundering herds. The jitter is not optional — without it, all instances retry at the same time after an outage.
+- **Max retries** — cap at 3-5 attempts. More than that and you're just adding latency.
+- **Total timeout** — bound the total time including all retries. A request that takes 60 seconds of retries is worse than a fast failure.
+- **Log each retry** at `warn` level with the attempt number and reason.
+- **Track retries in metrics** — increment a retry counter, and include `retry_attempt` as a label or field so you can see retry storms.
+
+### 5.3 Idempotency
+
+For non-idempotent operations (POST creating a resource, payment charges), either:
+- Use an idempotency key in the request header, or
+- Don't retry at all
+
+Document which operations are retried and which are not.
+
+---
+
+## 6. Circuit Breakers
+
+When a downstream dependency starts failing consistently, stop calling it. This prevents cascade failures and gives the downstream time to recover.
+
+### 6.1 Required Behavior
+
+- **Closed** (normal): requests flow through. Track failure rate.
+- **Open** (tripped): requests fail immediately without calling downstream. Return a degraded response or cached value if possible.
+- **Half-open** (probing): after a cooldown period, allow a small number of requests through. If they succeed, close the circuit. If they fail, re-open.
+
+### 6.2 Configuration
+
+These should be configurable (environment variables or config file):
+- Failure threshold to trip (e.g., 50% failure rate over 10 requests)
+- Cooldown period before half-open (e.g., 30 seconds)
+- Number of probe requests in half-open (e.g., 3)
+
+### 6.3 Observability
+
+- Expose circuit state as a metric (gauge: 0=closed, 1=half-open, 2=open)
+- Log state transitions at `warn` level (circuit opened, circuit closed)
+- When circuit is open, the fast-fail response should be distinguishable from a normal error in metrics (label: `circuit_open`)
+
+---
+
+## 7. Timeouts
+
+Every external call MUST have a timeout. "Hanging forever" is not an acceptable failure mode.
+
+### 7.1 Defaults
+
+- HTTP client calls: 5–30 seconds depending on the operation
+- Database queries: 5–15 seconds
+- S3 operations: 10–60 seconds depending on object size
+- Queue publish: 5 seconds
+- DNS resolution: 2 seconds (if configurable)
+
+### 7.2 Configuration
+
+Timeouts should be configurable per-dependency, not hardcoded. Use environment variables or a config file. Name them clearly (e.g., `PAYMENT_API_TIMEOUT_MS=5000`, not `TIMEOUT=5`).
+
+### 7.3 Timeout Hierarchy
+
+If a request handler has a total deadline (e.g., 30 seconds), individual downstream call timeouts must be shorter than the total. If you make 3 sequential calls with 30-second timeouts each, your handler can take 90 seconds — that's a bug.
+
+Use a request-scoped deadline that propagates to all downstream calls (e.g., Go's `context.Context`, or manually tracking remaining time).
+
+---
+
+## 8. Review Checklist (Summary)
+
+When reviewing code, walk through this list:
+
+- [ ] All error logs include context (see Section 1.1 for required fields per error type)
+- [ ] Log levels are used correctly (errors vs warnings vs info)
+- [ ] No sensitive data in logs
+- [ ] External API calls have request counters with status classification
+- [ ] External API calls have duration histograms
+- [ ] S3 operations have request counters, duration, and bytes metrics
+- [ ] Database operations have query counters and duration metrics
+- [ ] Liveness and readiness health checks exist
+- [ ] Graceful shutdown handles SIGTERM properly
+- [ ] Retry policy uses exponential backoff with jitter
+- [ ] Non-idempotent operations are not retried (or use idempotency keys)
+- [ ] Circuit breakers protect against cascade failures
+- [ ] Every external call has a configurable timeout
+- [ ] Timeout hierarchy is consistent (individual < total)
+
+---
+
+## Language-Specific Guidance
+
+For implementation patterns in specific languages, read the appropriate reference file:
+
+- **Python** (FastAPI, Flask, aiohttp, boto3): Read `references/python.md`
+- **Node.js** (Express, AWS SDK, axios/got): Read `references/nodejs.md`
+- **Rust** (axum, reqwest, aws-sdk-rust): Read `references/rust.md`
+
+These contain idiomatic code patterns, recommended libraries, and common pitfalls for each platform.

--- a/.claude/skills/product-acceptance-criteria
+++ b/.claude/skills/product-acceptance-criteria
@@ -1,0 +1,1 @@
+../../.agents/skills/product-acceptance-criteria

--- a/evm/evm-dump/PLAN.md
+++ b/evm/evm-dump/PLAN.md
@@ -1,0 +1,211 @@
+# PLAN.md — Remediation Plan for `evm-dump` SRE Acceptance Criteria
+
+Based on findings in `SRE_REPORT.md` (2026-02-28). Issues ordered by severity and risk.
+
+---
+
+## Phase 1: Critical — Data Integrity & Availability
+
+### 1.1 Graceful Shutdown (Score: 0/10)
+
+**Risk:** SIGTERM on Kubernetes causes immediate process death → corrupted/partial S3 objects, orphaned archive chunks.
+
+**Files to modify:**
+- `util/util-internal-dump-cli/src/dumper.ts` — add SIGTERM/SIGINT handler in `run()`
+- `util/util-internal-fs/src/s3.ts` — add `close()` method to drain pending S3 calls
+
+**Steps:**
+1. Add an `AbortController` to the base `Dumper` class, signalled on SIGTERM/SIGINT
+2. Pass the abort signal into the `ingest()` async generator loop to stop fetching new blocks
+3. After the loop exits, await all in-flight S3 `PutObject` calls (add a pending-writes counter in `S3Fs`)
+4. Close the Prometheus HTTP server via its existing `stoppable` wrapper
+5. Close the `RpcClient` (add a `close()` method that destroys the HTTP agent)
+6. Log `info` on clean shutdown, `warn` if force-exit deadline (30s configurable) is reached
+7. Exit with code 0 on clean shutdown
+
+**Reusable pattern:** `waitForInterruption()` in `util/util-internal-http-server/src/server.ts`
+
+### 1.2 Finite Retry Cap (Score: 4/10 — Retries)
+
+**Risk:** `retryAttempts: Number.MAX_SAFE_INTEGER` means a dead RPC endpoint hangs the dumper forever. No alert, no escalation.
+
+**Files to modify:**
+- `util/util-internal-dump-cli/src/dumper.ts` — change `retryAttempts` default, add CLI flag
+- `util/rpc-client/src/client.ts` — enforce max retries in `call()` / `batchCall()`
+
+**Steps:**
+1. Add `--max-retry-attempts <number>` CLI option (default: 50)
+2. Replace `retryAttempts: Number.MAX_SAFE_INTEGER` with the configurable value
+3. When retries exhausted, log at `error` level with structured context: `{ endpoint, method, totalAttempts, totalDuration_ms, lastError }`
+4. Exit with non-zero code on exhausted retries
+
+### 1.3 S3 Retry Logic
+
+**Risk:** A single transient S3 error (503 SlowDown, network timeout) kills the entire process.
+
+**Files to modify:**
+- `util/util-internal-fs/src/s3.ts` — wrap `this.client.send(...)` with retry logic
+
+**Steps:**
+1. Add retry wrapper for all S3 operations: retry on 503, 500, network errors
+2. Use exponential backoff: `[100, 500, 2000, 5000]` ms with jitter
+3. Max 4 retries per operation
+4. Move `EventEmitter.emit('S3FsOperation', ...)` to fire on both success (`status: 'success'`) and failure (`status: 'error'`), so metrics reflect reality
+5. Add explicit S3 request timeout (configurable, default 60s for PutObject, 30s for others)
+
+---
+
+## Phase 2: High — Observability & Operability
+
+### 2.1 Health Checks (Score: 0/10)
+
+**Risk:** Kubernetes cannot detect failed/stuck dumper processes. No automatic restart on deadlock; no traffic gating on readiness.
+
+**Files to modify:**
+- `util/util-internal-prometheus-server/src/server.ts` — add health endpoints
+- `util/util-internal-dump-cli/src/dumper.ts` — track startup/readiness state
+
+**Steps:**
+1. Add `/healthz` to Prometheus HTTP server — return 200 if event loop is responsive (no dependency checks)
+2. Add `/readyz` — return 200 only after first block has been received (`sqd_latest_received_block_number > 0`) AND RPC connection is live
+3. Add `/health/startup` — return 503 until RPC connection established and first block fetched, then 200 forever
+4. Accept a readiness callback in `createPrometheusServer()` so the dumper can provide its own readiness logic
+
+### 2.2 RPC Duration Histogram
+
+**Risk:** Tail latency invisible. A 60s spike averages out to nothing in the current gauge.
+
+**Files to modify:**
+- `util/util-internal-dump-cli/src/prometheus.ts` — replace gauge with histogram
+- `util/rpc-client/src/client.ts` — emit per-request duration (not cumulative average)
+
+**Steps:**
+1. Replace `sqd_chain_avg_response_time_seconds` (Gauge) with `sqd_chain_rpc_request_duration_seconds` (Histogram)
+2. Use buckets: `[0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 180]`
+3. Label by `url` (endpoint) and `method` (RPC method name)
+4. Deprecate the old gauge name (keep for 1 release cycle with a deprecation comment)
+
+### 2.3 Fix RPC Request Counter Type
+
+**Files to modify:**
+- `util/util-internal-dump-cli/src/prometheus.ts`
+
+**Steps:**
+1. Change `sqd_rpc_request_count` from Gauge to Counter
+2. Label with `status_class` (success / rate_limited / server_error / network_error) instead of binary `kind`
+3. Add `sqd_rpc_retry_attempts_total` Counter to track retry storms
+
+### 2.4 Fix S3 Metrics
+
+**Files to modify:**
+- `util/util-internal-fs/src/s3.ts` — emit on success AND failure
+- `util/util-internal-dump-cli/src/prometheus.ts` — add duration and bytes metrics
+
+**Steps:**
+1. Move `EventEmitter.emit()` to a `finally` block so it fires on both success and failure
+2. Add status label: `success` / `error`
+3. Add `sqd_s3_request_duration_seconds` Histogram (buckets: `[0.1, 0.5, 1, 2.5, 5, 10, 30, 60]`)
+4. Add `sqd_s3_bytes_transferred_total` Counter with labels `operation` and `bucket`
+
+---
+
+## Phase 3: Medium — Resilience Hardening
+
+### 3.1 Backoff Jitter
+
+**Risk:** After RPC recovery, all instances retry at the same millisecond → thundering herd prolongs outage.
+
+**Files to modify:**
+- `util/rpc-client/src/client.ts` — `backoff()` method
+
+**Steps:**
+1. Add jitter to the backoff pause: `pause = scheduledPause * (0.5 + Math.random())`
+2. This is a one-line change in the `backoff()` method
+
+### 3.2 Configurable RPC Timeout
+
+**Risk:** 180s hardcoded timeout can't be tuned for slow or fast networks.
+
+**Files to modify:**
+- `util/util-internal-dump-cli/src/dumper.ts` — add CLI option
+- `evm/evm-dump/src/dumper.ts` — (no changes if base class handles it)
+
+**Steps:**
+1. Add `--rpc-timeout <ms>` CLI flag (default: 180000)
+2. Pass to `RpcClient` constructor
+3. Document that this is per-request, not total
+
+### 3.3 S3 Timeout Configuration
+
+**Files to modify:**
+- `util/util-internal-fs/src/s3.ts` — add timeout to S3 client config
+
+**Steps:**
+1. Pass `requestTimeout` to the AWS SDK S3 client constructor
+2. Add `--s3-timeout <ms>` CLI flag (default: 60000)
+
+### 3.4 Failure Threshold Alerting (Lightweight Circuit Breaker)
+
+**Risk:** No way to distinguish transient blips from permanent RPC outage in dashboards.
+
+**Files to modify:**
+- `util/rpc-client/src/client.ts`
+
+**Steps:**
+1. When `connectionErrorsInRow` exceeds a threshold (e.g., 50), log at `error` level: `"RPC endpoint may be permanently unavailable"` with `{ endpoint, consecutiveErrors, backoffPause_ms }`
+2. Expose `sqd_rpc_consecutive_errors` Gauge so dashboards can alert on sustained failure
+3. Full circuit breaker (closed/open/half-open) is not needed for a batch dumper
+
+---
+
+## Phase 4: Low — Cleanup & Polish
+
+### 4.1 Fix Binary Name
+
+**File:** `evm/evm-dump/package.json`
+
+Change `"solana-dump"` → `"evm-dump"` in the `bin` field.
+
+### 4.2 Structured Error Context on Fatal
+
+**Files to modify:**
+- `util/util-internal-dump-cli/src/dumper.ts` — enrich `log.fatal()` calls
+
+**Steps:**
+1. Wrap the top-level `try/catch` in `run()` to extract structured fields from the error:
+   - If `HttpTimeoutError`: log `{ method, url, timeout_ms }`
+   - If `HttpError`: log `{ method, url, status_code, duration_ms }`
+   - If S3 error: log `{ operation, bucket, key }`
+2. Fallback: log the raw error for unexpected types
+
+### 4.3 Per-Retry Logging
+
+**Files to modify:**
+- `util/rpc-client/src/client.ts` — `backoff()` and request re-enqueue
+
+**Steps:**
+1. Log each retry attempt at `warn` level with `{ attempt, maxAttempts, method, endpoint, reason }`
+2. Currently only logs once per backoff epoch — change to log each re-enqueue on lines 407-409
+
+---
+
+## Implementation Order
+
+| Priority | Task | Est. Complexity | Shared Utility Impact |
+|----------|------|-----------------|----------------------|
+| P0 | 1.1 Graceful Shutdown | Medium | `util-internal-dump-cli`, `util-internal-fs` |
+| P0 | 1.2 Finite Retry Cap | Low | `util-internal-dump-cli`, `rpc-client` |
+| P0 | 1.3 S3 Retry Logic | Medium | `util-internal-fs` |
+| P1 | 2.1 Health Checks | Low | `util-internal-prometheus-server` |
+| P1 | 2.2 RPC Duration Histogram | Low | `util-internal-dump-cli`, `rpc-client` |
+| P1 | 2.3 Fix RPC Counter Type | Low | `util-internal-dump-cli` |
+| P1 | 2.4 Fix S3 Metrics | Low | `util-internal-fs`, `util-internal-dump-cli` |
+| P2 | 3.1 Backoff Jitter | Trivial | `rpc-client` |
+| P2 | 3.2 Configurable RPC Timeout | Low | `util-internal-dump-cli` |
+| P2 | 3.3 S3 Timeout Config | Low | `util-internal-fs` |
+| P2 | 3.4 Failure Threshold Alert | Low | `rpc-client` |
+| P3 | 4.1 Fix Binary Name | Trivial | `evm-dump` only |
+| P3 | 4.2 Structured Fatal Errors | Low | `util-internal-dump-cli` |
+| P3 | 4.3 Per-Retry Logging | Low | `rpc-client` |
+
+**Note:** Most changes are in shared `util/` packages, not in `evm-dump` itself. The same fixes will benefit `solana-dump` and any other service using these utilities.

--- a/evm/evm-dump/SRE_REPORT.md
+++ b/evm/evm-dump/SRE_REPORT.md
@@ -1,0 +1,178 @@
+# SRE Product Acceptance Criteria Review: `evm/evm-dump`
+
+**Date:** 2026-02-28
+**Service:** `@subsquid/evm-dump` — Data archiving tool for EVM-based chains
+**Key files reviewed:**
+- `evm/evm-dump/src/dumper.ts` — EVM-specific dumper implementation
+- `evm/evm-dump/src/main.ts` — Entry point
+- `evm/evm-dump/package.json` — Package manifest (note: `bin` field says `"solana-dump"` — copy-paste bug)
+- `util/util-internal-dump-cli/src/dumper.ts` — Base `Dumper` class
+- `util/util-internal-dump-cli/src/prometheus.ts` — Prometheus metrics
+- `util/rpc-client/src/client.ts` — RPC client with retry logic
+- `util/util-internal-fs/src/s3.ts` — S3 filesystem abstraction
+- `util/util-internal/src/misc.ts` — `runProgram` execution wrapper
+- `util/util-internal-prometheus-server/src/server.ts` — Prometheus HTTP server (only `/metrics` routes)
+
+---
+
+## Miscellaneous Bugs
+
+- **Binary name mismatch in `package.json`:** The `bin` field declares `"solana-dump": "./bin/run.js"` but this is the EVM dump package. Should be `"evm-dump"`.
+
+---
+
+## 1. Structured Logging
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| Machine-parseable logs | **PASS** | Uses `@subsquid/logger` with structured output (`sqd:evm-dump` namespace) |
+| Error context (Section 1.1) | **FAIL** | Terminal errors caught by `runProgram` are logged via `log.fatal(err)` — a raw error object without structured context fields (`method`, `url`, `status_code`, `duration_ms`) |
+| Log levels used correctly | **PARTIAL** | `debug` for cache/block ops, `info` for progress, `warn` for missing timestamps, `fatal` for crashes. No `error`-level logs exist — every failure is terminal (`fatal` + `process.exit(1)`) |
+| No sensitive data in logs | **PASS** | `RpcClient` constructor strips credentials from URL via `trimCredentials()` before logging. No tokens/keys logged |
+
+### Gaps
+
+- **RPC terminal errors lack structured context.** When a fatal RPC error propagates up, it is logged as `log.fatal(err)` in `dumper.ts:run()`. An on-call engineer sees something like `fatal: HttpTimeoutError: request timed out` without knowing which RPC method, which endpoint, how long it waited, or which block range was being fetched.
+- **S3 errors have zero structured context.** An S3 `PutObject` failure surfaces as a raw AWS SDK error without `operation`, `bucket`, `key`, or `duration_ms`.
+- **RPC client does log connection failures at `warn`.** The `backoff()` method in `rpc-client/src/client.ts:459-473` logs `{reason, httpResponseBody, rpcCall}` and the backoff pause duration. However, this log fires once per backoff epoch (not per individual request retry), and does not include a retry attempt number. This makes it hard to distinguish "occasional retries" from "retry storm."
+
+---
+
+## 2. Metrics
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| RPC request counter with status classification | **PARTIAL** | `sqd_rpc_request_count` is a **Gauge** (not Counter) with labels `url` and `kind` (`'success'`/`'failure'`). Does NOT classify by granular status (rate_limited / client_error / server_error / network_error). Using a Gauge for a monotonically increasing count means resets are possible |
+| RPC request duration histogram | **FAIL** | `sqd_chain_avg_response_time_seconds` is a **Gauge of the cumulative average** (`totalResponseTime / requestsServed`). Not a histogram — no percentile data (p50/p95/p99). Latency spikes are invisible |
+| S3 operation counter | **PARTIAL** | `sqd_s3_request_count` (Counter, label `kind`) tracks invocations by operation type (`PutObject`, `ListObjectsV2`, `DeleteObjects`, `GetObject`). Event is emitted **after** the S3 call succeeds — failed calls are not counted at all |
+| S3 operation duration | **FAIL** | No duration tracking for S3 operations |
+| S3 bytes transferred | **FAIL** | No bytes metric for S3 uploads/downloads |
+| S3 error classification | **FAIL** | S3 counter only fires on success (event emitted after `await client.send(...)` returns). Failures throw before the emit, so they are invisible in metrics |
+| Business metrics | **PASS** | Good coverage: `sqd_dump_chain_height`, `sqd_dump_last_written_block`, `sqd_blocks_delivery_delay`, `sqd_blocks_processing_time`, block number/timestamp tracking |
+
+### Gaps
+
+- **RPC duration must be a histogram.** The current averaged gauge hides tail latency entirely. A single 60s spike in a stream of 50ms calls averages out to nothing.
+- **`sqd_rpc_request_count` should be a Counter, not a Gauge.** Counters are designed for monotonically increasing values and work correctly with `rate()` in Prometheus. The current Gauge-with-`collect()` pattern resets the entire metric on every scrape via `rpc.getMetrics()`.
+- **S3 metrics only count successes.** The `EventEmitter.emit('S3FsOperation', ...)` call is placed after `await this.client.send(...)` in `s3.ts`. If the S3 call throws, the emit never fires. There is no way to detect S3 failures via metrics.
+- **No retry metric.** There is no counter for RPC retry attempts, making retry storms invisible in dashboards.
+
+---
+
+## 3. Health Checks
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| Liveness (`/healthz`) | **FAIL** | No liveness endpoint. `createPrometheusServer()` only registers `/metrics` and `/metrics/{name}` routes |
+| Readiness (`/readyz`) | **FAIL** | No readiness endpoint. No way to know if the dumper has started processing blocks |
+| Startup probe | **FAIL** | No startup endpoint. The dumper may take significant time to connect to RPC and fetch the first block |
+
+### Gaps
+
+The Prometheus HTTP server (`util/util-internal-prometheus-server/src/server.ts`) is the only HTTP surface. It creates an `HttpApp` with only `/metrics` and `/metrics/{name}`. Adding `/healthz` (return 200 if process alive), `/readyz` (return 200 if `sqd_latest_received_block_number > 0`), and `/health/startup` on the same server would be straightforward.
+
+---
+
+## 4. Graceful Shutdown
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| SIGTERM handler | **FAIL** | No signal handlers registered. `runProgram()` (`misc.ts:27-43`) only wraps `main().then(() => process.exit(0), onerror)` |
+| Stop accepting new work | **FAIL** | No mechanism to signal the `ingest()` async generator to stop yielding |
+| Finish in-flight work | **FAIL** | No draining of in-flight S3 writes or RPC calls |
+| Close connections | **FAIL** | `RpcClient`, `S3Client`, and Prometheus `ListeningServer` are never explicitly closed |
+| Flush buffered data | **FAIL** | No log/metric flush on exit |
+| Exit code 0 on clean shutdown | **FAIL** | `process.exit(1)` on any error; `process.exit(0)` only on natural range completion |
+
+### Gaps
+
+**This is the most critical gap.** On SIGTERM (e.g., Kubernetes pod termination):
+
+1. The process receives SIGTERM but has no handler — Node.js default behavior terminates the process
+2. In-flight S3 `PutObject` calls may leave partial/corrupted objects in the archive
+3. The Prometheus `ListeningServer` is not closed (the `stoppable` wrapper with 5s grace in `util-internal-http-server` is never invoked)
+4. No log line indicates shutdown was requested or completed
+5. `ArchiveLayout` may have a partially written chunk with no cleanup
+
+The codebase already has a reusable pattern in `util/util-internal-http-server/src/server.ts`:
+```typescript
+export function waitForInterruption(server: ListeningServer): Promise<void> {
+    return new Promise((resolve, reject) => {
+        function terminate() {
+            process.off('SIGINT', terminate)
+            process.off('SIGTERM', terminate)
+            server.close().then(resolve, reject)
+        }
+        process.on('SIGINT', terminate)
+        process.on('SIGTERM', terminate)
+    })
+}
+```
+
+---
+
+## 5. Retry Policies
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| Retry on transient failures | **PASS** | RPC client retries on 429, 408, 502, 503, 504, `HttpTimeoutError`, `HttpConnectionError`, `RpcConnectionError`, `RetryError`, rate-limit and timeout error messages |
+| Don't retry on 4xx (except 429, 408) | **PASS** | Other client errors are not classified as connection errors and are not retried |
+| Exponential backoff | **PASS** | Fixed schedule `[10, 100, 500, 2000, 10000, 20000]` ms indexed by `connectionErrorsInRow`, ceiling at 20s. Resets to 0 on first success |
+| Jitter | **FAIL** | No jitter/randomization in backoff. Pause is selected deterministically from the schedule array. All instances with the same error count retry at the exact same interval |
+| Max retries capped | **FAIL** | Dumper sets `retryAttempts: Number.MAX_SAFE_INTEGER` (`dumper.ts:rpc()`). The service will retry **forever** on a dead endpoint |
+| Total timeout bound | **FAIL** | No total deadline across retries. Effective timeout is infinite |
+| Log each retry | **PARTIAL** | The `backoff()` method (`client.ts:459-473`) logs at `warn` with `{reason, httpResponseBody, rpcCall}` and backoff duration. But: (a) only fires once per backoff epoch, not per individual request retry, (b) does not include attempt number or max attempts, (c) re-enqueued requests on lines 407-409 are silent |
+| Retry metrics | **FAIL** | `connectionErrors` is a cumulative total exposed via `getMetrics()`. No dedicated retry counter. Cannot distinguish "1 request retried 100 times" from "100 requests each failed once" |
+
+### Gaps
+
+- **Infinite retries is the most dangerous issue.** A permanently dead RPC endpoint causes the dumper to hang forever. The `backoff()` warn logs will fire repeatedly (every 20s at ceiling), but there is no escalation, no error-level alert, and no way to auto-recover.
+- **No jitter** means after a brief RPC outage, all dumper instances sharing the same endpoint retry at the same millisecond, creating a thundering herd that can prolong the outage.
+- **S3 has NO retry logic at all.** The `S3Fs` class (`s3.ts`) calls `this.client.send(...)` with no try/catch, no retry wrapper, and no backoff. A single transient S3 error (e.g., 503 SlowDown) kills the entire dumper process.
+
+---
+
+## 6. Circuit Breakers
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| Circuit breaker for RPC | **FAIL** | Not implemented. `connectionErrorsInRow` is tracked (`client.ts:121`) but only used to index into the backoff schedule, never to trip a circuit |
+| Circuit breaker for S3 | **FAIL** | Not implemented |
+| State exposed as metric | **FAIL** | N/A |
+
+**Recommendation:** For a batch data dumper, a full circuit breaker (closed/open/half-open) may be overkill since there's no degraded-response path. However, a **failure threshold that triggers `log.error` + a metric** (e.g., "50 consecutive RPC failures — endpoint may be permanently down") would be valuable for alerting and distinguishing transient blips from real outages.
+
+---
+
+## 7. Timeouts
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| RPC request timeout | **PASS** | `requestTimeout: 180_000` (3 minutes) set in `Dumper.rpc()` |
+| RPC timeout configurable | **FAIL** | Hardcoded in base `Dumper` class. Not exposed as a CLI flag or environment variable |
+| S3 timeout configured | **FAIL** | No explicit timeout on S3 operations. Relies on AWS SDK defaults (which may be very long or uncapped for large objects) |
+| Timeout hierarchy consistent | **FAIL** | Individual RPC calls timeout at 3 min, but infinite retries mean effective timeout is unbounded. No total-operation deadline exists |
+
+---
+
+## Summary Scorecard
+
+| Section | Score | Critical Issues |
+|---------|-------|-----------------|
+| 1. Structured Logging | 4/10 | Fatal error logs lack context fields for triage |
+| 2. Metrics | 4/10 | RPC duration is averaged gauge not histogram; S3 only counts successes; request count is a Gauge not Counter |
+| 3. Health Checks | 0/10 | None exist |
+| 4. Graceful Shutdown | 0/10 | No SIGTERM handling; risk of corrupted S3 archives |
+| 5. Retry Policies | 4/10 | Infinite retries, no jitter, no per-request retry logging; S3 has zero retries |
+| 6. Circuit Breakers | 0/10 | Not implemented (acceptable for batch workload if alerting exists — it doesn't) |
+| 7. Timeouts | 3/10 | RPC timeout hardcoded; S3 has none; no total deadline |
+
+---
+
+## Top 5 Priorities (by risk)
+
+1. **Graceful shutdown** — Add SIGTERM/SIGINT handlers to prevent corrupted S3 archives on pod termination. Reuse the `waitForInterruption` pattern from `util-internal-http-server`.
+2. **Finite retry cap** — Replace `retryAttempts: Number.MAX_SAFE_INTEGER` with a configurable limit (e.g., `--max-retry-attempts 50`). Log at `error` level when retries are exhausted.
+3. **Health checks** — Add `/healthz` and `/readyz` endpoints to the Prometheus HTTP server in `createPrometheusServer()`.
+4. **S3 resilience** — Add retry-with-backoff for transient S3 errors (503, network errors). Move the `EventEmitter.emit()` call to fire on both success and failure with a status label so failures appear in metrics.
+5. **RPC duration histogram** — Replace `sqd_chain_avg_response_time_seconds` (Gauge) with a proper `Histogram` to expose p50/p95/p99 latency percentiles.

--- a/util/rpc-client/src/client.ts
+++ b/util/rpc-client/src/client.ts
@@ -402,19 +402,20 @@ export class RpcClient {
             }
             req.resolve(result)
         }, err => {
-            if (this.closed) return req.reject(err)
+            let durationMs = Date.now() - startTime
+            if (this.closed) return req.reject(this.enrichError(err, req, durationMs))
             if (this.isConnectionError(err)) {
                 if (req.retryAttempts > 0) {
                     req.retryAttempts -= 1
                     this.enqueue(req)
                 } else {
-                    req.reject(err)
+                    req.reject(this.enrichError(err, req, durationMs))
                 }
                 if (this.backoffEpoch == backoffEpoch) {
                     this.backoff(err, req)
                 }
             } else {
-                req.reject(err)
+                req.reject(this.enrichError(err, req, durationMs))
             }
         }).finally(() => {
             this.capacity += 1
@@ -508,6 +509,15 @@ export class RpcClient {
                 rpcResponse: res
             })
         }
+    }
+
+    private enrichError(err: Error, req: Req, durationMs: number): Error {
+        let call = Array.isArray(req.call) ? req.call[0] : req.call
+        return addErrorContext(err, {
+            rpcUrl: this.url,
+            rpcMethod: call.method,
+            durationMs
+        })
     }
 
     isConnectionError(err: Error): boolean {

--- a/util/rpc-client/src/client.ts
+++ b/util/rpc-client/src/client.ts
@@ -402,6 +402,7 @@ export class RpcClient {
             }
             req.resolve(result)
         }, err => {
+            // Duration of this individual send attempt (not cumulative across retries)
             let durationMs = Date.now() - startTime
             if (this.closed) return req.reject(this.enrichError(err, req, durationMs))
             if (this.isConnectionError(err)) {
@@ -512,10 +513,20 @@ export class RpcClient {
     }
 
     private enrichError(err: Error, req: Req, durationMs: number): Error {
-        let call = Array.isArray(req.call) ? req.call[0] : req.call
+        let rpcMethod: string
+        let rpcBatchSize: number | undefined
+
+        if (Array.isArray(req.call)) {
+            rpcBatchSize = req.call.length
+            rpcMethod = req.call.map(c => c.method).join(',')
+        } else {
+            rpcMethod = req.call.method
+        }
+
         return addErrorContext(err, {
             rpcUrl: this.url,
-            rpcMethod: call.method,
+            rpcMethod,
+            rpcBatchSize,
             durationMs
         })
     }


### PR DESCRIPTION
## Summary

- **SRE_REPORT.md** — Full production-readiness audit of `evm-dump` against 7 SRE criteria (logging, metrics, health checks, graceful shutdown, retries, circuit breakers, timeouts). Scores range from 0/10 to 4/10.
- **PLAN.md** — Prioritized remediation roadmap (P0–P3) with 14 actionable tasks, file-level guidance, and complexity estimates.
- **RPC error context enrichment** — `RpcClient.enrichError()` attaches `rpcUrl`, `rpcMethod`, and `durationMs` to all errors that escape the retry loop via the existing `addErrorContext` utility. Fatal log lines now carry enough context for on-call triage without any changes to call sites.

## Key findings (from SRE_REPORT.md)

| Area | Score | Top issue |
|------|-------|-----------|
| Graceful Shutdown | 0/10 | No SIGTERM handler — corrupted S3 objects on pod kill |
| Health Checks | 0/10 | No `/healthz` or `/readyz` endpoints |
| Retry Policies | 4/10 | `retryAttempts: Number.MAX_SAFE_INTEGER` — hangs forever |
| Metrics | 4/10 | RPC duration is averaged gauge, not histogram |
| Timeouts | 3/10 | RPC timeout hardcoded at 180s, S3 has none |

## Test plan

- [x] `tsc --noEmit` passes for `util/rpc-client` (only pre-existing `removeArrayItem` error)
- [ ] Verify enriched error fields appear in structured logs during manual RPC failure test
- [ ] Review PLAN.md priorities with team before starting Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)