### PR TITLE
[NET-489] [Alert RWmDD4] uniblock_hyperliquid-mainnet_Hotblocks_Critical_Lag

### DIFF
--- a/evm/evm-rpc/src/chain-utils.ts
+++ b/evm/evm-rpc/src/chain-utils.ts
@@ -112,7 +112,11 @@ export class ChainUtils {
             let transactions = block.transactions as Transaction[]
             let txByHash = new Map(transactions.map(tx => [getTxHash(tx), tx]))
             logs = logs.filter(log => {
-                let tx = assertNotNull(txByHash.get(log.transactionHash))
+                let tx = txByHash.get(log.transactionHash)
+                // Hyperliquid can produce logs whose transactionHash references a system
+                // transaction that is absent from block.transactions. Treat those as
+                // system-tx logs and filter them out rather than asserting non-null.
+                if (tx == null) return false
                 return !isHyperliquidSystemTx(tx)
             })
         }


### PR DESCRIPTION
Automated fix proposal for alert `RWmDD4`.

- Alert: uniblock_hyperliquid-mainnet_Hotblocks_Critical_Lag
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/RWmDD4`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/RWmDD4/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: implementer:

● Find proposed fix files (shell)
  │ find /root/alert/incident-agent/agent-system/data/investigations/RWmDD4
  │ -path "*/fixes/proposed*" 2>/dev/null | head -20
  └ 6 lines...

● Read chain-utils.ts
  │ data/investigations/RWmDD4/fixes/proposed/evm/evm-rpc/src/chain-utils.ts
  └ L100:135 (36 lines read)

● All evidence verified. Now writing the final response:

● Write FINAL_RESPONSE.md (shell)
  │ cat > /root/alert/incident-agent/agent-system/data/investigations/RWmDD4/t
  │ erminal_debate/RWmDD4__terminal_debate__20260514_084243/FINAL_RESPONSE.md
  │ << 'EOF'
  │ # FINAL RESPONSE — uniblock_hyperliquid-mainnet_Hotblocks_Critical_Lag
  │ (RWmDD4)…
  └ 143 lines...

● Print FINAL_RESPONSE.md (shell)
  │ cat /root/alert/incident-agent/agent-system/data/investigations/RWmDD4/termi
  │ nal_debate/RWmDD4__terminal_debate__20260514_084243/FINAL_RESPONSE.md
  └ 94 lines...

● Verdict: accept — the claude implementer's fix is correct and complete.

  Summary:

   - Root cause confirmed [evidence]: Deterministic AssertionError in
  calculateLogsBloom (chain-utils.ts Hyperliquid branch, line 115) —
  txByHash.get(log.transactionHash) returns undefined when Hyperliquid emits
  receipt logs for hidden system transactions absent from block.transactions.
  Pod crashes every ~30 s at block 35068135; blockAge spikes 100–160 s past
  the 60 s alert threshold.
   - Fix [evidence]: Replace assertNotNull(txByHash.get(...)) with a null-safe
   guard that returns false (filter out the log) when the tx is not found.
  Proposed patch is at fixes/proposed/evm/evm-rpc/src/chain-utils.ts, ready to
   PR against subsquid/squid-sdk branch open-beta.
   - Rejected config changes [memory:8LVGbY]: verify_logs_bloom: false /
  batch-limit tuning in uniblock.yaml — maintainer explicitly rejected this
  approach on identical prior incident PR #408.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, code
- **Falsification:** if logs show the AssertionError stops and blockAge drops below 60s after deploy, this fix is confirmed; if it throws elsewhere in the same code path on a different block, a broader pattern exists
- **Follow-up:** none — root cause is deterministic and confirmed by live pod logs at block 35068135
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
implementer:

● Find proposed fix files (shell)
  │ find /root/alert/incident-agent/agent-system/data/investigations/RWmDD4
  │ -path "*/fixes/proposed*" 2>/dev/null | head -20
  └ 6 lines...

● Read chain-utils.ts
  │ data/investigations/RWmDD4/fixes/proposed/evm/evm-rpc/src/chain-utils.ts
  └ L100:135 (36 lines read)

● All evidence verified. Now writing the final response:

● Write FINAL_RESPONSE.md (shell)
  │ cat > /root/alert/incident-agent/agent-system/data/investigations/RWmDD4/t
  │ erminal_debate/RWmDD4__terminal_debate__20260514_084243/FINAL_RESPONSE.md
  │ << 'EOF'
  │ # FINAL RESPONSE — uniblock_hyperliquid-mainnet_Hotblocks_Critical_Lag
  │ (RWmDD4)…
  └ 143 lines...

● Print FINAL_RESPONSE.md (shell)
  │ cat /root/alert/incident-agent/agent-system/data/investigations/RWmDD4/termi
  │ nal_debate/RWmDD4__terminal_debate__20260514_084243/FINAL_RESPONSE.md
  └ 94 lines...

● Verdict: accept — the claude implementer's fix is correct and complete.

  Summary:

   - Root cause confirmed [evidence]: Deterministic AssertionError in
  calculateLogsBloom (chain-utils.ts Hyperliquid branch, line 115) —
  txByHash.get(log.transactionHash) returns undefined when Hyperliquid emits
  receipt logs for hidden system transactions absent from block.transactions.
  Pod crashes every ~30 s at block 35068135; blockAge spikes 100–160 s past
  the 60 s alert threshold.
   - Fix [evidence]: Replace assertNotNull(txByHash.get(...)) with a null-safe
   guard that returns false (filter out the log) when the tx is not found.
  Proposed patch is at fixes/proposed/evm/evm-rpc/src/chain-utils.ts, ready to
   PR against subsquid/squid-sdk branch open-beta.
   - Rejected config changes [memory:8LVGbY]: verify_logs_bloom: false /
  batch-limit tuning in uniblock.yaml — maintainer explicitly rejected this
  approach on identical prior incident PR #408.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/chain-utils.ts`

## Notify
cc @tmcgroul (automation opened this PR.)