### PR TITLE
Improve error observability for the incident-resolution agent

### DIFF
--- a/evm/evm-rpc/src/data-source/get-blocks.test.ts
+++ b/evm/evm-rpc/src/data-source/get-blocks.test.ts
@@ -3,7 +3,8 @@ import {getBlocks} from './get-blocks'
 import type {Block, DataRequest} from '../types'
 import type {Rpc} from '../rpc'
 
-vi.mock('@subsquid/util-internal', () => ({
+vi.mock('@subsquid/util-internal', async (importOriginal) => ({
+    ...await importOriginal<typeof import('@subsquid/util-internal')>(),
     wait: vi.fn().mockResolvedValue(undefined)
 }))
 

--- a/evm/evm-rpc/src/data-source/get-blocks.ts
+++ b/evm/evm-rpc/src/data-source/get-blocks.ts
@@ -1,5 +1,5 @@
 import {FiniteRange, rangeToArray} from '@subsquid/util-internal-range'
-import {wait} from '@subsquid/util-internal'
+import {addErrorContext, wait} from '@subsquid/util-internal'
 import {Rpc} from '../rpc'
 import {Block, DataRequest} from '../types'
 
@@ -24,9 +24,28 @@ export async function getBlocks(
         if (indices.length == 0) return blocks
 
         if (retries == 5) {
+            // When a provider silently stops serving some blocks or a method,
+            // the bare "failed to load blocks: N" message names neither the
+            // endpoint nor the reason. Attach both so a single log line
+            // localizes the failure.
+            let failedBlocks = indices.map(i => numbers[i])
             let invalid = blocks.find(b => b?._isInvalid)
-            if (invalid) throw new Error(invalid._errorMessage)
-            throw new Error(`failed to load blocks: ${indices.map(i => numbers[i]).join(', ')}`)
+            if (invalid) {
+                throw addErrorContext(new Error(invalid._errorMessage), {
+                    rpcUrl: rpc.endpoint,
+                    failedBlocks,
+                    retries
+                })
+            }
+            throw addErrorContext(
+                new Error(`failed to load blocks: ${failedBlocks.join(', ')}`),
+                {
+                    rpcUrl: rpc.endpoint,
+                    failedBlocks,
+                    retries,
+                    reason: 'rpc returned null for these blocks (provider may not serve them or the method)'
+                }
+            )
         }
 
         await wait(100)

--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -79,6 +79,12 @@ export class Rpc {
         this.log = createLogger('sqd:evm-rpc')
     }
 
+    /** RPC endpoint URL — exposed so error paths outside this class can name
+     * the failing provider in logs and error context. */
+    get endpoint(): string {
+        return this.client.url
+    }
+
     getConcurrency(): number {
         return this.client.getConcurrency()
     }
@@ -263,7 +269,7 @@ export class Rpc {
                 if (this.checkLogIndex) {
                     let logIndex = 0
                     for (let log of logs) {
-                        assert.equal(qty2Int(log.logIndex), logIndex++)
+                        assert.equal(qty2Int(log.logIndex), logIndex++, 'unexpected log index in eth_getLogs response')
                     }
                 }
 
@@ -274,7 +280,9 @@ export class Rpc {
             } catch (err: any) {
                 throw addErrorContext(err, {
                     blockNumber: block.number,
-                    blockHash: block.hash
+                    blockHash: block.hash,
+                    rpcUrl: this.client.url,
+                    rpcMethod: 'eth_getLogs'
                 })
             }
 
@@ -391,7 +399,7 @@ export class Rpc {
                 if (this.checkLogIndex) {
                     let logIndex = 0
                     for (let log of logs) {
-                        assert.equal(qty2Int(log.logIndex), logIndex++)
+                        assert.equal(qty2Int(log.logIndex), logIndex++, 'unexpected log index in receipt logs')
                     }
                 }
 
@@ -399,7 +407,14 @@ export class Rpc {
                     let prevCumulativeGasUsed = 0n
                     for (let receipt of receipts) {
                         let cumulativeGasUsed = BigInt(receipt.cumulativeGasUsed)
-                        assert.equal(cumulativeGasUsed, prevCumulativeGasUsed + BigInt(receipt.gasUsed))
+                        // This assertion used to fire bare ("0n == 77629n") with no
+                        // hint of the failing data — name the receipt so it is
+                        // identifiable from a single log line.
+                        assert.equal(
+                            cumulativeGasUsed,
+                            prevCumulativeGasUsed + BigInt(receipt.gasUsed),
+                            `cumulativeGasUsed mismatch at receipt of tx ${receipt.transactionHash}`
+                        )
                         prevCumulativeGasUsed = cumulativeGasUsed
                     }
                 }
@@ -426,7 +441,9 @@ export class Rpc {
             } catch (err: any) {
                 throw addErrorContext(err, {
                     blockNumber: block.number,
-                    blockHash: block.hash
+                    blockHash: block.hash,
+                    rpcUrl: this.client.url,
+                    rpcMethod: 'receipts validation (receipts-by-block path)'
                 })
             }
 
@@ -858,7 +875,11 @@ export class Rpc {
                     let prevCumulativeGasUsed = 0n
                     for (let receipt of receipts) {
                         let cumulativeGasUsed = BigInt(receipt.cumulativeGasUsed)
-                        assert.equal(cumulativeGasUsed, prevCumulativeGasUsed + BigInt(receipt.gasUsed))
+                        assert.equal(
+                            cumulativeGasUsed,
+                            prevCumulativeGasUsed + BigInt(receipt.gasUsed),
+                            `cumulativeGasUsed mismatch at receipt of tx ${receipt.transactionHash}`
+                        )
                         prevCumulativeGasUsed = cumulativeGasUsed
                     }
                 }
@@ -875,7 +896,9 @@ export class Rpc {
             } catch (err: any) {
                 throw addErrorContext(err, {
                     blockNumber: block.number,
-                    blockHash: block.hash
+                    blockHash: block.hash,
+                    rpcUrl: this.client.url,
+                    rpcMethod: 'receipts validation (eth_getTransactionReceipt path)'
                 })
             }
 

--- a/util/util-internal-json/src/json.ts
+++ b/util/util-internal-json/src/json.ts
@@ -21,6 +21,12 @@ export function toJSON(val: unknown): any {
                 } else {
                     json.stack = val.toString()
                 }
+                // `cause` is non-enumerable on V8, so the property walk below
+                // misses it — a wrapped error would reach the log without its
+                // root cause (e.g. the ECONNREFUSED inside a batch failure).
+                if ((val as any).cause != null) {
+                    json.cause = toJSON((val as any).cause)
+                }
                 json = toJsonObject(val, json)
                 return json
             } else if (val instanceof Map) {

--- a/util/util-internal/src/misc.ts
+++ b/util/util-internal/src/misc.ts
@@ -39,8 +39,11 @@ export function runProgram(main: () => Promise<void>, log?: (err: Error) => void
     // path) bypasses the main() chain below and terminates the process as
     // bare stderr text outside the structured logger — a crash-looping pod
     // then shows no machine-readable cause in its last lines.
-    process.on('unhandledRejection', onerror)
-    process.on('uncaughtException', onerror)
+    // Some bundled runtimes ship a `process` shim without `.on`.
+    if (typeof process.on === 'function') {
+        process.on('unhandledRejection', onerror)
+        process.on('uncaughtException', onerror)
+    }
 
     try {
         main().then(() => process.exit(0), onerror)

--- a/util/util-internal/src/misc.ts
+++ b/util/util-internal/src/misc.ts
@@ -35,6 +35,13 @@ export function runProgram(main: () => Promise<void>, log?: (err: Error) => void
         process.exit(1)
     }
 
+    // A rejection escaping via a detached promise (or a throw on an event
+    // path) bypasses the main() chain below and terminates the process as
+    // bare stderr text outside the structured logger — a crash-looping pod
+    // then shows no machine-readable cause in its last lines.
+    process.on('unhandledRejection', onerror)
+    process.on('uncaughtException', onerror)
+
     try {
         main().then(() => process.exit(0), onerror)
     } catch(e: unknown) {


### PR DESCRIPTION
Logging/error-context-only changes so archive and hotblocks failures can be diagnosed from pod logs alone — primarily for the automated incident-resolution agent that reads them.

- **`util-internal-json`**: serialize `Error.cause` (non-enumerable on V8, so the property walk missed it) — a wrapped error used to reach the log without its root cause
- **`util-internal`**: `runProgram` installs `unhandledRejection` / `uncaughtException` handlers, so a crashing process reports the cause through the structured logger instead of bare stderr text
- **`evm-rpc`**: block-validation asserts name the offending receipt (`cumulativeGasUsed mismatch at receipt of tx 0x…`) and log index; validation `catch` blocks attach `rpcUrl` + `rpcMethod` to the error context; `Rpc` exposes a public `endpoint` getter for error paths outside the class
- **`evm-rpc` / `get-blocks`**: `failed to load blocks` carries `rpcUrl`, the failed block numbers, retries and a reason

Notes for review:
- the process-level handlers in `runProgram` apply to every SDK-based process (including user squids); the cause is now reported via the provided logger and the exit code is a deterministic 1
- `Error.cause` serialization recurses through the cause chain

Verified with `rush build --to @subsquid/evm-rpc` (also rebuilds `util-internal` and `util-internal-json`).
