### PR TITLE
[NET-499] [Alert rPA4rP] uniblock_hyperliquid-mainnet_Hotblocks_Critical_Lag

### DIFF
--- a/evm/evm-rpc/src/chain-utils.ts
+++ b/evm/evm-rpc/src/chain-utils.ts
@@ -112,7 +112,9 @@ export class ChainUtils {
             let transactions = block.transactions as Transaction[]
             let txByHash = new Map(transactions.map(tx => [getTxHash(tx), tx]))
             logs = logs.filter(log => {
-                let tx = assertNotNull(txByHash.get(log.transactionHash))
+                let tx = txByHash.get(log.transactionHash)
+                // System txs are absent from block.transactions; treat their logs as system logs
+                if (tx == null) return false
                 return !isHyperliquidSystemTx(tx)
             })
         }


### PR DESCRIPTION
Automated fix proposal for alert `rPA4rP`.

- Alert: uniblock_hyperliquid-mainnet_Hotblocks_Critical_Lag
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/rPA4rP`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/rPA4rP/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: (rPA4rP)

   Fix class:        rca_fix
   Confidence:       high
   Evidence basis:   logs, code
   Falsification:    if the null-guard patch does NOT clear the restart loop,
  the
                     uniblock RPC has a distinct data issue beyond the
  system-tx pattern
   Follow-up:        confirm dwellir doesn't eventually crash at a later
  system-tx block;
                     monitor uniblock lag after SDK deploy

  Verdict: accept — the implementer's SDK patch is correct and directly
  verified against live pod logs. Claude lane was degraded (usage limit $0);
  all evidence was collected via the copilot lane.
  Track A — Safe action now

  Root-cause fix: PR on squid-sdk branch open-beta, file
  evm/evm-rpc/src/chain-utils.ts:

        if (this.isHyperliquidMainnet || this.isHyperliquidTestnet) {
            let transactions = block.transactions as Transaction[]
            let txByHash = new Map(transactions.map(tx => [getTxHash(tx),
  tx]))
            logs = logs.filter(log => {
   -            let tx = assertNotNull(txByHash.get(log.transactionHash))
   -            return !isHyperliquidSystemTx(tx)
   +            let tx = txByHash.get(log.transactionHash)
   +            // System txs are absent from block.transactions; treat their
  logs as system logs
   +            if (tx == null) return false
   +            return !isHyperliquidSystemTx(tx)
            })
        }

  Patch is already written to fixes/proposed/evm/evm-rpc/src/chain-utils.ts.

  Stopgap (operator-gated, while PR is reviewed): set verify_logs_bloom: false
  in uniblock.yaml to unblock the lag. Revert once SDK fix is deployed.
  Track B — Root cause confirmed

   - [evidence] Uniblock pod: Running, restart_count=0 (k8s), but in tight
  app-level retry loop — AssertionError at chain-utils.js:80 /
  calculateLogsBloom, repeating every few seconds in logs
   - [evidence] Exact stack: assertNotNull(txByHash.get(log.transactionHash))
  → undefined → throws. Uniblock's RPC returns logs whose transactionHash
  references system txs absent from block.transactions
   - [evidence] Dwellir pod: healthy, progressed to block 35157398
  (blockAge=725) — Dwellir's RPC doesn't expose these system-tx logs
   - [evidence] No SDK null-guard merged; last chain-utils.ts commits
  (2026-04-16) were Cronos-only
   - [memory:8LVGbY] Same crash class, same file/line, same network —
  maintainer confirmed infra-only tuning "won't help"

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, code
- **Falsification:** if the null-guard patch does NOT clear the restart loop,
- **Follow-up:** confirm dwellir doesn't eventually crash at a later
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
(rPA4rP)

   Fix class:        rca_fix
   Confidence:       high
   Evidence basis:   logs, code
   Falsification:    if the null-guard patch does NOT clear the restart loop,
  the
                     uniblock RPC has a distinct data issue beyond the
  system-tx pattern
   Follow-up:        confirm dwellir doesn't eventually crash at a later
  system-tx block;
                     monitor uniblock lag after SDK deploy

  Verdict: accept — the implementer's SDK patch is correct and directly
  verified against live pod logs. Claude lane was degraded (usage limit $0);
  all evidence was collected via the copilot lane.
  Track A — Safe action now

  Root-cause fix: PR on squid-sdk branch open-beta, file
  evm/evm-rpc/src/chain-utils.ts:

        if (this.isHyperliquidMainnet || this.isHyperliquidTestnet) {
            let transactions = block.transactions as Transaction[]
            let txByHash = new Map(transactions.map(tx => [getTxHash(tx),
  tx]))
            logs = logs.filter(log => {
   -            let tx = assertNotNull(txByHash.get(log.transactionHash))
   -            return !isHyperliquidSystemTx(tx)
   +            let tx = txByHash.get(log.transactionHash)
   +            // System txs are absent from block.transactions; treat their
  logs as system logs
   +            if (tx == null) return false
   +            return !isHyperliquidSystemTx(tx)
            })
        }

  Patch is already written to fixes/proposed/evm/evm-rpc/src/chain-utils.ts.

  Stopgap (operator-gated, while PR is reviewed): set verify_logs_bloom: false
  in uniblock.yaml to unblock the lag. Revert once SDK fix is deployed.
  Track B — Root cause confirmed

   - [evidence] Uniblock pod: Running, restart_count=0 (k8s), but in tight
  app-level retry loop — AssertionError at chain-utils.js:80 /
  calculateLogsBloom, repeating every few seconds in logs
   - [evidence] Exact stack: assertNotNull(txByHash.get(log.transactionHash))
  → undefined → throws. Uniblock's RPC returns logs whose transactionHash
  references system txs absent from block.transactions
   - [evidence] Dwellir pod: healthy, progressed to block 35157398
  (blockAge=725) — Dwellir's RPC doesn't expose these system-tx logs
   - [evidence] No SDK null-guard merged; last chain-utils.ts commits
  (2026-04-16) were Cronos-only
   - [memory:8LVGbY] Same crash class, same file/line, same network —
  maintainer confirmed infra-only tuning "won't help"

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/chain-utils.ts`

## Notify
cc @tmcgroul (automation opened this PR.)