### PR TITLE
Add metrics for cache/below queries and active workers

### DIFF
--- a/evm/evm-data-service/src/main.ts
+++ b/evm/evm-data-service/src/main.ts
@@ -82,6 +82,7 @@ runProgram(async () => {
     }
 
     let mainWorker = new WorkerClient(dataSourceOptions)
+    let service: Awaited<ReturnType<typeof runDataService>> | undefined
     let dataSource: DataSource<Block> = {
         getHead() {
             return mainWorker.getHead()
@@ -91,9 +92,11 @@ runProgram(async () => {
         },
         async *getFinalizedStream(req: StreamRequest): BlockStream<Block> {
             let worker = new WorkerClient(dataSourceOptions)
+            service?.metrics.incActiveWorkers()
             try {
                 yield* worker.getFinalizedStream(req)
             } finally {
+                service?.metrics.decActiveWorkers()
                 worker.close()
             }
         },
@@ -102,7 +105,7 @@ runProgram(async () => {
         }
     }
 
-    let service = await runDataService({
+    service = await runDataService({
         source: dataSource,
         blockCacheSize: args.blockCacheSize,
         port: args.port

--- a/util/util-internal-data-service/src/data-service.ts
+++ b/util/util-internal-data-service/src/data-service.ts
@@ -53,15 +53,30 @@ export class DataService {
     }
 
     async query(from: number, parentHash?: string): Promise<DataResponse | InvalidBaseBlock> {
-        if (from <= this.chain.firstBlock().parentNumber) {
-            return this.belowQuery(from, parentHash)
-        } else {
-            let res = this.chain.query(from, parentHash)
-            if (res instanceof InvalidBaseBlock) return res
-            if (res.tail) return res
-            await this.waitForBlock(from)
-            return this.chain.query(from, parentHash)
+        let result: DataResponse | InvalidBaseBlock
+        try {
+            if (from <= this.chain.firstBlock().parentNumber) {
+                result = await this.belowQuery(from, parentHash)
+                this.metrics.incQuery(result instanceof InvalidBaseBlock ? 'error' : 'backfill')
+            } else {
+                let res = this.chain.query(from, parentHash)
+                if (res instanceof InvalidBaseBlock) {
+                    this.metrics.incQuery('error')
+                    return res
+                }
+                if (res.tail) {
+                    this.metrics.incQuery('cache')
+                    return res
+                }
+                await this.waitForBlock(from)
+                result = this.chain.query(from, parentHash)
+                this.metrics.incQuery(result instanceof InvalidBaseBlock ? 'error' : 'cache')
+            }
+        } catch(err) {
+            this.metrics.incQuery('error')
+            throw err
         }
+        return result
     }
 
     private async belowQuery(from: number, parentHash?: string): Promise<DataResponse | InvalidBaseBlock> {

--- a/util/util-internal-data-service/src/index.ts
+++ b/util/util-internal-data-service/src/index.ts
@@ -2,6 +2,7 @@ import {BlockBatch, BlockStream, DataSource, StreamRequest} from '@subsquid/util
 import {ListeningServer} from '@subsquid/util-internal-http-server'
 import {DataService} from './data-service'
 import {createHttpApp} from './http-app'
+import {Metrics} from './metrics'
 import {Block, BlockHeader, BlockRef} from './types'
 
 
@@ -12,6 +13,7 @@ export {
     BlockRef,
     BlockStream,
     DataSource,
+    Metrics,
     StreamRequest
 }
 
@@ -23,7 +25,7 @@ export interface DataServiceOptions {
 }
 
 
-export async function runDataService(args: DataServiceOptions): Promise<ListeningServer & {started: Promise<void>}> {
+export async function runDataService(args: DataServiceOptions): Promise<ListeningServer & {started: Promise<void>, metrics: Metrics}> {
     let service = new DataService(args.source, args.blockCacheSize ?? 1000)
     let app = createHttpApp(service)
 
@@ -34,6 +36,7 @@ export async function runDataService(args: DataServiceOptions): Promise<Listenin
 
     return {
         started: service.started(),
+        metrics: service.metrics,
         port: server.port,
         close(): Promise<void> {
             service.stop()

--- a/util/util-internal-data-service/src/metrics.ts
+++ b/util/util-internal-data-service/src/metrics.ts
@@ -11,6 +11,8 @@ export class Metrics {
     private hotBlocksStoredBlocksGauge: Gauge
     private blockLagHistogram: Histogram
     private blockProcessingTimeHistogram: Histogram
+    private queriesCounter: Counter
+    private activeWorkersGauge: Gauge
 
     constructor() {
         this.hotBlocksLastBlockGauge = new Gauge({
@@ -57,6 +59,25 @@ export class Metrics {
             registers: [this.registry]
         });
 
+        this.queriesCounter = new Counter({
+            name: 'sqd_hotblocks_queries_total',
+            help: 'Total number of queries by type',
+            labelNames: ['type'],
+            registers: [this.registry],
+        })
+
+        this.activeWorkersGauge = new Gauge({
+            name: 'sqd_hotblocks_active_workers',
+            help: 'Number of currently active worker threads',
+            registers: [this.registry],
+        })
+
+        // Initialize so metrics appear on /metrics immediately
+        this.queriesCounter.inc({type: 'cache'}, 0)
+        this.queriesCounter.inc({type: 'backfill'}, 0)
+        this.queriesCounter.inc({type: 'error'}, 0)
+        this.activeWorkersGauge.set(0)
+
         collectDefaultMetrics({register: this.registry})
     }
 
@@ -94,6 +115,18 @@ export class Metrics {
     trackProcessingTime(startTime: number) {
         const duration = Date.now() - startTime;
         this.blockProcessingTimeHistogram.observe(duration);
+    }
+
+    incQuery(type: 'cache' | 'backfill' | 'error') {
+        this.queriesCounter.inc({type})
+    }
+
+    incActiveWorkers() {
+        this.activeWorkersGauge.inc()
+    }
+
+    decActiveWorkers() {
+        this.activeWorkersGauge.dec()
     }
 }
 


### PR DESCRIPTION
## Summary

- Single `sqd_hotblocks_queries_total` counter with `type` label: `cache`, `backfill`, `error`
- `sqd_hotblocks_active_workers` gauge for currently active worker threads
- `InvalidBaseBlock` responses tracked as `error`
- Expose `metrics` from `runDataService` so callers can instrument worker lifecycle

## New metrics

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `sqd_hotblocks_queries_total` | Counter | `type=cache\|backfill\|error` | Query counts by type |
| `sqd_hotblocks_active_workers` | Gauge | — | Currently active worker threads |

## Why

Backfill queries spawn a new worker thread (V8 isolate) per request — the main source of CPU/memory spikes. These metrics help understand the ratio and decide if worker pooling is needed.

## Test plan

- [ ] Deploy, verify metrics appear on `/metrics`
- [ ] Trigger a backfill query by requesting blocks below cache range
- [ ] Confirm counter labels and gauge reflect actual state

🤖 Generated with [Claude Code](https://claude.com/claude-code)