### PR TITLE
[NET-673] [Alert Ok2jmG] ink-sepolia_No_Dumper_Data

### DIFF
--- a/evm/evm-rpc/src/rpc-data.ts
+++ b/evm/evm-rpc/src/rpc-data.ts
@@ -218,7 +218,8 @@ export const Transaction = object({
     input: option(BYTES),
     maxFeePerGas: option(QTY),
     maxPriorityFeePerGas: option(QTY),
-    nonce: SMALL_QTY,
+    // Optional for OP Stack 0x7e deposit transactions which have no nonce
+    nonce: option(SMALL_QTY),
     v: option(QTY),
     r: option(BYTES),
     s: option(BYTES),

--- a/evm/evm-rpc/src/verification.ts
+++ b/evm/evm-rpc/src/verification.ts
@@ -144,7 +144,7 @@ function encodeTransaction(tx: Transaction): Buffer {
     if (tx.type == '0x0') {
         return Buffer.from(
             RLP.encode([
-                BigInt(tx.nonce),
+                BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
                 BigInt(assertNotNull(tx.gasPrice, 'tx.gasPrice is missing')),
                 BigInt(tx.gas),
                 tx.to ? decodeHex(tx.to) : Buffer.alloc(0),
@@ -158,7 +158,7 @@ function encodeTransaction(tx: Transaction): Buffer {
     } else if (tx.type == '0x1') {
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.gasPrice, 'tx.gasPrice is missing')),
             BigInt(tx.gas),
             tx.to ? decodeHex(tx.to) : Buffer.alloc(0),
@@ -173,7 +173,7 @@ function encodeTransaction(tx: Transaction): Buffer {
     } else if (tx.type == '0x2') {
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
             BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
             BigInt(tx.gas),
@@ -190,7 +190,7 @@ function encodeTransaction(tx: Transaction): Buffer {
         // https://eips.ethereum.org/EIPS/eip-4844
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
             BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
             BigInt(tx.gas),
@@ -209,7 +209,7 @@ function encodeTransaction(tx: Transaction): Buffer {
         // https://eips.ethereum.org/EIPS/eip-7702
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
             BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
             BigInt(tx.gas),
@@ -250,7 +250,7 @@ function encodeTransaction(tx: Transaction): Buffer {
         // https://github.com/OffchainLabs/go-ethereum/blob/7503143fd13f73e46a966ea2c42a058af96f7fcf/core/types/arb_types.go#L161
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             decodeHex(tx.from),
             BigInt(tx.gasPrice ?? 0),
             BigInt(tx.gas),
@@ -472,7 +472,7 @@ function encodeTempoTransactionFields(tx: Transaction): any[] {
         assertNotNull(tx.calls, 'tx.calls is missing for 0x76 tx').map(encodeTempoCall),
         decodeAccessList(tx.accessList ?? []),
         BigInt(assertNotNull(tx.nonceKey, 'tx.nonceKey is missing for 0x76 tx')),
-        BigInt(tx.nonce),
+        BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
         // valid_before: u64 when present, 0x80 (empty string) when null
         tx.validBefore != null ? BigInt(tx.validBefore) : Buffer.alloc(0),
         // valid_after: u64 when present, 0x80 (empty string) when null
@@ -524,7 +524,7 @@ function encodeTempoTransactionFieldsForSigning(tx: Transaction): any[] {
         assertNotNull(tx.calls, 'tx.calls is missing for 0x76 tx').map(encodeTempoCall),
         decodeAccessList(tx.accessList ?? []),
         BigInt(assertNotNull(tx.nonceKey, 'tx.nonceKey is missing for 0x76 tx')),
-        BigInt(tx.nonce),
+        BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
         tx.validBefore != null ? BigInt(tx.validBefore) : Buffer.alloc(0),
         tx.validAfter != null ? BigInt(tx.validAfter) : Buffer.alloc(0),
         // fee_token: skipped when fee_payer_signature is present
@@ -677,7 +677,7 @@ export function isBloomSuperset(superset: string, subset: string): boolean {
 function serializeTransaction(tx: Transaction): Uint8Array | undefined {
     if (tx.type == '0x0') {
         let fields = [
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(tx.gasPrice ?? 0),
             BigInt(tx.gas),
             tx.to ? decodeHex(tx.to) : Buffer.alloc(0),
@@ -694,7 +694,7 @@ function serializeTransaction(tx: Transaction): Uint8Array | undefined {
     } else if (tx.type == '0x1') {
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(tx.gasPrice ?? 0),
             BigInt(tx.gas),
             tx.to ? decodeHex(tx.to) : Buffer.alloc(0),
@@ -706,7 +706,7 @@ function serializeTransaction(tx: Transaction): Uint8Array | undefined {
     } else if (tx.type == '0x2') {
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
             BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
             BigInt(tx.gas),
@@ -719,7 +719,7 @@ function serializeTransaction(tx: Transaction): Uint8Array | undefined {
     } else if (tx.type == '0x3') {
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
             BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
             BigInt(tx.gas),
@@ -734,7 +734,7 @@ function serializeTransaction(tx: Transaction): Uint8Array | undefined {
     } else if (tx.type == '0x4') {
         let payload = RLP.encode([
             BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
-            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.nonce, 'tx.nonce is missing')),
             BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
             BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
             BigInt(tx.gas),


### PR DESCRIPTION
Automated fix proposal for alert `Ok2jmG`.

- Alert: ink-sepolia_No_Dumper_Data
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/Ok2jmG`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/Ok2jmG/report.html`

## Reviewer quick view
- Scope: 2 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: ink-sepolia_No_Dumper_Data (Ok2jmG) — Root Cause Confirmed

  Root cause: dump-ink-sepolia-0 is in CrashLoopBackOff (124 restarts, exit 1) because OP Stack
  deposit transactions (type 0x7e) legitimately omit nonce, but rpc-data.ts declares nonce:
  SMALL_QTY as mandatory — causing DataValidationError on every block containing a 0x7e tx.

  Fix — 2 files in evm/evm-rpc/src/ (squid-sdk, open-beta):

   1. rpc-data.ts (1 line): nonce: SMALL_QTY → nonce: option(SMALL_QTY)
   2. verification.ts (15 sites): BigInt(tx.nonce) → BigInt(assertNotNull(tx.nonce, 'tx.nonce is
  missing')) — prevents TypeScript compile failure now that nonce is optional

  Operator action required: After PR merges and new evm-dump image is built, update ink-sepolia.yaml
   image tag from 87fd3349 to the new digest.

  Verdict: accept — implementer patch is correct and complete; root cause fully explained by direct
  log + code evidence.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, code
- **Falsification:** If rpc-data.ts line 221 already reads nonce: option(SMALL_QTY) in
- **Follow-up:** Merge PR → build new evm-dump image → update ink-sepolia.yaml image
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
ink-sepolia_No_Dumper_Data (Ok2jmG) — Root Cause Confirmed

  Root cause: dump-ink-sepolia-0 is in CrashLoopBackOff (124 restarts, exit 1) because OP Stack
  deposit transactions (type 0x7e) legitimately omit nonce, but rpc-data.ts declares nonce:
  SMALL_QTY as mandatory — causing DataValidationError on every block containing a 0x7e tx.

  Fix — 2 files in evm/evm-rpc/src/ (squid-sdk, open-beta):

   1. rpc-data.ts (1 line): nonce: SMALL_QTY → nonce: option(SMALL_QTY)
   2. verification.ts (15 sites): BigInt(tx.nonce) → BigInt(assertNotNull(tx.nonce, 'tx.nonce is
  missing')) — prevents TypeScript compile failure now that nonce is optional

  Operator action required: After PR merges and new evm-dump image is built, update ink-sepolia.yaml
   image tag from 87fd3349 to the new digest.

  Verdict: accept — implementer patch is correct and complete; root cause fully explained by direct
  log + code evidence.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/rpc-data.ts`
- `evm/evm-rpc/src/verification.ts`

## Notify
cc @tmcgroul (automation opened this PR.)