### PR TITLE
docs: SQD rebrand + canonical links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,50 @@
 # Squid SDK - an ETL framework for Web3 data
 
-Subsquid SDK is a TypeScript ETL toolkit for blockchain data, that currently supports
+[![npm](https://img.shields.io/npm/v/@subsquid/evm-processor.svg)](https://www.npmjs.com/package/@subsquid/evm-processor)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
+[![Docs](https://img.shields.io/badge/docs-sqd.dev-blue.svg)](https://docs.sqd.dev)
+
+Squid SDK is a TypeScript ETL toolkit for blockchain data, that currently supports
 
 * Ethereum and everything Ethereum-like
-* [Substrate](https://substrate.io)-based chains
+* [Substrate](https://github.com/paritytech/polkadot-sdk)-based chains
 * Solana.
 
-Subsquid SDK stands apart from the competition by
+Squid SDK is distinguished by
 
 * Being a toolkit (rather than an indexing app like TheGraph or Ponder)
 * Fast binary data codecs and type-safe access to decoded data
-* Native support for sourcing the data from Subsquid Network.
+* Native support for sourcing the data from SQD Network.
 
-The latter is a key point, as [Subsquid Network](https://docs.subsquid.io/subsquid-network/overview/) 
+The latter is a key point, as [SQD Network](https://docs.sqd.dev/en/network/overview)
 is a decentralized data lake and query engine,
 that allows to granularly select and stream subset of block data to lightweight clients
-while providing game changing performance over traditional RPC API.
+while providing high performance compared to traditional RPC APIs.
 
-## Getting started
+## Quickstart
 
-The best way to get started is to install [squid CLI](https://github.com/subsquid/squid-cli) and scaffold a squid project with [`sqd init`](https://docs.subsquid.io/squid-cli/init/). 
+Install the [SQD CLI](https://github.com/subsquid/squid-cli) and scaffold a new project:
 
-For step-by-step instructions, follow one of the [Quickstart guides](https://docs.subsquid.io/quickstart/).
+```bash
+npm install -g @subsquid/cli
+sqd init my-squid
+```
+
+For step-by-step instructions, follow the [How to start guide](https://docs.sqd.dev/en/sdk/squid-sdk/how-to-start).
+
+## Documentation
+
+* Full documentation: [docs.sqd.dev](https://docs.sqd.dev)
+* SQD CLI reference: [docs.sqd.dev/en/cloud/reference/cli](https://docs.sqd.dev/en/cloud/reference/cli)
+* Website: [sqd.dev](https://sqd.dev)
 
 ## Developer community
 
-Our developers are active on [Telegram](https://t.me/HydraDevs). Feel free to join and ask any question!
+Our developers are active in the SQD developer community on [Telegram](https://t.me/HydraDevs). Feel free to join and ask any question!
 
 ## Contributing
 
-Subsquid is an OpenSource project, contributions are welcomed, encouraged and will be rewarded!
+SQD is an open-source project, contributions are welcomed, encouraged and will be rewarded!
 
 Please consult [CONTRIBUTING.md](CONTRIBUTING.md) for hacking instructions
 and make sure to read our [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Focused README-only refresh. No code or config touched.

## Changes
- **Rebrand:** "Subsquid SDK" -> "Squid SDK", "Subsquid Network" -> "SQD Network", "Subsquid is an OpenSource project" -> "SQD is an open-source project". Product name "Squid SDK" preserved; `@subsquid/*` package names and `github.com/subsquid/*` URLs left intact.
- **Canonical doc links repointed** (all verified 200):
  - `docs.subsquid.io/subsquid-network/overview/` -> https://docs.sqd.dev/en/network/overview
  - `docs.subsquid.io/squid-cli/init/` -> https://docs.sqd.dev/en/cloud/reference/cli
  - `docs.subsquid.io/quickstart/` -> https://docs.sqd.dev/en/sdk/squid-sdk/how-to-start
- **Removed unverifiable marketing phrases** "stands apart from the competition" and "game changing performance"; reworded factually.
- **Badges added** near the top: npm version for `@subsquid/evm-processor`, a static Apache-2.0 license badge linked to `./LICENSE`, and a docs badge to https://docs.sqd.dev.
- **Quickstart section added** (install `@subsquid/cli`, run `sqd init`) plus a **Documentation section** linking https://docs.sqd.dev and https://sqd.dev, so user-facing content leads.
- **"Change Management" / Rush section kept** in place (not moved or deleted); quickstart and docs now precede it.
- **Telegram** relabeled as the "SQD developer community" (https://t.me/HydraDevs URL unchanged).
- Fixed a pre-existing dead link: `https://substrate.io` (404) repointed to the canonical https://github.com/paritytech/polkadot-sdk.

## Link verification
Every URL in the final README was checked with `curl -s -o /dev/null -w '%{http_code}' -L <url>` and returns **200**. The npm package link was confirmed via https://registry.npmjs.org/@subsquid/evm-processor (200). The `./LICENSE` badge target is a real file in the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)