### PR TITLE
[NET-486] [Alert gVynhU] moonriver-mainnet_Dumper_Pod_Restarts

### DIFF
--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -298,6 +298,7 @@ export class Rpc {
             validateResult: getResultValidator(nullable(array(nullable(Receipt)))),
             validateError: info => {
                 if (info.message.includes('invalid block height')) throw new RetryError() // Hyperliquid
+                if (info.code === -32603 && info.message.includes('substrate parent block hash')) throw new RetryError() // Dwellir/Substrate transient internal error
                 throw new RpcError(info)
             }
         })


### PR DESCRIPTION
Automated fix proposal for alert `gVynhU`.

- Alert: moonriver-mainnet_Dumper_Pod_Restarts
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/gVynhU`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/gVynhU/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: FINAL RESPONSE — moonriver-mainnet Dumper Pod Restarts (gVynhU)

   Fix class:        rca_fix
   Confidence:       medium
   Evidence basis:   logs, rpc, code
   Falsification:    next crash after deploy shows a different error on the
  same block range
   Follow-up:        F1 secondary endpoint deferred — needs org-approved
  Moonriver provider key

  Verdict: accept

  The implementer lane produced a complete, evidence-backed root-cause fix.

  ---------------------------------------------------------------------------

  Track A — Safe action now

  Merge a one-line code fix into evm/evm-rpc/src/rpc.ts (branch open-beta).

  Root cause chain [evidence]

   1. dump-moonriver-mainnet-0 (evm-archive): CrashLoopBackOff, 18 restarts,
  exit=1
   2. Crash: RpcError: Failed to retrieve substrate parent block hash (code
  -32603), method eth_getBlockReceipts, block 0xf82ab8, endpoint
  api-moonriver.n.dwellir.com
   3. addReceiptsByBlock.validateError in rpc.ts has no handler for -32603 →
  throw new RpcError(info) (unrecoverable) → crash loop
   4. RPC liveness verified: eth_blockNumber → 0xf82d51 ✅,
  eth_getBlockReceipts ["0xf82ab8"] → success ✅ — the -32603 was transient
   5. Single endpoint, no fallback (moonriver-mainnet.yaml)

  Proposed patch — addReceiptsByBlock.validateError (~line 300)

   // BEFORE
   validateError: info => {
       if (info.message.includes('invalid block height')) throw new
  RetryError() // Hyperliquid
       throw new RpcError(info)
   }

   // AFTER (+1 line)
   validateError: info => {
       if (info.message.includes('invalid block height')) throw new
  RetryError() // Hyperliquid
       if (info.code === -32603 && info.message.includes('substrate parent
  block hash')) throw new RetryError() // Dwellir/Substrate transient internal
   error
       throw new RpcError(info)
   }

  Proposed file: fixes/proposed/evm/evm-rpc/src/rpc.ts

  Success signal: pod exits CrashLoopBackOff, block counter advances past
  0xf82ab8, alert clears.

  Temporary mitigation (operator-only)

   kubectl delete pod dump-moonriver-mainnet-0 -n evm-archive

  Since block 0xf82ab8 now resolves on Dwellir, a fresh pod will self-heal —
  but remains vulnerable to the next transient Substrate error without the
  code fix.

  ---------------------------------------------------------------------------

  Track B — What we still need

   - Root cause confirmed. The -32603 unhandled error path is the sole crash
  trigger.
   - F1 (secondary endpoint) deferred — no org-approved Moonriver provider key
   exists in the infra repo; Alchemy Moonbeam key is not reusable for
  Moonriver. Requires procurement.

  Structural debt (do not PR)

   - moonriver-mainnet.yaml single endpoint; no fallback. Schedule a
  Moonriver-specific secondary key.
   - Other Substrate-based EVM networks (Moonbeam, Acala) on the same evm-dump
   version may be affected by the same unhandled -32603 — worth a follow-up
  audit.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** medium
- **Evidence basis:** logs, rpc, code
- **Falsification:** next crash after deploy shows a different error on the
- **Follow-up:** F1 secondary endpoint deferred — needs org-approved
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
FINAL RESPONSE — moonriver-mainnet Dumper Pod Restarts (gVynhU)

   Fix class:        rca_fix
   Confidence:       medium
   Evidence basis:   logs, rpc, code
   Falsification:    next crash after deploy shows a different error on the
  same block range
   Follow-up:        F1 secondary endpoint deferred — needs org-approved
  Moonriver provider key

  Verdict: accept

  The implementer lane produced a complete, evidence-backed root-cause fix.

  ---------------------------------------------------------------------------

  Track A — Safe action now

  Merge a one-line code fix into evm/evm-rpc/src/rpc.ts (branch open-beta).

  Root cause chain [evidence]

   1. dump-moonriver-mainnet-0 (evm-archive): CrashLoopBackOff, 18 restarts,
  exit=1
   2. Crash: RpcError: Failed to retrieve substrate parent block hash (code
  -32603), method eth_getBlockReceipts, block 0xf82ab8, endpoint
  api-moonriver.n.dwellir.com
   3. addReceiptsByBlock.validateError in rpc.ts has no handler for -32603 →
  throw new RpcError(info) (unrecoverable) → crash loop
   4. RPC liveness verified: eth_blockNumber → 0xf82d51 ✅,
  eth_getBlockReceipts ["0xf82ab8"] → success ✅ — the -32603 was transient
   5. Single endpoint, no fallback (moonriver-mainnet.yaml)

  Proposed patch — addReceiptsByBlock.validateError (~line 300)

   // BEFORE
   validateError: info => {
       if (info.message.includes('invalid block height')) throw new
  RetryError() // Hyperliquid
       throw new RpcError(info)
   }

   // AFTER (+1 line)
   validateError: info => {
       if (info.message.includes('invalid block height')) throw new
  RetryError() // Hyperliquid
       if (info.code === -32603 && info.message.includes('substrate parent
  block hash')) throw new RetryError() // Dwellir/Substrate transient internal
   error
       throw new RpcError(info)
   }

  Proposed file: fixes/proposed/evm/evm-rpc/src/rpc.ts

  Success signal: pod exits CrashLoopBackOff, block counter advances past
  0xf82ab8, alert clears.

  Temporary mitigation (operator-only)

   kubectl delete pod dump-moonriver-mainnet-0 -n evm-archive

  Since block 0xf82ab8 now resolves on Dwellir, a fresh pod will self-heal —
  but remains vulnerable to the next transient Substrate error without the
  code fix.

  ---------------------------------------------------------------------------

  Track B — What we still need

   - Root cause confirmed. The -32603 unhandled error path is the sole crash
  trigger.
   - F1 (secondary endpoint) deferred — no org-approved Moonriver provider key
   exists in the infra repo; Alchemy Moonbeam key is not reusable for
  Moonriver. Requires procurement.

  Structural debt (do not PR)

   - moonriver-mainnet.yaml single endpoint; no fallback. Schedule a
  Moonriver-specific secondary key.
   - Other Substrate-based EVM networks (Moonbeam, Acala) on the same evm-dump
   version may be affected by the same unhandled -32603 — worth a follow-up
  audit.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/rpc.ts`

## Notify
cc @tmcgroul (automation opened this PR.)