### PR TITLE
Feat/evm stream drop default fields

### DIFF
--- a/common/changes/@subsquid/evm-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/evm-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
-      "type": "none",
+      "type": "minor",
       "packageName": "@subsquid/evm-stream"
     }
   ],

--- a/common/changes/@subsquid/evm-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/evm-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
+      "type": "none",
+      "packageName": "@subsquid/evm-stream"
+    }
+  ],
+  "packageName": "@subsquid/evm-stream",
+  "email": "abernatskiy@toha.li"
+}

--- a/common/changes/@subsquid/fuel-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/fuel-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
+      "type": "none",
+      "packageName": "@subsquid/fuel-stream"
+    }
+  ],
+  "packageName": "@subsquid/fuel-stream",
+  "email": "abernatskiy@toha.li"
+}

--- a/common/changes/@subsquid/fuel-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/fuel-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
-      "type": "none",
+      "type": "minor",
       "packageName": "@subsquid/fuel-stream"
     }
   ],

--- a/common/changes/@subsquid/solana-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/solana-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
+      "type": "none",
+      "packageName": "@subsquid/solana-stream"
+    }
+  ],
+  "packageName": "@subsquid/solana-stream",
+  "email": "abernatskiy@toha.li"
+}

--- a/common/changes/@subsquid/solana-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/solana-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
-      "type": "none",
+      "type": "minor",
       "packageName": "@subsquid/solana-stream"
     }
   ],

--- a/common/changes/@subsquid/starknet-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/starknet-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
+      "type": "none",
+      "packageName": "@subsquid/starknet-stream"
+    }
+  ],
+  "packageName": "@subsquid/starknet-stream",
+  "email": "abernatskiy@toha.li"
+}

--- a/common/changes/@subsquid/starknet-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
+++ b/common/changes/@subsquid/starknet-stream/feat-evm-stream-drop-default-fields_2026-05-13-19-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Drop DEFAULT_FIELDS; .setFields() is now the sole source of selected fields",
-      "type": "none",
+      "type": "minor",
       "packageName": "@subsquid/starknet-stream"
     }
   ],

--- a/evm/evm-stream/src/builder.ts
+++ b/evm/evm-stream/src/builder.ts
@@ -1,7 +1,7 @@
 import {PortalClient, type PortalClientOptions} from '@subsquid/portal-client'
 import {type Range, type RangeRequest, type RangeRequestList, applyRangeBound, mergeRangeRequests} from '@subsquid/util-internal-range'
 import assert from 'assert'
-import {DEFAULT_FIELDS, type FieldSelection} from './data/model'
+import type {FieldSelection} from './data/model'
 import type {DataRequest, LogRequest, StateDiffRequest, TraceRequest, TransactionRequest} from './data/request'
 import {PortalEvmDataSource} from './portal/source'
 import {type Query, QueryBuilder} from './query'
@@ -11,7 +11,7 @@ interface BlockRange {
     range?: Range
 }
 
-export class DataSourceBuilder<F extends FieldSelection = typeof DEFAULT_FIELDS> {
+export class DataSourceBuilder<F extends FieldSelection = {}> {
     private requests: RangeRequest<DataRequest>[] = []
     private fields?: FieldSelection
     private blockRange?: Range
@@ -163,6 +163,6 @@ export class DataSourceBuilder<F extends FieldSelection = typeof DEFAULT_FIELDS>
         assert(this.portal, 'Portal settings not set')
 
         let portal = this.portal instanceof PortalClient ? this.portal : new PortalClient(this.portal)
-        return new PortalEvmDataSource<F>(portal, (this.fields ?? DEFAULT_FIELDS) as F, this.getRequests())
+        return new PortalEvmDataSource<F>(portal, (this.fields ?? {}) as F, this.getRequests())
     }
 }

--- a/evm/evm-stream/src/data/model.ts
+++ b/evm/evm-stream/src/data/model.ts
@@ -50,35 +50,6 @@ export interface FieldSelection {
 export type FieldKey = keyof FieldSelection
 
 /**
- * Default field set applied when {@link DataSourceBuilder#setFields} is not
- * called.  `as const` preserves the literal `true` values so they feed through
- * {@link GetFields} correctly.
- */
-export const DEFAULT_FIELDS = {
-    block: {
-        timestamp: true,
-    },
-    log: {
-        address: true,
-        topics: true,
-        data: true,
-    },
-    transaction: {
-        from: true,
-        to: true,
-        hash: true,
-    },
-    trace: {
-        error: true,
-    },
-    stateDiff: {
-        kind: true,
-        next: true,
-        prev: true,
-    },
-} as const satisfies FieldSelection
-
-/**
  * A concrete item type derived from a raw data shape, the always-present
  * required keys, and a per-section field selection.
  */

--- a/fuel/fuel-stream/src/data/model.ts
+++ b/fuel/fuel-stream/src/data/model.ts
@@ -37,23 +37,6 @@ export interface FieldSelection {
 }
 
 
-export const DEFAULT_FIELDS = {
-    block: {
-        time: true
-    },
-    transaction: {
-        hash: true,
-        type: true,
-        status: true
-    },
-    receipt: {
-        receiptType: true
-    },
-    input: {},
-    output: {},
-} as const
-
-
 type Item<
     Data,
     RequiredFields extends keyof Data,
@@ -61,7 +44,7 @@ type Item<
     K extends keyof FieldSelection
 > = Simplify<
     Pick<Data, RequiredFields> &
-    Select<Data, GetFields<FieldSelection, typeof DEFAULT_FIELDS, F, K>>
+    Select<Data, GetFields<FieldSelection, F, K>>
 >
 
 

--- a/fuel/fuel-stream/src/data/util.ts
+++ b/fuel/fuel-stream/src/data/util.ts
@@ -3,22 +3,11 @@ export type Simplify<T> = {
 } & {}
 
 
-export type ExcludeUndefined<T> = {
-    [K in keyof T as undefined extends T[K] ? never : K]: T[K]
-} & {}
-
-
 export type GetFields<
     FieldSelectionType,
-    Defaults extends FieldSelectionType,
     Selection extends FieldSelectionType,
     K extends keyof FieldSelectionType
-> = TrueFields<MergeDefault<Selection[K], Defaults[K]>>
-
-
-type MergeDefault<T, D> = Simplify<
-    undefined extends T ? D : Omit<D, keyof ExcludeUndefined<T>> & ExcludeUndefined<T>
->
+> = TrueFields<Selection[K]>
 
 
 export type TrueFields<F> = keyof {

--- a/fuel/fuel-stream/src/fields.ts
+++ b/fuel/fuel-stream/src/fields.ts
@@ -1,35 +1,9 @@
-import {DEFAULT_FIELDS, FieldSelection} from './data/model'
-import {Selector} from './data/util'
+import {FieldSelection} from './data/model'
 
 
 /**
  * Get effective set of selected fields.
  */
 export function getFields(fields: FieldSelection | undefined): FieldSelection {
-    return {
-        block: merge(DEFAULT_FIELDS.block, fields?.block),
-        transaction: merge(DEFAULT_FIELDS.transaction, fields?.transaction),
-        receipt: merge(DEFAULT_FIELDS.receipt, fields?.receipt),
-        input: merge(DEFAULT_FIELDS.input, fields?.input),
-        output: merge(DEFAULT_FIELDS.output, fields?.output),
-    }
-}
-
-
-function merge<Keys extends string>(def: Selector<Keys>, requested: Selector<Keys> = {}): Selector<Keys> {
-    let fields: Selector<Keys> = {}
-
-    for (let key in def) {
-        if (requested[key] !== false) {
-            fields[key] = def[key]
-        }
-    }
-
-    for (let key in requested) {
-        if (requested[key]) {
-            fields[key] = true
-        }
-    }
-
-    return fields
+    return fields ?? {}
 }

--- a/solana/solana-stream/src/builder.ts
+++ b/solana/solana-stream/src/builder.ts
@@ -2,7 +2,7 @@ import {PortalClient, PortalClientOptions} from '@subsquid/portal-client'
 import {getOrGenerateSquidId} from '@subsquid/util-internal-processor-tools'
 import {applyRangeBound, mergeRangeRequests, Range, RangeRequest, RangeRequestList} from '@subsquid/util-internal-range'
 import assert from 'assert'
-import {DEFAULT_FIELDS, FieldSelection} from './data/model'
+import {FieldSelection} from './data/model'
 import {
     BalanceRequest,
     DataRequest,
@@ -20,7 +20,7 @@ interface BlockRange {
     range?: Range
 }
 
-export class DataSourceBuilder<F extends FieldSelection = typeof DEFAULT_FIELDS> {
+export class DataSourceBuilder<F extends FieldSelection = {}> {
     private requests: RangeRequest<DataRequest>[] = []
     private fields?: FieldSelection
     private blockRange?: Range
@@ -198,7 +198,7 @@ export class DataSourceBuilder<F extends FieldSelection = typeof DEFAULT_FIELDS>
         assert(this.portal, 'Portal settings not set')
 
         let portal = this.portal instanceof PortalClient ? this.portal : new PortalClient(this.portal)
-        return new PortalSolanaDataSource<F>(portal, this.fields ?? DEFAULT_FIELDS, () => this.getRequests(), {
+        return new PortalSolanaDataSource<F>(portal, (this.fields ?? {}) as F, () => this.getRequests(), {
             squidId: getOrGenerateSquidId(),
         })
     }

--- a/solana/solana-stream/src/data/model.ts
+++ b/solana/solana-stream/src/data/model.ts
@@ -33,50 +33,6 @@ export interface FieldSelection {
 export type FieldKey = keyof FieldSelection
 
 /**
- * Default field set applied when {@link DataSourceBuilder#setFields} is not
- * called.  `as const` preserves the literal `true` values so they feed through
- * {@link GetFields} correctly.
- */
-export const DEFAULT_FIELDS = {
-    block: {
-        timestamp: true,
-    },
-    transaction: {
-        signatures: true,
-        err: true,
-    },
-    instruction: {
-        programId: true,
-        accounts: true,
-        data: true,
-        isCommitted: true,
-    },
-    log: {
-        programId: true,
-        kind: true,
-        message: true,
-    },
-    balance: {
-        pre: true,
-        post: true,
-    },
-    tokenBalance: {
-        preMint: true,
-        preDecimals: true,
-        preOwner: true,
-        preAmount: true,
-        postMint: true,
-        postDecimals: true,
-        postOwner: true,
-        postAmount: true,
-    },
-    reward: {
-        lamports: true,
-        rewardType: true,
-    },
-} as const satisfies FieldSelection
-
-/**
  * A concrete item type derived from a raw data shape, the always-present
  * required keys, and a per-section field selection.
  */

--- a/starknet/starknet-stream/src/data/model.ts
+++ b/starknet/starknet-stream/src/data/model.ts
@@ -15,14 +15,6 @@ export interface FieldSelection {
     event?: Selector<Exclude<keyof data.Event, EventRequiredFields>>
 }
 
-export const DEFAULT_FIELDS = {
-    block: {
-        timestamp: true
-    },
-    transaction: {},
-    event: {}
-} as const
-
 type Item<
     Data,
     RequiredFields extends keyof Data,
@@ -30,7 +22,7 @@ type Item<
     K extends keyof FieldSelection
 > = Simplify<
     Pick<Data, RequiredFields> &
-    Select<Data, GetFields<FieldSelection, typeof DEFAULT_FIELDS, F, K>>
+    Select<Data, GetFields<FieldSelection, F, K>>
 >
 
 export type BlockHeader<F extends FieldSelection = {}> = Item<

--- a/starknet/starknet-stream/src/data/util.ts
+++ b/starknet/starknet-stream/src/data/util.ts
@@ -3,22 +3,11 @@ export type Simplify<T> = {
 } & {}
 
 
-export type ExcludeUndefined<T> = {
-    [K in keyof T as undefined extends T[K] ? never : K]: T[K]
-} & {}
-
-
 export type GetFields<
     FieldSelectionType,
-    Defaults extends FieldSelectionType,
     Selection extends FieldSelectionType,
     K extends keyof FieldSelectionType
-> = TrueFields<MergeDefault<Selection[K], Defaults[K]>>
-
-
-type MergeDefault<T, D> = Simplify<
-    undefined extends T ? D : Omit<D, keyof ExcludeUndefined<T>> & ExcludeUndefined<T>
->
+> = TrueFields<Selection[K]>
 
 
 export type TrueFields<F> = keyof {

--- a/starknet/starknet-stream/src/fields.ts
+++ b/starknet/starknet-stream/src/fields.ts
@@ -1,33 +1,9 @@
-import {DEFAULT_FIELDS, FieldSelection} from './data/model'
-import {Selector} from './data/util'
+import {FieldSelection} from './data/model'
 
 
 /**
  * Get effective set of selected fields.
  */
 export function getFields(fields: FieldSelection | undefined): FieldSelection {
-    return {
-        block: merge(DEFAULT_FIELDS.block, fields?.block),
-        transaction: merge(DEFAULT_FIELDS.transaction, fields?.transaction),
-        event: merge(DEFAULT_FIELDS.event, fields?.event)
-    }
-}
-
-
-function merge<Keys extends string>(def: Selector<Keys>, requested: Selector<Keys> = {}): Selector<Keys> {
-    let fields: Selector<Keys> = {}
-
-    for (let key in def) {
-        if (requested[key] !== false) {
-            fields[key] = def[key]
-        }
-    }
-
-    for (let key in requested) {
-        if (requested[key]) {
-            fields[key] = true
-        }
-    }
-
-    return fields
+    return fields ?? {}
 }


### PR DESCRIPTION
The new semantics (.setFields replaces the field assignment) is unusable and we cannot revert to the old SDK 1.0 semantics, so we're switching to requesting all fields explicitly
