### PR TITLE
fix(evm-rpc): tolerate Hyperliquid system-tx logs in calculateLogsBloom

### DIFF
--- a/evm/evm-rpc/src/chain-utils.ts
+++ b/evm/evm-rpc/src/chain-utils.ts
@@ -113,7 +113,14 @@ export class ChainUtils {
             let transactions = block.transactions as Transaction[]
             let txByHash = new Map(transactions.map(tx => [getTxHash(tx), tx]))
             logs = logs.filter(log => {
-                let tx = assertNotNull(txByHash.get(log.transactionHash))
+                let tx = txByHash.get(log.transactionHash)
+                // Hyperliquid system transactions can emit logs while being absent
+                // from the canonical block.transactions list. Such a log has no
+                // matching transaction here; treat it as a system-tx log and drop
+                // it from the bloom (the canonical header bloom also omits system-tx
+                // logs) instead of crashing on assertNotNull. A genuinely missing
+                // non-system log is still caught by the subsequent logs-bloom check.
+                if (tx == null) return false
                 return !isHyperliquidSystemTx(tx)
             })
         }


### PR DESCRIPTION
## Problem
`hyperliquid-testnet` evm-dump pod has been crash-looping (714 restarts) since ~2026-06-12 22:00 UTC, stalling the writer at block 55410003. Crash:

```
AssertionError at assertNotNull (evm-rpc/lib/chain-utils.js:80)
  ChainUtils.calculateLogsBloom — block 55415753
```

A Hyperliquid **system transaction** emits logs/receipts but is absent from the canonical `block.transactions` list. `calculateLogsBloom`'s Hyperliquid branch did `assertNotNull(txByHash.get(log.transactionHash))`, so this log hard-crashed the dump deterministically on a poison block.

## Evidence it's chain-inherent, not a provider issue
Both Uniblock and Alchemy return the **identical canonical block** (same hash) for 55415753 — a provider swap will not fix it. The deployed image bump `982c0432d` (`87fd3349`→`59864f9d`) only added observability labels; the assertion is byte-identical in both, so an image revert will **not** fix it either.

## Fix
Drop logs whose referencing tx is absent from `block.transactions` (i.e. system-tx logs) instead of asserting. The canonical header bloom already omits system-tx logs, so the computed bloom still matches the header. This mirrors the existing `isHyperliquidSystemReceipt` filtering in `calculateReceiptsRoot`. Gated on `isHyperliquidMainnet/Testnet`, so no other network is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)