### PR TITLE
evm-rpc: ride out intermittent missing/invalid blocks instead of crash-looping the dumper

### DIFF
--- a/common/changes/@subsquid/evm-rpc/master_2026-06-19-14-30.json
+++ b/common/changes/@subsquid/evm-rpc/master_2026-06-19-14-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "getBlocks: back off exponentially and extend the retry budget for transiently missing/invalid blocks so an intermittent provider response (e.g. a flaky eth_getBlockReceipts returning null for a block that genuinely has data) is ridden out instead of crash-looping the dumper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-rpc/src/data-source/get-blocks.test.ts
+++ b/evm/evm-rpc/src/data-source/get-blocks.test.ts
@@ -65,4 +65,25 @@ describe('getBlocks', () => {
         expect(result).toHaveLength(5)
         expect(result.map(b => b.number)).toEqual([100, 101, 102, 103, 104])
     })
+
+    it('rides out an intermittent provider that stays flaky beyond the old 5-retry budget', async () => {
+        // Provider keeps dropping blocks 103/104 for 7 consecutive rounds (more
+        // than the previous 5-retry window) before finally serving them. With the
+        // enlarged retry budget this recovers instead of crash-looping the dumper.
+        let callCount = 0
+        const rpc = mkRpc(async (numbers: number[]) => {
+            callCount++
+            if (callCount === 1) {
+                return [mkBlock(100), mkBlock(101), mkBlock(102)]
+            }
+            if (callCount <= 7) {
+                return []
+            }
+            return numbers.map(n => mkBlock(n))
+        })
+
+        const result = await getBlocks(rpc, REQ, {from: 100, to: 104})
+        expect(result).toHaveLength(5)
+        expect(result.map(b => b.number)).toEqual([100, 101, 102, 103, 104])
+    })
 })

--- a/evm/evm-rpc/src/data-source/get-blocks.ts
+++ b/evm/evm-rpc/src/data-source/get-blocks.ts
@@ -23,7 +23,7 @@ export async function getBlocks(
 
         if (indices.length == 0) return blocks
 
-        if (retries == 5) {
+        if (retries == MAX_RETRIES) {
             // When a provider silently stops serving some blocks or a method,
             // the bare "failed to load blocks: N" message names neither the
             // endpoint nor the reason. Attach both so a single log line
@@ -48,7 +48,16 @@ export async function getBlocks(
             )
         }
 
-        await wait(100)
+        // Some providers intermittently return null / an `_isInvalid` block for
+        // a block that genuinely has data — e.g. a flaky `eth_getBlockReceipts`
+        // that serves the very same block on a later attempt. A fixed ~0.5s of
+        // retries (5 x 100ms) is too short to ride out such a transient
+        // degradation window, so the bad response would propagate as a fatal
+        // error and crash-loop the dumper. Back off exponentially (mirroring the
+        // rpc-client's own escalating pause) so a transient hiccup is absorbed,
+        // while a genuinely unservable block still fails loudly once the budget
+        // is exhausted.
+        await wait(Math.min(100 * 2 ** retries, MAX_RETRY_BACKOFF_MS))
         let result = await rpc.getBlockBatch(indices.map(i => numbers[i]), req)
         for (let i = 0; i < result.length; i++) {
             blocks[indices[i]] = result[i]
@@ -57,3 +66,11 @@ export async function getBlocks(
         retries += 1
     }
 }
+
+
+// Retry budget for transiently missing / invalid blocks. With exponential
+// backoff capped at MAX_RETRY_BACKOFF_MS this spans ~40s before failing, enough
+// to absorb a flaky provider window without crash-looping while still surfacing
+// a persistently unservable block.
+const MAX_RETRIES = 10
+const MAX_RETRY_BACKOFF_MS = 10_000


### PR DESCRIPTION
## Cause (proven)

The `polygon-amoy-testnet` EVM dumper (`evm-archive`) entered `CrashLoopBackOff`
(15 restarts, exit 1). The fatal error was:

```
Error: eth_getBlockReceipts returned null
  at getBlocks (evm/evm-rpc/lib/data-source/get-blocks.js)
  rpcUrl: https://api.uniblock.dev/.../chainId=80002
  failedBlocks: [40429264,40429265,40429266,40429267], retries: 5
```

`addReceiptsByBlock` already flags a null `eth_getBlockReceipts` result as
`_isInvalid` (`rpc.ts`) so `getBlocks` can retry it. But `getBlocks` retried only
**5 times with a fixed 100ms wait (~0.5s total)** before throwing a fatal,
non-retryable error that crash-loops the dumper.

The upstream null is **intermittent, not inherent to the chain**. Probing block
`0x268e6d0` (40429264) directly:

- **uniblock** `eth_getBlockReceipts` → returns full receipts on two attempts,
  `null` on a third (the block is served fine by `eth_getBlockByNumber`).
- **alchemy** (different node implementation) `eth_getBlockReceipts` → returns the
  full receipt set every time.

So the block genuinely has receipts; uniblock just flakily drops them. A ~0.5s
retry window is too short to ride out that degradation window, so a transient
provider hiccup becomes a fatal crash.

## Fix (tested)

`getBlocks` now backs off **exponentially** (capped at 10s, mirroring the
rpc-client's own escalating pause) and uses a larger retry budget (10), so the
retry window spans ~40s and absorbs a transient provider degradation window
instead of crash-looping after half a second. A block that is **genuinely
unservable still fails loudly** once the budget is exhausted — the existing
fail-early behaviour is preserved.

This is the durable, fleet-wide guard for *any* `_isInvalid` path (receipts,
traces, statediffs, replays all route through this loop), not just today's
uniblock/amoy trigger.

Verified by unit tests (in this PR): full-success, persistent-failure-throws,
quick-recover, and a new **flaky-for-7-rounds-then-recovers** case that would
have crashed under the old 5-retry budget but now succeeds.

## Operator follow-up (not part of this PR)

Switching `polygon-amoy-testnet`'s dump endpoint from uniblock to alchemy removes
*today's* trigger (alchemy serves the receipts reliably in probing), but a
provider swap is a temporary mitigation — this code change is the durable fix. The
uniblock data-quality issue (intermittent null `eth_getBlockReceipts`) should be
raised with the provider.

## Falsification

This is the wrong fix if the dumper still crashes with `eth_getBlockReceipts
returned null` after deploying an evm-dump image built from this commit — i.e. if
uniblock's null responses are *sustained* for >~40s per block rather than
intermittent (in which case the resolution is the provider swap, not a retry
budget). Probing showed uniblock serving the same block successfully within
seconds, so the intermittent case holds.
