### PR TITLE
[NET-652] [Alert EdvwWb] ink-sepolia_No_Dumper_Data

### DIFF
--- a/evm/evm-rpc/src/rpc-data.ts
+++ b/evm/evm-rpc/src/rpc-data.ts
@@ -218,7 +218,7 @@ export const Transaction = object({
     input: option(BYTES),
     maxFeePerGas: option(QTY),
     maxPriorityFeePerGas: option(QTY),
-    nonce: SMALL_QTY,
+    nonce: option(SMALL_QTY),
     v: option(QTY),
     r: option(BYTES),
     s: option(BYTES),


### PR DESCRIPTION
Automated fix proposal for alert `EdvwWb`.

- Alert: ink-sepolia_No_Dumper_Data
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/EdvwWb`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/EdvwWb/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: response now.

● Write FINAL_RESPONSE.md (shell)
  │ cat > /root/alert/incident-agent/agent-system/data/investigations/EdvwWb/t
  │ erminal_debate/EdvwWb__terminal_debate__20260521_105615/FINAL_RESPONSE.md
  │ << 'ENDOFFILE'
  │ # FINAL RESPONSE — EdvwWb: ink-sepolia_No_Dumper_Data…
  └ 205 lines...

● FINAL RESPONSE written. Here's the summary:

  Verdict: accept_with_changes (implementer patch is correct; one PR-note addition)

  Root cause confirmed [evidence]: dump-ink-sepolia-0 is in CrashLoopBackOff (5 restarts) because
  every Ink Sepolia block contains an OP-Stack type-0x7e deposit transaction with no nonce field,
  but rpc-data.ts:221 declares nonce: SMALL_QTY (required). This causes DataValidationError at
  rpc.js:997 on every eth_getBlockByNumber call → crash → loop.

  Fix (one line, open-beta):

   # evm/evm-rpc/src/rpc-data.ts:221
   -    nonce: SMALL_QTY,
   +    nonce: option(SMALL_QTY),

  Staged at fixes/proposed/evm/evm-rpc/src/rpc-data.ts — diff verified (1 line only).

  Operator actions required:

   1. Merge PR → build new evm-dump image
   2. Update image tag in infra chart
   3. ArgoCD sync → verify pod Running without new restarts

  PR note: add tx.nonce != null guard in the Cronos phantom-tx loop at rpc.ts:471/483 as defensive
  hygiene (not a blocker for this incident).

  Temporary mitigation (if build cycle > few hours): comment out ink-sepolia.yaml in infra to stop
  the crash loop — explicitly NOT the fix.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, code
- **Falsification:** if QuikNode ink-sepolia RPC returns "nonce":"0x0" on deposit txs —
- **Follow-up:** verify dump-ink-sepolia-0 runs >5 min without restart and blocks
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
response now.

● Write FINAL_RESPONSE.md (shell)
  │ cat > /root/alert/incident-agent/agent-system/data/investigations/EdvwWb/t
  │ erminal_debate/EdvwWb__terminal_debate__20260521_105615/FINAL_RESPONSE.md
  │ << 'ENDOFFILE'
  │ # FINAL RESPONSE — EdvwWb: ink-sepolia_No_Dumper_Data…
  └ 205 lines...

● FINAL RESPONSE written. Here's the summary:

  Verdict: accept_with_changes (implementer patch is correct; one PR-note addition)

  Root cause confirmed [evidence]: dump-ink-sepolia-0 is in CrashLoopBackOff (5 restarts) because
  every Ink Sepolia block contains an OP-Stack type-0x7e deposit transaction with no nonce field,
  but rpc-data.ts:221 declares nonce: SMALL_QTY (required). This causes DataValidationError at
  rpc.js:997 on every eth_getBlockByNumber call → crash → loop.

  Fix (one line, open-beta):

   # evm/evm-rpc/src/rpc-data.ts:221
   -    nonce: SMALL_QTY,
   +    nonce: option(SMALL_QTY),

  Staged at fixes/proposed/evm/evm-rpc/src/rpc-data.ts — diff verified (1 line only).

  Operator actions required:

   1. Merge PR → build new evm-dump image
   2. Update image tag in infra chart
   3. ArgoCD sync → verify pod Running without new restarts

  PR note: add tx.nonce != null guard in the Cronos phantom-tx loop at rpc.ts:471/483 as defensive
  hygiene (not a blocker for this incident).

  Temporary mitigation (if build cycle > few hours): comment out ink-sepolia.yaml in infra to stop
  the crash loop — explicitly NOT the fix.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/rpc-data.ts`

## Notify
cc @tmcgroul (automation opened this PR.)