### PR TITLE
evm-rpc: tolerate null from trace_replayBlockTransactions (fixes tempo hotblocks crash-loop)

### DIFF
--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -1132,13 +1132,22 @@ export class Rpc {
 
         let replaysByBlock = await this.reduceBatchOnRetry(call, {
             validateResult: getResultValidator(
-                array(getTraceTransactionReplayValidator(traces))
+                nullable(array(getTraceTransactionReplayValidator(traces)))
             )
         })
 
         for (let i = 0; i < blocks.length; i++) {
             let block = blocks[i]
             let replays = replaysByBlock[i]
+            // A provider can transiently return `null` for a freshly produced
+            // (tip) block whose trace index isn't ready yet. Treat it like the
+            // debug_trace* paths do — flag the block for retry instead of
+            // crashing ingestion with a fatal "null is not an array" error.
+            if (replays == null) {
+                block._isInvalid = true
+                block._errorMessage = 'failed to get trace replays for a block'
+                continue
+            }
             let txs = new Set(block.block.transactions.map(getTxHash))
 
             for (let rep of replays) {


### PR DESCRIPTION
## Incident
Hotblocks data-lag alert on **tempo-mainnet** (correlated providers dwellir/uniblock), onset ~13:31 UTC on 2026-06-17, ~9 min after a fleet-wide deploy of `evm-data-service:e56f20a9` (image bump commit `d409edb` at 13:20 UTC).

## Root cause
The new image introduced a **crash-loop** on tempo: `trace_replayBlockTransactions` transiently returns `result: null` for a freshly-produced tip block whose trace index isn't ready yet. In `Rpc.addTraceTxReplays`, the result is validated with `array(...)`, so a `null` throws a **fatal, non-retryable** `DataValidationError: null is not an array`, terminating ingestion repeatedly.

Evidence:
- Old tempo pod (image `56617aaf`) had **0 terminations** over 3h before cutover; crash-looping began only with `e56f20a9`.
- Direct RPC probe: the same blocks that returned `null` during the incident now return a valid empty array `[]` → confirms the `null` is a **transient tip-race**, not a permanent capability gap.
- The sibling `debug_*` paths (`addDebugStateDiffs` / `addDebugFrames`, and `eth_getBlockReceipts`) already tolerate `null` by flagging the block for retry. `addTraceTxReplays` was the lone path missing this guard.

(Note: the cronos-mainnet error `could not find results for height` is **pre-existing** on both images and is a separate issue, not introduced by this bump.)

## Fix
Mirror the existing debug-path pattern in `addTraceTxReplays`:
- wrap the validator in `nullable(array(...))`
- on `null`, set `block._isInvalid = true` + `_errorMessage` and `continue`, so the batch is retried instead of crashing.

Structurally identical to the already-shipping `addDebugStateDiffs` / `addDebugFrames` null handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)