### PR TITLE
[NET-495] [Alert kEOeBU] moonriver-mainnet_No_Dumper_Data

### DIFF
--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -298,6 +298,7 @@ export class Rpc {
             validateResult: getResultValidator(nullable(array(nullable(Receipt)))),
             validateError: info => {
                 if (info.message.includes('invalid block height')) throw new RetryError() // Hyperliquid
+                if (info.code === -32603 && info.message.includes('substrate parent block hash')) throw new RetryError() // Dwellir/Substrate transient internal error
                 throw new RpcError(info)
             }
         })


### PR DESCRIPTION
Automated fix proposal for alert `kEOeBU`.

- Alert: moonriver-mainnet_No_Dumper_Data
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/kEOeBU`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/kEOeBU/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: Verdict: accept — root cause confirmed, fix ready to merge.
  Fix metadata

   Fix class:        rca_fix
   Confidence:       high
   Evidence basis:   logs, code, env_profile
   Falsification:    If fresh pod logs show a different error code/class
   Follow-up:        Merge PR #472 → rebuild image → ArgoCD sync → alert
  clears
  Summary

  The implementer's analysis is correct and complete. Key evidence:

   - Pod state [evidence]: dump-moonriver-mainnet-0 in evm-archive —
  phase=Running but container=CrashLoopBackOff, restart_count=294,
  exit_code=1, last terminated 2026-05-14T15:49:48Z
   - Bug [evidence]: rpc.ts (open-beta, addReceiptsByBlock.validateError) only
   guards invalid block height; no guard for code -32603 — confirmed by code
  diff
   - Crash trigger [memory:gVynhU]: Dwellir Moonriver returns -32603 / "Failed
   to retrieve substrate parent block hash" on eth_getBlockReceipts → falls
  through to throw new RpcError(info) → unrecoverable exit
   - PR #472 [evidence]: state=OPEN, mergedAt=null — fix not yet merged or
  deployed; running image unchanged (subsquid/evm-dump:7483a774)

  Proposed fix (one line, fixes/proposed/evm/evm-rpc/src/rpc.ts):

   if (info.code === -32603 && info.message.includes('substrate parent block
  hash')) throw new RetryError() // Dwellir/Substrate transient

  Temporary mitigation (operator-gated, not the fix):

   kubectl delete pod dump-moonriver-mainnet-0 -n evm-archive

  Next steps: Merge PR #472 → rebuild subsquid/evm-dump image → ArgoCD sync →
  confirm restarts plateau and alert clears.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, code, env_profile
- **Falsification:** If fresh pod logs show a different error code/class
- **Follow-up:** Merge PR #472 → rebuild image → ArgoCD sync → alert
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
Verdict: accept — root cause confirmed, fix ready to merge.
  Fix metadata

   Fix class:        rca_fix
   Confidence:       high
   Evidence basis:   logs, code, env_profile
   Falsification:    If fresh pod logs show a different error code/class
   Follow-up:        Merge PR #472 → rebuild image → ArgoCD sync → alert
  clears
  Summary

  The implementer's analysis is correct and complete. Key evidence:

   - Pod state [evidence]: dump-moonriver-mainnet-0 in evm-archive —
  phase=Running but container=CrashLoopBackOff, restart_count=294,
  exit_code=1, last terminated 2026-05-14T15:49:48Z
   - Bug [evidence]: rpc.ts (open-beta, addReceiptsByBlock.validateError) only
   guards invalid block height; no guard for code -32603 — confirmed by code
  diff
   - Crash trigger [memory:gVynhU]: Dwellir Moonriver returns -32603 / "Failed
   to retrieve substrate parent block hash" on eth_getBlockReceipts → falls
  through to throw new RpcError(info) → unrecoverable exit
   - PR #472 [evidence]: state=OPEN, mergedAt=null — fix not yet merged or
  deployed; running image unchanged (subsquid/evm-dump:7483a774)

  Proposed fix (one line, fixes/proposed/evm/evm-rpc/src/rpc.ts):

   if (info.code === -32603 && info.message.includes('substrate parent block
  hash')) throw new RetryError() // Dwellir/Substrate transient

  Temporary mitigation (operator-gated, not the fix):

   kubectl delete pod dump-moonriver-mainnet-0 -n evm-archive

  Next steps: Merge PR #472 → rebuild subsquid/evm-dump image → ArgoCD sync →
  confirm restarts plateau and alert clears.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/rpc.ts`

## Notify
cc @tmcgroul (automation opened this PR.)