### PR TITLE
[NET-662] [Alert wOMlr3] moonriver-mainnet_No_Dumper_Data

### DIFF
--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -298,6 +298,7 @@ export class Rpc {
             validateResult: getResultValidator(nullable(array(nullable(Receipt)))),
             validateError: info => {
                 if (info.message.includes('invalid block height')) throw new RetryError() // Hyperliquid
+                if (info.message.includes('Failed to retrieve substrate parent block hash')) throw new RetryError() // Dwellir/Substrate
                 throw new RpcError(info)
             }
         })


### PR DESCRIPTION
Automated fix proposal for alert `wOMlr3`.

- Alert: moonriver-mainnet_No_Dumper_Data
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/wOMlr3`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/wOMlr3/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: Incident wOMlr3 — moonriver-mainnet No_Dumper_Data

  Root cause confirmed [evidence]: dump-moonriver-mainnet-0 is in CrashLoopBackOff (88 restarts)
  because Dwellir returns -32603: "Failed to retrieve substrate parent block hash" on
  eth_getBlockReceipts for block 0xf99c31. The addReceiptsByBlock.validateError handler in rpc.ts
  has no guard for this Substrate error → falls through to throw new RpcError(info) → pod crash.

  Both patches produced (fixes/proposed/):

   1. evm/evm-rpc/src/rpc.ts — 1-line addition: if (info.message.includes('Failed to retrieve
  substrate parent block hash')) throw new RetryError() // Dwellir/Substrate (same pattern as the
  existing Hyperliquid invalid block height handler)
   2. moonriver-mainnet.yaml — adds Alchemy backup endpoint (capacity: 3), reusing key already
  active in moonbeam-mainnet.yaml

  Why both are needed: Code fix alone makes the error retryable but retries would loop against the
  same broken Dwellir endpoint. The Alchemy backup gives reduceBatchOnRetry a different provider to
  route through.

  One pre-deploy check: Confirm the Alchemy key cOGkEbYWW2dpY6S6V31Wh covers moonriver-mainnet
  specifically (not just Moonbeam) before deploying the YAML patch.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, code
- **Falsification:** If error persists after deploy, the Substrate error occurs on another
- **Follow-up:** Monitor restart count after image rebuild; confirm last_block advances
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
Incident wOMlr3 — moonriver-mainnet No_Dumper_Data

  Root cause confirmed [evidence]: dump-moonriver-mainnet-0 is in CrashLoopBackOff (88 restarts)
  because Dwellir returns -32603: "Failed to retrieve substrate parent block hash" on
  eth_getBlockReceipts for block 0xf99c31. The addReceiptsByBlock.validateError handler in rpc.ts
  has no guard for this Substrate error → falls through to throw new RpcError(info) → pod crash.

  Both patches produced (fixes/proposed/):

   1. evm/evm-rpc/src/rpc.ts — 1-line addition: if (info.message.includes('Failed to retrieve
  substrate parent block hash')) throw new RetryError() // Dwellir/Substrate (same pattern as the
  existing Hyperliquid invalid block height handler)
   2. moonriver-mainnet.yaml — adds Alchemy backup endpoint (capacity: 3), reusing key already
  active in moonbeam-mainnet.yaml

  Why both are needed: Code fix alone makes the error retryable but retries would loop against the
  same broken Dwellir endpoint. The Alchemy backup gives reduceBatchOnRetry a different provider to
  route through.

  One pre-deploy check: Confirm the Alchemy key cOGkEbYWW2dpY6S6V31Wh covers moonriver-mainnet
  specifically (not just Moonbeam) before deploying the YAML patch.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/rpc.ts`

## Notify
cc @tmcgroul (automation opened this PR.)