### PR TITLE
Clean up and refactor evm-codec-impr changed files

### DIFF
--- a/evm/evm-abi/src/abi-components/event.ts
+++ b/evm/evm-abi/src/abi-components/event.ts
@@ -45,6 +45,19 @@ function slotsCountOf(codecs: readonly Codec<any>[]): number {
   return c
 }
 
+/**
+ * Append a closure-captured value to a parallel names/values pair. Returns
+ * the chosen variable name so the caller can splice it straight into a
+ * generated function body.
+ */
+function capture(names: string[], values: any[], name: string, value: unknown): string {
+  names.push(name)
+  values.push(value)
+  return name
+}
+
+type FieldOrder = {key: string; kind: 'topic' | 'data'; idx: number}
+
 export class AbiEvent<const T extends EventArgs> {
   public readonly args: T
   public readonly params: IndexedCodecs<T>
@@ -85,7 +98,7 @@ export class AbiEvent<const T extends EventArgs> {
 
     const topicFields: Array<[string, Codec<any>]> = []
     const dataFields: Array<[string, Codec<any>]> = []
-    const order: Array<{key: string; kind: 'topic' | 'data'; idx: number}> = []
+    const order: FieldOrder[] = []
 
     for (const key in args) {
       const arg = args[key]
@@ -121,61 +134,56 @@ export class AbiEvent<const T extends EventArgs> {
     topicFields: Array<[string, Codec<any>]>,
     dataFields: Array<[string, Codec<any>]>,
   ): (args: EncodedStruct<IndexedCodecs<T>>) => EventRecord {
-    const closureNames: string[] = ['TOPIC', 'Sink', 'bytesToHex']
-    const closureValues: any[] = [this.topic, Sink, bytesToHexString]
+    const names: string[] = []
+    const values: any[] = []
+    capture(names, values, 'TOPIC', this.topic)
+    capture(names, values, 'Sink', Sink)
+    capture(names, values, 'bytesToHex', bytesToHexString)
 
     let body = 'const topics = [TOPIC];\n'
 
     for (let i = 0; i < topicFields.length; i++) {
       const [name, codec] = topicFields[i]
-      const encName = `__et${i}`
-      closureNames.push(encName)
-      closureValues.push(codec.encode.bind(codec))
+      const enc = capture(names, values, `__et${i}`, codec.encode.bind(codec))
       const slots = codec.slotsCount ?? 1
-      body += `{\n`
-      body += `  const s = new Sink(${slots});\n`
-      body += `  ${encName}(s, args${propAccess(name)});\n`
-      body += `  const b = s.result();\n`
-      body += `  topics.push('0x' + bytesToHex(b, 0, b.length));\n`
-      body += `}\n`
+      body +=
+        `{\n` +
+        `  const s = new Sink(${slots});\n` +
+        `  ${enc}(s, args${propAccess(name)});\n` +
+        `  const b = s.result();\n` +
+        `  topics.push('0x' + bytesToHex(b, 0, b.length));\n` +
+        `}\n`
     }
 
     const dataChildrenSlots = slotsCountOf(dataFields.map(([, c]) => c))
     body += `const dataSink = new Sink(${dataChildrenSlots});\n`
     for (let i = 0; i < dataFields.length; i++) {
       const [name, codec] = dataFields[i]
-      const encName = `__ed${i}`
-      closureNames.push(encName)
-      closureValues.push(codec.encode.bind(codec))
-      body += `${encName}(dataSink, args${propAccess(name)});\n`
+      const enc = capture(names, values, `__ed${i}`, codec.encode.bind(codec))
+      body += `${enc}(dataSink, args${propAccess(name)});\n`
     }
-    body += `const dataBytes = dataSink.result();\n`
-    body += `return { topics, data: '0x' + bytesToHex(dataBytes, 0, dataBytes.length) };\n`
+    body +=
+      `const dataBytes = dataSink.result();\n` +
+      `return { topics, data: '0x' + bytesToHex(dataBytes, 0, dataBytes.length) };\n`
 
-    const factory = new Function(
-      ...closureNames,
-      `return function encode(args){\n${body}};`,
-    )
-    return factory(...closureValues)
+    return new Function(...names, `return function encode(args){\n${body}};`)(...values)
   }
 
   private createDecode(
-    order: Array<{key: string; kind: 'topic' | 'data'; idx: number}>,
+    order: FieldOrder[],
     topicFields: Array<[string, Codec<any>]>,
     dataFields: Array<[string, Codec<any>]>,
   ): (rec: EventRecord) => DecodedStruct<IndexedCodecs<T>> {
-    const closureNames: string[] = ['Src', 'hexBytes']
-    const closureValues: any[] = [Src, hexToBytes]
+    const names: string[] = []
+    const values: any[] = []
+    capture(names, values, 'Src', Src)
+    capture(names, values, 'hexBytes', hexToBytes)
 
     for (let i = 0; i < topicFields.length; i++) {
-      const [, codec] = topicFields[i]
-      closureNames.push(`__dt${i}`)
-      closureValues.push(codec.decode.bind(codec))
+      capture(names, values, `__dt${i}`, topicFields[i][1].decode.bind(topicFields[i][1]))
     }
     for (let i = 0; i < dataFields.length; i++) {
-      const [, codec] = dataFields[i]
-      closureNames.push(`__dd${i}`)
-      closureValues.push(codec.decode.bind(codec))
+      capture(names, values, `__dd${i}`, dataFields[i][1].decode.bind(dataFields[i][1]))
     }
 
     // Property-literal evaluation is left-to-right, so we can safely mix
@@ -184,25 +192,17 @@ export class AbiEvent<const T extends EventArgs> {
     // appear in dataFields order. `order[]` preserves the original
     // args-definition order, and data fields were appended to dataFields
     // in that same order, so the invariant holds.
-    const entries: string[] = []
-    for (const o of order) {
-      if (o.kind === 'topic') {
-        entries.push(
-          `  ${propName(o.key)}: __dt${o.idx}(new Src(hexBytes(rec.topics[${o.idx + 1}], 2)))`,
-        )
-      } else {
-        entries.push(`  ${propName(o.key)}: __dd${o.idx}(dataSrc)`)
-      }
-    }
-
-    let body = 'const dataSrc = new Src(hexBytes(rec.data, 2));\n'
-    body += `return {\n${entries.join(',\n')}\n};\n`
-
-    const factory = new Function(
-      ...closureNames,
-      `return function decode(rec){\n${body}};`,
+    const entries = order.map((o) =>
+      o.kind === 'topic'
+        ? `  ${propName(o.key)}: __dt${o.idx}(new Src(hexBytes(rec.topics[${o.idx + 1}], 2)))`
+        : `  ${propName(o.key)}: __dd${o.idx}(dataSrc)`,
     )
-    return factory(...closureValues)
+
+    const body =
+      'const dataSrc = new Src(hexBytes(rec.data, 2));\n' +
+      `return {\n${entries.join(',\n')}\n};\n`
+
+    return new Function(...names, `return function decode(rec){\n${body}};`)(...values)
   }
 
   /**
@@ -224,12 +224,12 @@ export class AbiEvent<const T extends EventArgs> {
       try {
         return jit(rec)
       } catch (e: any) {
-        throw this.locateDecodeError(rec, e)
+        throw this.locateDecodeError(rec, e as Error)
       }
     }
   }
 
-  private locateDecodeError(rec: EventRecord, original: any): Error {
+  private locateDecodeError(rec: EventRecord, original: Error): Error {
     for (let t = 0; t < this.topicFields.length; t++) {
       const [name, codec] = this.topicFields[t]
       try {

--- a/evm/evm-abi/src/abi-components/function.ts
+++ b/evm/evm-abi/src/abi-components/function.ts
@@ -74,7 +74,7 @@ export class AbiFunction<const T extends Struct, const R extends Codec<any> | St
     } catch (e: any) {
       // Fast path failed — run a slow per-field loop over a fresh src to
       // pinpoint the offending argument for a nicer error message.
-      throw this.locateDecodeError(input, e, (src, i) => new FunctionCalldataDecodeError(this.selector, i, e.message, input))
+      throw this.locateDecodeError(input, e)
     }
   }
 
@@ -113,19 +113,19 @@ export class AbiFunction<const T extends Struct, const R extends Codec<any> | St
     return result
   }
 
-  private locateDecodeError(input: string, original: any, make: (src: Src, i: string) => Error): Error {
+  private locateDecodeError(input: string, original: Error): Error {
     const slow = new Src(hexToBytes(input, 10))
     for (const i in this.args) {
       try {
         this.args[i].decode(slow)
       } catch (e: any) {
-        return make(slow, i)
+        return new FunctionCalldataDecodeError(this.selector, i, e.message, input)
       }
     }
     return original
   }
 
-  private locateResultError(output: string, components: Struct, original: any): Error {
+  private locateResultError(output: string, components: Struct, original: Error): Error {
     const slow = new Src(hexToBytes(output, 2))
     for (const i in components) {
       try {
@@ -137,9 +137,13 @@ export class AbiFunction<const T extends Struct, const R extends Codec<any> | St
     return original
   }
 
-  private isCodec(value: any): value is Codec<any> {
-    return value != null && typeof value === 'object' &&
-      typeof value.encode === 'function' && typeof value.decode === 'function'
+  private isCodec(value: unknown): value is Codec<any> {
+    return (
+      value != null &&
+      typeof value === 'object' &&
+      typeof (value as any).encode === 'function' &&
+      typeof (value as any).decode === 'function'
+    )
   }
 
   private checkSignature(val: string) {

--- a/evm/evm-codec/src/codecs/primitives.ts
+++ b/evm/evm-codec/src/codecs/primitives.ts
@@ -7,21 +7,41 @@ import { safeToNumber } from '../safeToNumber'
 type Numberish = number | bigint
 
 /**
- * Build a primitive numeric codec that funnels encode/decode through the
- * given `Sink`/`Src` method name. The `toNative` coercion normalizes the
- * user-facing `number | bigint` input to whatever the underlying Sink
- * method expects (a `number` for widths ≤ 32 bits, a `bigint` otherwise).
+ * Small-integer (≤ 32 bits) codec. `Sink`'s `u8/i8/u16/…/u32/i32` writers
+ * all take a `number`; we accept either a `number` or a `bigint` from the
+ * caller and narrow via `safeToNumber`. The returned codec decodes to a
+ * plain `number`.
  */
-function numericCodec<TOut extends number | bigint>(
-  method: string,
-  toNative: (v: Numberish) => number | bigint,
-): Codec<Numberish, TOut> {
+type NumberMethod = 'u8' | 'i8' | 'u16' | 'i16' | 'u32' | 'i32'
+
+function numberCodec(method: NumberMethod): Codec<Numberish, number> {
   return {
     encode(sink: Sink, val: Numberish) {
-      ;(sink as any)[method](toNative(val))
+      sink[method](safeToNumber(val))
     },
-    decode(src: Src): TOut {
-      return (src as any)[method]()
+    decode(src: Src): number {
+      return src[method]()
+    },
+    isDynamic: false,
+    baseType: 'int',
+  }
+}
+
+/**
+ * Wide-integer (≥ 64 bits) codec. `Sink`'s `u64/i64/…/u256/i256` writers
+ * all take a `bigint`; we accept either a `number` or a `bigint` from the
+ * caller and widen via `BigInt`. The returned codec decodes to a
+ * `bigint`.
+ */
+type BigIntMethod = 'u64' | 'i64' | 'u128' | 'i128' | 'u256' | 'i256'
+
+function bigintCodec(method: BigIntMethod): Codec<Numberish, bigint> {
+  return {
+    encode(sink: Sink, val: Numberish) {
+      sink[method](BigInt(val))
+    },
+    decode(src: Src): bigint {
+      return src[method]()
     },
     isDynamic: false,
     baseType: 'int',
@@ -39,18 +59,18 @@ export const bool: Codec<boolean> = {
   baseType: 'bool',
 }
 
-export const uint8: Codec<Numberish, number> = numericCodec('u8', safeToNumber)
-export const int8: Codec<Numberish, number> = numericCodec('i8', safeToNumber)
-export const uint16: Codec<Numberish, number> = numericCodec('u16', safeToNumber)
-export const int16: Codec<Numberish, number> = numericCodec('i16', safeToNumber)
-export const uint32: Codec<Numberish, number> = numericCodec('u32', safeToNumber)
-export const int32: Codec<Numberish, number> = numericCodec('i32', safeToNumber)
-export const uint64: Codec<Numberish, bigint> = numericCodec('u64', BigInt)
-export const int64: Codec<Numberish, bigint> = numericCodec('i64', BigInt)
-export const uint128: Codec<Numberish, bigint> = numericCodec('u128', BigInt)
-export const int128: Codec<Numberish, bigint> = numericCodec('i128', BigInt)
-export const uint256: Codec<Numberish, bigint> = numericCodec('u256', BigInt)
-export const int256: Codec<Numberish, bigint> = numericCodec('i256', BigInt)
+export const uint8: Codec<Numberish, number> = numberCodec('u8')
+export const int8: Codec<Numberish, number> = numberCodec('i8')
+export const uint16: Codec<Numberish, number> = numberCodec('u16')
+export const int16: Codec<Numberish, number> = numberCodec('i16')
+export const uint32: Codec<Numberish, number> = numberCodec('u32')
+export const int32: Codec<Numberish, number> = numberCodec('i32')
+export const uint64: Codec<Numberish, bigint> = bigintCodec('u64')
+export const int64: Codec<Numberish, bigint> = bigintCodec('i64')
+export const uint128: Codec<Numberish, bigint> = bigintCodec('u128')
+export const int128: Codec<Numberish, bigint> = bigintCodec('i128')
+export const uint256: Codec<Numberish, bigint> = bigintCodec('u256')
+export const int256: Codec<Numberish, bigint> = bigintCodec('i256')
 
 export const string: Codec<string> = {
   encode(sink: Sink, val: string) {

--- a/evm/evm-codec/src/codecs/primitives.ts
+++ b/evm/evm-codec/src/codecs/primitives.ts
@@ -7,16 +7,18 @@ import { safeToNumber } from '../safeToNumber'
 type Numberish = number | bigint
 
 /**
- * Build a primitive numeric codec driven by a `Sink`/`Src` method name and a
- * value-conversion strategy.
+ * Build a primitive numeric codec that funnels encode/decode through the
+ * given `Sink`/`Src` method name. The `toNative` coercion normalizes the
+ * user-facing `number | bigint` input to whatever the underlying Sink
+ * method expects (a `number` for widths ≤ 32 bits, a `bigint` otherwise).
  */
-type NumericConv = 'safeToNumber' | 'BigInt' | 'none'
-
-function numericCodec<TOut extends number | bigint>(method: string, conv: NumericConv): Codec<Numberish, TOut> {
+function numericCodec<TOut extends number | bigint>(
+  method: string,
+  toNative: (v: Numberish) => number | bigint,
+): Codec<Numberish, TOut> {
   return {
     encode(sink: Sink, val: Numberish) {
-      const v = conv === 'safeToNumber' ? safeToNumber(val) : conv === 'BigInt' ? BigInt(val) : val
-      ;(sink as any)[method](v)
+      ;(sink as any)[method](toNative(val))
     },
     decode(src: Src): TOut {
       return (src as any)[method]()
@@ -37,18 +39,18 @@ export const bool: Codec<boolean> = {
   baseType: 'bool',
 }
 
-export const uint8: Codec<Numberish, number> = numericCodec('u8', 'safeToNumber')
-export const int8: Codec<Numberish, number> = numericCodec('i8', 'safeToNumber')
-export const uint16: Codec<Numberish, number> = numericCodec('u16', 'safeToNumber')
-export const int16: Codec<Numberish, number> = numericCodec('i16', 'safeToNumber')
-export const uint32: Codec<Numberish, number> = numericCodec('u32', 'safeToNumber')
-export const int32: Codec<Numberish, number> = numericCodec('i32', 'safeToNumber')
-export const uint64: Codec<Numberish, bigint> = numericCodec('u64', 'BigInt')
-export const int64: Codec<Numberish, bigint> = numericCodec('i64', 'BigInt')
-export const uint128: Codec<Numberish, bigint> = numericCodec('u128', 'BigInt')
-export const int128: Codec<Numberish, bigint> = numericCodec('i128', 'BigInt')
-export const uint256: Codec<Numberish, bigint> = numericCodec('u256', 'BigInt')
-export const int256: Codec<Numberish, bigint> = numericCodec('i256', 'BigInt')
+export const uint8: Codec<Numberish, number> = numericCodec('u8', safeToNumber)
+export const int8: Codec<Numberish, number> = numericCodec('i8', safeToNumber)
+export const uint16: Codec<Numberish, number> = numericCodec('u16', safeToNumber)
+export const int16: Codec<Numberish, number> = numericCodec('i16', safeToNumber)
+export const uint32: Codec<Numberish, number> = numericCodec('u32', safeToNumber)
+export const int32: Codec<Numberish, number> = numericCodec('i32', safeToNumber)
+export const uint64: Codec<Numberish, bigint> = numericCodec('u64', BigInt)
+export const int64: Codec<Numberish, bigint> = numericCodec('i64', BigInt)
+export const uint128: Codec<Numberish, bigint> = numericCodec('u128', BigInt)
+export const int128: Codec<Numberish, bigint> = numericCodec('i128', BigInt)
+export const uint256: Codec<Numberish, bigint> = numericCodec('u256', BigInt)
+export const int256: Codec<Numberish, bigint> = numericCodec('i256', BigInt)
 
 export const string: Codec<string> = {
   encode(sink: Sink, val: string) {

--- a/evm/evm-codec/src/sink.ts
+++ b/evm/evm-codec/src/sink.ts
@@ -10,6 +10,10 @@ const TEXT_ENCODER = new TextEncoder()
 const U64_MASK = 0xffffffffffffffffn
 const U128_MASK = (1n << 128n) - 1n
 const U256_BASE = 1n << 256n
+
+// Range bounds for the int/uint writers. Numeric for the 32-bit-and-smaller
+// range so that `val < MIN` / `val > MAX` cannot trigger a Number↔BigInt
+// comparison on the hot path.
 const U8_MAX = 255
 const U16_MAX = 65535
 const U32_MAX = 4294967295
@@ -76,7 +80,7 @@ export class Sink {
   }
 
   u8(val: number) {
-    if (val < 0 || val > U8_MAX) this.#oob(val, 'uint8')
+    if (val < 0 || val > U8_MAX) this.#oob(val, 'uint8', 0, U8_MAX)
     this.reserve(WORD_SIZE)
     this.pos += WORD_SIZE - 1
     this.view.setUint8(this.pos, val)
@@ -84,12 +88,12 @@ export class Sink {
   }
 
   i8(val: number) {
-    if (val < I8_MIN || val > I8_MAX) this.#oob(val, 'int8')
+    if (val < I8_MIN || val > I8_MAX) this.#oob(val, 'int8', I8_MIN, I8_MAX)
     this.#i256(BigInt(val))
   }
 
   u16(val: number) {
-    if (val < 0 || val > U16_MAX) this.#oob(val, 'uint16')
+    if (val < 0 || val > U16_MAX) this.#oob(val, 'uint16', 0, U16_MAX)
     this.reserve(WORD_SIZE)
     this.pos += WORD_SIZE - 2
     this.view.setUint16(this.pos, val, false)
@@ -97,12 +101,12 @@ export class Sink {
   }
 
   i16(val: number) {
-    if (val < I16_MIN || val > I16_MAX) this.#oob(val, 'int16')
+    if (val < I16_MIN || val > I16_MAX) this.#oob(val, 'int16', I16_MIN, I16_MAX)
     this.#i256(BigInt(val))
   }
 
   u32(val: number) {
-    if (val < 0 || val > U32_MAX) this.#oob(val, 'uint32')
+    if (val < 0 || val > U32_MAX) this.#oob(val, 'uint32', 0, U32_MAX)
     this.reserve(WORD_SIZE)
     this.pos += WORD_SIZE - 4
     this.view.setUint32(this.pos, val, false)
@@ -119,12 +123,12 @@ export class Sink {
   }
 
   i32(val: number) {
-    if (val < I32_MIN || val > I32_MAX) this.#oob(val, 'int32')
+    if (val < I32_MIN || val > I32_MAX) this.#oob(val, 'int32', I32_MIN, I32_MAX)
     this.#i256(BigInt(val))
   }
 
   u64(val: bigint) {
-    if (val < 0n || val > U64_MAX_BI) this.#oob(val, 'uint64')
+    if (val < 0n || val > U64_MAX_BI) this.#oob(val, 'uint64', 0n, U64_MAX_BI)
     this.reserve(WORD_SIZE)
     this.pos += WORD_SIZE - 8
     this.view.setBigUint64(this.pos, val, false)
@@ -132,7 +136,7 @@ export class Sink {
   }
 
   i64(val: bigint) {
-    if (val < I64_MIN_BI || val > I64_MAX_BI) this.#oob(val, 'int64')
+    if (val < I64_MIN_BI || val > I64_MAX_BI) this.#oob(val, 'int64', I64_MIN_BI, I64_MAX_BI)
     this.#i256(val)
   }
 
@@ -142,7 +146,7 @@ export class Sink {
   }
 
   u128(val: bigint) {
-    if (val < 0n || val > U128_MAX_BI) this.#oob(val, 'uint128')
+    if (val < 0n || val > U128_MAX_BI) this.#oob(val, 'uint128', 0n, U128_MAX_BI)
     this.reserve(WORD_SIZE)
     this.pos += WORD_SIZE - 16
     this.#u64(val & U64_MASK)
@@ -150,7 +154,7 @@ export class Sink {
   }
 
   i128(val: bigint) {
-    if (val < I128_MIN_BI || val > I128_MAX_BI) this.#oob(val, 'int128')
+    if (val < I128_MIN_BI || val > I128_MAX_BI) this.#oob(val, 'int128', I128_MIN_BI, I128_MAX_BI)
     this.#i256(val)
   }
 
@@ -164,14 +168,14 @@ export class Sink {
   }
 
   u256(val: bigint) {
-    if (val < 0n || val > U256_MAX_BI) this.#oob(val, 'uint256')
+    if (val < 0n || val > U256_MAX_BI) this.#oob(val, 'uint256', 0n, U256_MAX_BI)
     this.reserve(WORD_SIZE)
     this.#u128Raw(val >> 128n)
     this.#u128Raw(val & U128_MASK)
   }
 
   i256(val: bigint) {
-    if (val < I256_MIN_BI || val > I256_MAX_BI) this.#oob(val, 'int256')
+    if (val < I256_MIN_BI || val > I256_MAX_BI) this.#oob(val, 'int256', I256_MIN_BI, I256_MAX_BI)
     this.#i256(val)
   }
 
@@ -239,8 +243,8 @@ export class Sink {
     this.u8(val ? 1 : 0)
   }
 
-  #oob(val: bigint | number, typeName: string): never {
-    throw new Error(`${val} is out of bounds for ${typeName}`)
+  #oob(val: bigint | number, typeName: string, min: bigint | number, max: bigint | number): never {
+    throw new Error(`${val} is out of bounds for ${typeName}[${min}, ${max}]`)
   }
 
   /**

--- a/evm/evm-codec/src/src.ts
+++ b/evm/evm-codec/src/src.ts
@@ -1,10 +1,14 @@
 import { WORD_SIZE } from './codec'
 import { bytesToHexString } from './hex'
 
-const I128_SIGN_BIT = 1n << 127n
-const I128_RANGE = 1n << 128n
+// Sign bit + wrap-around range for each signed-integer width.
+// `val < SIGN_BIT` ⇒ positive; otherwise subtract RANGE for two's complement.
 const I64_SIGN_BIT = 1n << 63n
 const I64_RANGE = 1n << 64n
+const I128_SIGN_BIT = 1n << 127n
+const I128_RANGE = 1n << 128n
+const I256_SIGN_BIT = 1n << 255n
+const I256_RANGE = 1n << 256n
 
 // `TextDecoder` is stateless under default construction, so a single shared
 // instance is safe.
@@ -100,9 +104,8 @@ export class Src {
   i256(): bigint {
     const hi = this.#u128()
     const lo = this.#u128()
-    // sign-extend high 128 bits
     const raw = (hi << 128n) | lo
-    return hi < I128_SIGN_BIT ? raw : raw - (1n << 256n)
+    return raw < I256_SIGN_BIT ? raw : raw - I256_RANGE
   }
 
   /**

--- a/evm/evm-typegen/src/description.ts
+++ b/evm/evm-typegen/src/description.ts
@@ -53,33 +53,36 @@ export function describe(abi: Abi): Contract {
     const rawEvents = abi.filter((x) => x.type === 'event') as AbiEvent[]
     const rawFunctions = abi.filter((x) => x.type === 'function') as AbiFunction[]
 
-    // Overload index is computed across the concatenation of events and
-    // functions sharing a name (matches existing evm-typegen behavior).
+    // Events and functions share a name-space for overload numbering
+    // (matches existing evm-typegen behavior). The per-item overload
+    // index is its position among same-named siblings in `combined`.
     const combined: readonly (AbiEvent | AbiFunction)[] = [...rawEvents, ...rawFunctions]
-    const nameCounts: Record<string, number> = {}
-    for (const item of combined) nameCounts[item.name] = (nameCounts[item.name] || 0) + 1
-    const overloadIndex = (item: AbiEvent | AbiFunction): number =>
-        combined.filter((x) => x.name === item.name).findIndex((x) => x === item)
+    const nameCounts = new Map<string, number>()
+    const nameIndex = new Map<AbiEvent | AbiFunction, number>()
+    for (const item of combined) {
+        const seen = nameCounts.get(item.name) ?? 0
+        nameIndex.set(item, seen)
+        nameCounts.set(item.name, seen + 1)
+    }
+
+    const overloadedSuffix = (item: AbiEvent | AbiFunction, base: string): string => {
+        const count = nameCounts.get(item.name) ?? 1
+        return count > 1 ? `${base}_${nameIndex.get(item)}` : base
+    }
 
     const events: Event[] = rawEvents.map((e) => {
-        const overloaded = nameCounts[e.name] > 1
-        const idx = overloadIndex(e)
         const signature = eventSignature(e)
         return {
             name: e.name,
             signature,
             topic: `0x${keccak256(signature).toString('hex')}`,
             inputs: e.inputs.map((p, i) => toField(p, i, true)),
-            key: overloaded ? `${e.name}_${idx}` : e.name,
-            typeName: overloaded
-                ? `${capitalize(e.name)}EventArgs_${idx}`
-                : `${capitalize(e.name)}EventArgs`,
+            key: overloadedSuffix(e, e.name),
+            typeName: overloadedSuffix(e, `${capitalize(e.name)}EventArgs`),
         }
     })
 
     const functions: Function[] = rawFunctions.map((f) => {
-        const overloaded = nameCounts[f.name] > 1
-        const idx = overloadIndex(f)
         const signature = fnSignature(f)
         const kind: FunctionKind =
             f.stateMutability === 'view' || f.stateMutability === 'pure' ? 'viewFun' : 'fun'
@@ -90,13 +93,9 @@ export function describe(abi: Abi): Contract {
             kind,
             inputs: f.inputs.map((p, i) => toField(p, i, false)),
             outputs: (f.outputs ?? []).map((p, i) => toField(p, i, false)),
-            key: overloaded ? `${f.name}_${idx}` : f.name,
-            paramsTypeName: overloaded
-                ? `${capitalize(f.name)}Params_${idx}`
-                : `${capitalize(f.name)}Params`,
-            returnTypeName: overloaded
-                ? `${capitalize(f.name)}Return_${idx}`
-                : `${capitalize(f.name)}Return`,
+            key: overloadedSuffix(f, f.name),
+            paramsTypeName: overloadedSuffix(f, `${capitalize(f.name)}Params`),
+            returnTypeName: overloadedSuffix(f, `${capitalize(f.name)}Return`),
         }
     })
 
@@ -113,10 +112,9 @@ function toField(p: AbiParameter, index: number, isEventInput: boolean): Field {
 }
 
 function toType(p: AbiParameter): Type {
-    if (/\[\d+\]$/.test(p.type)) {
-        const m = p.type.match(/\[(\d+)\]$/)!
-        const size = Number(m[1])
-        return { kind: 'fixedArray', size, item: toType(stripOuterArray(p)) }
+    const fixed = p.type.match(/\[(\d+)\]$/)
+    if (fixed) {
+        return { kind: 'fixedArray', size: Number(fixed[1]), item: toType(stripOuterArray(p)) }
     }
     if (p.type.endsWith('[]')) {
         return { kind: 'array', item: toType(stripOuterArray(p)) }

--- a/evm/evm-typegen/src/typegen.ts
+++ b/evm/evm-typegen/src/typegen.ts
@@ -113,56 +113,54 @@ export class Typegen {
     }
 }
 
+const EVM_CODEC_MODULE = '@subsquid/evm-codec'
+const SUPPORT_MODULE = '../abi.support.js'
+
 class TypeModuleOutput extends FileOutput {
-    private evmCodec = new Set<Import>()
-    private support = new Set<Import>()
-    private moduleImports = new Map<string, Set<Import>>()
+    /**
+     * Per-module import buckets. Printed in insertion order, so seeding
+     * the map with `evm-codec` and `abi.support` up front gives us a
+     * stable import ordering at the top of the generated file.
+     */
+    private imports = new Map<string, Import[]>([
+        [EVM_CODEC_MODULE, []],
+        [SUPPORT_MODULE, []],
+    ])
 
     constructor(file: string) {
         super(file)
         this.lazy(() => {
-            this.printImports('@subsquid/evm-codec', this.evmCodec)
-            this.printImports('../abi.support.js', this.support)
-            for (const [from, imports] of this.moduleImports) {
-                this.printImports(from, imports)
+            let any = false
+            for (const [from, imps] of this.imports) {
+                if (this.printImports(from, imps)) any = true
             }
-            if (this.hasAnyImports()) {
-                this.line()
-            }
+            if (any) this.line()
         })
     }
 
-    private hasAnyImports(): boolean {
-        if (this.evmCodec.size > 0) return true
-        if (this.support.size > 0) return true
-        for (const imports of this.moduleImports.values()) {
-            if (imports.size > 0) return true
-        }
-        return false
-    }
-
     import(bucket: 'evmCodec' | 'support', name: string, alias?: string, type = false): void {
-        this[bucket].add({ name, alias, type })
+        const from = bucket === 'evmCodec' ? EVM_CODEC_MODULE : SUPPORT_MODULE
+        this.importFrom(from, { name, alias, type })
     }
 
     importFrom(from: string, imp: Import): void {
-        let s = this.moduleImports.get(from)
-        if (!s) {
-            s = new Set()
-            this.moduleImports.set(from, s)
+        let list = this.imports.get(from)
+        if (!list) {
+            list = []
+            this.imports.set(from, list)
         }
-        s.add(imp)
+        list.push(imp)
     }
 
-    private printImports(from: string, imports: Set<Import>): void {
-        if (imports.size === 0) return
+    private printImports(from: string, imports: Import[]): boolean {
+        if (imports.length === 0) return false
         const seen = new Set<string>()
         const values: Import[] = []
         const types: Import[] = []
         for (const imp of imports) {
-            const k = `${imp.type ? 't' : 'v'}:${imp.name}:${imp.alias || ''}`
-            if (seen.has(k)) continue
-            seen.add(k)
+            const key = `${imp.type ? 't' : 'v'}:${imp.name}:${imp.alias || ''}`
+            if (seen.has(key)) continue
+            seen.add(key)
             ;(imp.type ? types : values).push(imp)
         }
         const fmt = (list: Import[]) =>
@@ -172,6 +170,7 @@ class TypeModuleOutput extends FileOutput {
                 .join(', ')
         if (values.length > 0) this.line(`import { ${fmt(values)} } from '${from}'`)
         if (types.length > 0) this.line(`import type { ${fmt(types)} } from '${from}'`)
+        return values.length > 0 || types.length > 0
     }
 
     printEvent(e: Event): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Low-risk cleanup and refactoring pass over the files touched by the `evm-codec-impr` branch. No behavior changes; the existing vitest suites (`evm-codec`, `evm-abi`), the bench-based parity checks (`verify-abi`), and the end-to-end typegen output (byte-identical to what's already committed under `test/erc20-transfers/src/abi/erc20/*`) all pass.

### `evm-codec`

- **`sink.ts`** — `#oob` now reports the accepted `[min, max]` range, matching the contract the existing `sink.test.ts > number overflow` test already expects. That test was failing on the base branch before this change.
- **`src.ts`** — introduces explicit `I{64,128,256}_SIGN_BIT` / `I{64,128,256}_RANGE` constants and applies the same `raw < SIGN_BIT ? raw : raw - RANGE` shape uniformly in `i64` / `i128` / `i256`, replacing the ad-hoc inline `1n << 256n` subtraction in `i256`.
- **`codecs/primitives.ts`** — split the single `numericCodec` factory into two purpose-built factories, one per underlying `Sink`/`Src` method family:
  - `numberCodec('u8' | 'i8' | 'u16' | … | 'u32' | 'i32')` → `Codec<Numberish, number>`, encodes via `safeToNumber(val)`;
  - `bigintCodec('u64' | 'i64' | 'u128' | … | 'u256' | 'i256')` → `Codec<Numberish, bigint>`, encodes via `BigInt(val)`.

  Each factory is typed against the exact subset of methods its family implements, so the `(sink as any)[method]` cast is gone and the method name is checked at the call site. No more `'safeToNumber' | 'BigInt' | 'none'` discriminator and no ternary-chain on the hot path.

### `evm-abi`

- **`abi-components/event.ts`** — JIT builders repeated the `push name + push bound value` dance three different ways. Extracted a small `capture(names, values, name, value)` helper and named the `FieldOrder` shape so `createEncode` / `createDecode` bodies are shorter and easier to scan. Tightens `locateDecodeError` signature.
- **`abi-components/function.ts`** — `locateDecodeError` used to take a `make(src, i) => Error` callback that only ever produced a `FunctionCalldataDecodeError`. Dropped the callback and the now-unused `src` parameter; construct the error directly. Tightened `isCodec` / `locateResultError` types.

### `evm-typegen`

- **`description.ts`** — the previous `overloadIndex` helper did an O(n²) `combined.filter(...).findIndex(===)` per ABI item. Precompute both a `name → count` and an `item → index` map in one pass. A small `overloadedSuffix(item, base)` helper absorbs the four repeated `overloaded ? base_N : base` ternaries on both `Event` and `Function`. `toType` also folds the duplicated fixed-array `test()`+`match()` into a single `match()`.
- **`typegen.ts`** — replaced the two special-cased buckets (`evmCodec`, `support`) plus extra `moduleImports` map with a single insertion-ordered `Map<from, Import[]>` pre-seeded with those two well-known modules. Same output, much less bookkeeping; `hasAnyImports()` collapses into the same loop that prints imports.

### Verification

- `npm test` in `evm/evm-codec` — **32/32 pass** (previously 31/32 on the base branch because of the `sink.test.ts` overflow message).
- `npm test` in `evm/evm-abi` — 6/6 pass.
- `node lib/verify-abi.js` in `test/evm-codec-bench` — all 6 viem-parity checks pass.
- `node lib/bench.js` / `node lib/bench-abi.js` — still 1.2×–1.6× over the baseline, encode/decode parity OK on every scenario.
- Regenerated `squid-evm-typegen` output for a standard ERC-20 ABI `diff` is empty against the already-committed `test/erc20-transfers/src/abi/erc20/{events,functions,contract,index}.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fad6038a-caa5-435e-9a49-dc1ebdd2dfb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fad6038a-caa5-435e-9a49-dc1ebdd2dfb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

