### PR TITLE
[NET-674] [Alert odMjbK] ink-sepolia_Writer_Short_Stall

### DIFF
--- a/evm/evm-rpc/src/rpc-data.ts
+++ b/evm/evm-rpc/src/rpc-data.ts
@@ -218,7 +218,7 @@ export const Transaction = object({
     input: option(BYTES),
     maxFeePerGas: option(QTY),
     maxPriorityFeePerGas: option(QTY),
-    nonce: SMALL_QTY,
+    nonce: option(SMALL_QTY),
     v: option(QTY),
     r: option(BYTES),
     s: option(BYTES),


### PR DESCRIPTION
Automated fix proposal for alert `odMjbK`.

- Alert: ink-sepolia_Writer_Short_Stall
- Base branch: `open-beta`
- Investigation: `/root/alert/incident-agent/agent-system/data/investigations/odMjbK`
- Report: `/root/alert/incident-agent/agent-system/data/investigations/odMjbK/report.html`

## Reviewer quick view
- Scope: 1 file(s) in evm
- Root cause (agent): not explicitly captured
- Summary: ✗ Read k8s.logs__74ecc9a49ebab5cd.raw.json
  │ data/investigations/odMjbK/tool_cache/k8s.logs__74ecc9a49ebab5cd.raw.json
  └ Path does not exist

● Read copilot_implementer.md
  │ data/investigations/odMjbK/terminal_debate/odMjbK__terminal_debate__20260522
  │ _113136/copilot_implementer.md
  └ 156 lines read

● Read rpc-data.ts
  │ data/investigations/odMjbK/github_files/subsquid_squid-sdk/open-beta/evm/evm
  │ -rpc/src/rpc-data.ts
  └ L215:260 (46 lines read)

● List tool cache files (shell)
  │ ls /root/alert/incident-agent/agent-system/data/investigations/odMjbK/tool_c
  │ ache/ 2>/dev/null | head -20
  └ 1 line...

● Check proposed fix exists and nonce line (shell)
  │ find
  │ /root/alert/incident-agent/agent-system/data/investigations/odMjbK/fixes
  │ -type f 2>/dev/null && grep -n "nonce" /root/alert/incident-agent/agent-syst
  │ em/data/investigations/odMjbK/fixes/proposed/evm/evm-rpc/src/rpc-data.ts
  │ 2>/dev/null | grep "221\|option.*nonce\|nonce.*option"
  └ 6 lines...

● The proposed fix file is confirmed: line 221 now reads nonce: option(SMALL_QTY). Now I'll write
  the final response.

● Write FINAL_RESPONSE.md (shell)
  │ cat > /root/alert/incident-agent/agent-system/data/investigations/odMjbK/t
  │ erminal_debate/odMjbK__terminal_debate__20260522_113136/FINAL_RESPONSE.md
  │ << 'FINAL_EOF'
  │ # FINAL RESPONSE — ink-sepolia_Writer_Short_Stall (odMjbK)…
  └ 188 lines...

● Summary

  Verdict: accept — root cause confirmed, one-line code fix staged.

  Root cause chain [evidence]:

   1. Block 50,231,612 on ink-sepolia contains an OP Stack deposit tx (type 0x7e) with nonce:
  undefined
   2. Transaction schema in evm/evm-rpc/src/rpc-data.ts:221 requires nonce: SMALL_QTY (non-optional)
   → DataValidationError crash
   3. dump-ink-sepolia-0 enters CrashLoopBackOff (127 restarts) → no S3 output → write container
  loops → sqd_last_block_total frozen at 50,231,611

  Fix (one line) — fixes/proposed/evm/evm-rpc/src/rpc-data.ts is staged:

   -    nonce: SMALL_QTY,
   +    nonce: option(SMALL_QTY),

  Identical pattern to PR #482 (EdvwWb). sourceHash/mint in the same object are already option().

  Operator actions required: build new evm-dump image → update infra chart tag → ArgoCD sync →
  verify sqd_last_block_total advances past 50,231,611.

## Fix metadata
- **Fix class:** rca_fix
- **Confidence:** high
- **Evidence basis:** logs, metrics, code
- **Falsification:** If block 50,231,612's type 0x7e tx actually contained a nonce field,
- **Follow-up:** Verify sqd_last_block_total advances past 50,231,611 after deploy.
_(Generated by the terminal-debate agent — values reflect the agent's self-assessment, not a verified verdict. Use them as a starting point for review.)_

## Summary
✗ Read k8s.logs__74ecc9a49ebab5cd.raw.json
  │ data/investigations/odMjbK/tool_cache/k8s.logs__74ecc9a49ebab5cd.raw.json
  └ Path does not exist

● Read copilot_implementer.md
  │ data/investigations/odMjbK/terminal_debate/odMjbK__terminal_debate__20260522
  │ _113136/copilot_implementer.md
  └ 156 lines read

● Read rpc-data.ts
  │ data/investigations/odMjbK/github_files/subsquid_squid-sdk/open-beta/evm/evm
  │ -rpc/src/rpc-data.ts
  └ L215:260 (46 lines read)

● List tool cache files (shell)
  │ ls /root/alert/incident-agent/agent-system/data/investigations/odMjbK/tool_c
  │ ache/ 2>/dev/null | head -20
  └ 1 line...

● Check proposed fix exists and nonce line (shell)
  │ find
  │ /root/alert/incident-agent/agent-system/data/investigations/odMjbK/fixes
  │ -type f 2>/dev/null && grep -n "nonce" /root/alert/incident-agent/agent-syst
  │ em/data/investigations/odMjbK/fixes/proposed/evm/evm-rpc/src/rpc-data.ts
  │ 2>/dev/null | grep "221\|option.*nonce\|nonce.*option"
  └ 6 lines...

● The proposed fix file is confirmed: line 221 now reads nonce: option(SMALL_QTY). Now I'll write
  the final response.

● Write FINAL_RESPONSE.md (shell)
  │ cat > /root/alert/incident-agent/agent-system/data/investigations/odMjbK/t
  │ erminal_debate/odMjbK__terminal_debate__20260522_113136/FINAL_RESPONSE.md
  │ << 'FINAL_EOF'
  │ # FINAL RESPONSE — ink-sepolia_Writer_Short_Stall (odMjbK)…
  └ 188 lines...

● Summary

  Verdict: accept — root cause confirmed, one-line code fix staged.

  Root cause chain [evidence]:

   1. Block 50,231,612 on ink-sepolia contains an OP Stack deposit tx (type 0x7e) with nonce:
  undefined
   2. Transaction schema in evm/evm-rpc/src/rpc-data.ts:221 requires nonce: SMALL_QTY (non-optional)
   → DataValidationError crash
   3. dump-ink-sepolia-0 enters CrashLoopBackOff (127 restarts) → no S3 output → write container
  loops → sqd_last_block_total frozen at 50,231,611

  Fix (one line) — fixes/proposed/evm/evm-rpc/src/rpc-data.ts is staged:

   -    nonce: SMALL_QTY,
   +    nonce: option(SMALL_QTY),

  Identical pattern to PR #482 (EdvwWb). sourceHash/mint in the same object are already option().

  Operator actions required: build new evm-dump image → update infra chart tag → ArgoCD sync →
  verify sqd_last_block_total advances past 50,231,611.

## Risk & rollout
- Suggested rollout: canary / one-network-first, then broader rollout after signal is stable.
- Rollback: revert this PR (or restore previous config values/files) if the incident signal worsens.

## Reproduction status
Incident behavior was reproduced or corroborated strongly enough for a non-hypothesis fix proposal.

## Validation checklist
- [ ] Verify the original incident signal improves (logs/metrics/alerts) after deploy.
- [ ] Verify no regression on sibling networks/providers/services touched by this change.
- [ ] Confirm queue / delivery pipeline status returns to expected steady state.

## Changed files
- `evm/evm-rpc/src/rpc-data.ts`

## Notify
cc @tmcgroul (automation opened this PR.)