### PR TITLE
[NET-568] [Alert lfdaVK] binance-mainnet_Writer_Short_Stall

### DIFF
--- a/evm/evm-normalization/src/data.ts
+++ b/evm/evm-normalization/src/data.ts
@@ -221,7 +221,7 @@ export interface TraceCreateResult {
 
 export interface TraceCallAction {
     from: Bytes20,
-    to: Bytes20,
+    to?: Bytes20,
     value?: Qty,
     gas: Qty,
     input: Bytes,

--- a/evm/evm-normalization/src/mapping.ts
+++ b/evm/evm-normalization/src/mapping.ts
@@ -103,8 +103,7 @@ function* mapDebugFrame(
             case 'CALLCODE':
             case 'DELEGATECALL':
             case 'delegateCall':
-            case 'STATICCALL':
-            case 'INVALID': {
+            case 'STATICCALL': {
                 trace = {
                     ...base,
                     type: 'call',
@@ -112,6 +111,34 @@ function* mapDebugFrame(
                         callType: frame.type.toLowerCase(),
                         from: frame.from.toLowerCase(),
                         to: assertNotNull(frame.to).toLowerCase(),
+                        value: frame.value ?? undefined,
+                        gas: frame.gas,
+                        input: frame.input,
+                    }
+                }
+
+                let result: Partial<TraceCallResult> = {}
+                if (frame.gasUsed) {
+                    result.gasUsed = frame.gasUsed
+                }
+                if (frame.output) {
+                    result.output = frame.output
+                }
+                if (!isEmpty(result)) {
+                    trace.result = result
+                }
+                break
+            }
+            case 'INVALID': {
+                // INVALID opcode traces may have a null `to` (e.g. Solidity assert() failures).
+                // Handle separately so assertNotNull(frame.to) in the CALL branch is not triggered.
+                trace = {
+                    ...base,
+                    type: 'call',
+                    action: {
+                        callType: 'invalid',
+                        from: frame.from.toLowerCase(),
+                        to: frame.to ? frame.to.toLowerCase() : undefined,
                         value: frame.value ?? undefined,
                         gas: frame.gas,
                         input: frame.input,


### PR DESCRIPTION
Automated fix proposal for alert `lfdaVK`.

- Alert: binance-mainnet_Writer_Short_Stall
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/lfdaVK`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/lfdaVK/report.html`

## Reviewer quick view
- Scope: 2 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: Verdict: accept

  Root cause confirmed [evidence]: BNB block 99,335,053 contains an INVALID-opcode trace with
  frame.to == null. In mapping.ts (squid-sdk open-beta), case 'INVALID': falls through to the CALL
  branch which calls assertNotNull(frame.to) → AssertionError → dump HTTP 500 → ingest retries every
   5s forever → stall alert.

  Two proposed fixes are correct and complete:

   1. Code fix (root cause) — mapping.ts: break INVALID out of the CALL fall-through, use frame.to ?
   frame.to.toLowerCase() : undefined (same pattern as the SELFDESTRUCT fix at line 160). Also
  data.ts: TraceCallAction.to: Bytes20 → to?: Bytes20 (required for TypeScript correctness).
   2. Temporary mitigation — binance-mainnet.yaml: traces: false unblocks ingest immediately;
  labeled temporary with a revert checklist (merge fix → build image → re-enable traces).

  The implementer lane produced clean, minimal artifacts with no probe changes, no pod restarts, and
   no speculative RPC swaps — all correct.

## Fix metadata
- **Fix class:** rca_fix (mapping.ts + data.ts) + mitigation (binance-mainnet.yaml)
- **Confidence:** high
- **Evidence basis:** logs, code
- **Falsification:** If BNB block 99,335,053 processes without AssertionError after patching,
- **Follow-up:** Re-enable traces: true in binance-mainnet.yaml once patched image is deployed.
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
Verdict: accept

  Root cause confirmed [evidence]: BNB block 99,335,053 contains an INVALID-opcode trace with
  frame.to == null. In mapping.ts (squid-sdk open-beta), case 'INVALID': falls through to the CALL
  branch which calls assertNotNull(frame.to) → AssertionError → dump HTTP 500 → ingest retries every
   5s forever → stall alert.

  Two proposed fixes are correct and complete:

   1. Code fix (root cause) — mapping.ts: break INVALID out of the CALL fall-through, use frame.to ?
   frame.to.toLowerCase() : undefined (same pattern as the SELFDESTRUCT fix at line 160). Also
  data.ts: TraceCallAction.to: Bytes20 → to?: Bytes20 (required for TypeScript correctness).
   2. Temporary mitigation — binance-mainnet.yaml: traces: false unblocks ingest immediately;
  labeled temporary with a revert checklist (merge fix → build image → re-enable traces).

  The implementer lane produced clean, minimal artifacts with no probe changes, no pod restarts, and
   no speculative RPC swaps — all correct.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-normalization/src/data.ts`
- `evm/evm-normalization/src/mapping.ts`

## Notify
cc @tmcgroul (automation opened this PR.)