### PR TITLE
dump-cli: recover from transient ForkException on finalized dump instead of crashing

### DIFF
--- a/util/util-internal-dump-cli/src/dumper.ts
+++ b/util/util-internal-dump-cli/src/dumper.ts
@@ -1,6 +1,6 @@
 import {createLogger, Logger} from '@subsquid/logger'
 import {RpcClient} from '@subsquid/rpc-client'
-import {assertNotNull, def, last, runProgram, Throttler, waitDrain} from '@subsquid/util-internal'
+import {assertNotNull, def, last, runProgram, Throttler, wait, waitDrain} from '@subsquid/util-internal'
 import {
     ArchiveLayout,
     checkShorHashMatch,
@@ -263,23 +263,52 @@ export abstract class Dumper<B extends RawBlock, O extends DumperOptions = Dumpe
                 let archive = new ArchiveLayout(this.destination(), {
                     topDirSize: this.options().topDirSize
                 })
-                await archive.appendRawBlocks({
-                    blocks: (nextBlock, prevHash) => this.ingest(nextBlock, prevHash),
-                    range: this.range(),
-                    chunkSize: chunkSize * 1024 * 1024,
-                    onSuccessWrite: ctx => {
-                        const blockHeight = ctx.blockRange.to.number;
-                        prometheus.setLastWrittenBlock(blockHeight);
 
-                        const cachedTimestamp = this.timestampCache.get(blockHeight);
-                        if (cachedTimestamp) {
-                            prometheus.setProcessedBlockMetrics(cachedTimestamp);
-                            this.log().debug(`Processed block ${blockHeight} at ${cachedTimestamp}`);
-                        } else {
-                            this.log().warn(`No cached timestamp available for height ${blockHeight}`);
+                // The finalized dump stream can throw a ForkException when the
+                // upstream RPC serves inconsistent finalized data (e.g. a
+                // load-balanced provider whose backend jumped to a recent
+                // snapshot and now reports a gapped/forked view of an already
+                // finalized slot range). Finalized blocks are immutable, so
+                // this is never a real reorg — it's transient provider noise.
+                // appendRawBlocks only persists complete chunks, so the
+                // in-flight (unflushed) buffer is discarded on throw and the
+                // resume point is re-derived from the last persisted chunk on
+                // the next call: identical to a process restart, but without
+                // crash-looping the dumper. We only give up (re-throw) when
+                // retries stop making progress, so a genuine, persistent
+                // archive/chain divergence still surfaces as a hard failure.
+                let lastWrittenBlock = -1
+                await appendWithForkRecovery(
+                    () => archive.appendRawBlocks({
+                        blocks: (nextBlock, prevHash) => this.ingest(nextBlock, prevHash),
+                        range: this.range(),
+                        chunkSize: chunkSize * 1024 * 1024,
+                        onSuccessWrite: ctx => {
+                            const blockHeight = ctx.blockRange.to.number;
+                            lastWrittenBlock = blockHeight;
+                            prometheus.setLastWrittenBlock(blockHeight);
+
+                            const cachedTimestamp = this.timestampCache.get(blockHeight);
+                            if (cachedTimestamp) {
+                                prometheus.setProcessedBlockMetrics(cachedTimestamp);
+                                this.log().debug(`Processed block ${blockHeight} at ${cachedTimestamp}`);
+                            } else {
+                                this.log().warn(`No cached timestamp available for height ${blockHeight}`);
+                            }
                         }
+                    }),
+                    () => lastWrittenBlock,
+                    async ({message, lastWrittenBlock, stuckRetries}) => {
+                        this.log().warn(
+                            {reason: message, lastWrittenBlock, attempt: stuckRetries},
+                            'finalized dump stream hit a chain-continuity error. Finalized data ' +
+                            'is immutable, so this is transient upstream/provider inconsistency ' +
+                            'rather than a real reorg. Discarding the in-flight buffer and ' +
+                            'retrying from the last persisted chunk.'
+                        )
+                        await wait(Math.min(30_000, 1000 * 2 ** stuckRetries))
                     }
-                })
+                )
             }
         }, err => {
             if (err instanceof ErrorMessage) {
@@ -295,5 +324,57 @@ export abstract class Dumper<B extends RawBlock, O extends DumperOptions = Dumpe
 export class ErrorMessage extends Error {
     constructor(msg: string) {
         super(msg)
+    }
+}
+
+
+/**
+ * A ForkException raised by a data source (it carries the `isSqdForkException`
+ * marker). Detected structurally so this package doesn't need to depend on the
+ * data-source package that defines the class.
+ */
+export function isForkException(err: unknown): boolean {
+    return err instanceof Error && (err as {isSqdForkException?: boolean}).isSqdForkException === true
+}
+
+
+/**
+ * Run `append` (a finalized archive append loop), recovering from transient
+ * ForkExceptions instead of crashing.
+ *
+ * On a ForkException the in-flight, not-yet-persisted buffer is dropped and
+ * `append` is invoked again — it re-derives its resume point from the last
+ * persisted chunk, so retrying is equivalent to a clean process restart.
+ *
+ * Recovery is bounded by progress, not a fixed attempt count: as long as a
+ * retry manages to persist a higher block than before, the counter resets.
+ * Only when `maxStuckRetries` consecutive retries fail to advance the last
+ * written block do we re-throw — that signals a genuine, persistent divergence
+ * (not transient provider noise) which must surface as a hard failure rather
+ * than be silently retried forever.
+ */
+export async function appendWithForkRecovery(
+    append: () => Promise<void>,
+    getLastWrittenBlock: () => number,
+    onForkRetry: (info: {message: string; lastWrittenBlock: number; stuckRetries: number}) => Promise<void>,
+    maxStuckRetries = 10,
+): Promise<void> {
+    let lastProgress = -1
+    let stuckRetries = 0
+    while (true) {
+        try {
+            return await append()
+        } catch (err: unknown) {
+            if (!isForkException(err)) throw err
+            let lastWrittenBlock = getLastWrittenBlock()
+            if (lastWrittenBlock > lastProgress) {
+                stuckRetries = 0
+            } else {
+                stuckRetries += 1
+            }
+            lastProgress = lastWrittenBlock
+            if (stuckRetries > maxStuckRetries) throw err
+            await onForkRetry({message: (err as Error).message, lastWrittenBlock, stuckRetries})
+        }
     }
 }


### PR DESCRIPTION
## Symptom
Alert **solana-devnet_Writer_Short_Stall** (solana-archive, kind=ingest, onset 2026-06-19 11:42 PDT). The writer stalls because no new raw chunks are being produced.

## Root cause (proven)
The upstream `dump-solana-devnet-0` pod (ns `solana-archive`) crash-loops (81 restarts, `exit=1`, `reason=Error`). Logs:

```
ForkException: expected 470552136#CwBp9Tj4qG6PvAYnf7CZTF2jpPvzZXBuHY1S8h5FJBUP to have parent
  2mQdd58epwuH5r6mQFLu7i5XmebCTGvNs66zYcu3ppPE, but got 470552135#A2efcChzc1nWqQt5m1NE4kLNdSVB9WsU9rwDi1Ysx2mk
    at ChainFixer.acceptBatch (.../solana-rpc/lib/data-source/chain-fixer.js)
    at SolanaRpcDataSource.getFinalizedStream (...)
    at SolanaDumper.getBlocks (.../solana-dump/lib/dumper.js)
    at Dumper.ingest (.../util-internal-dump-cli/lib/dumper.js)
```

The `ForkException` thrown by `ChainFixer` on the **finalized** dump stream propagates uncaught up through `getFinalizedStream` → `ingest()` → `appendRawBlocks` → `runProgram`, which `log().fatal`s and exits. k8s restarts the pod, it resumes from the last persisted chunk, hits the same upstream inconsistency, and crash-loops indefinitely → writer stall.

### Provider cross-check (independent node implementations — rule against blaming the chain)
`getBlock` for the two slots, **Helius** (the configured endpoint) vs the **official public devnet RPC** (different node implementation):

| slot | Helius | public api.devnet.solana.com |
|---|---|---|
| 470552135 | `A2efcChz…` (clean) | `A2efcChz…` (clean) |
| 470552136 | **`error -32007: Slot 470552136 was skipped … due to ledger jump to recent snapshot`** | `CwBp9Tj4…`, parentSlot 470552135, prev `A2efcChz…` (clean, continuous) |

The chain is **continuous and fine** (block 470552136 links cleanly to 470552135 on the independent source). Helius reports the slot missing due to a **snapshot/ledger jump on a backend** — transient provider inconsistency across its load-balanced nodes. Finalized blocks are immutable, so the `ForkException` here is never a real reorg.

## Fix (tested)
Make the finalized archive dump **survive** the transient inconsistency instead of crash-looping. `appendRawBlocks` only persists *complete* chunks, so the in-flight (unflushed) buffer — including the offending block — is discarded on throw, and the resume point is re-derived from the last persisted chunk on the next call. This PR wraps the finalized append loop so a `ForkException` triggers an **in-process retry from that durable boundary** — identical to a clean process restart, but without exiting.

Recovery is **bounded by progress**: each retry that persists a higher block resets the counter; if `maxStuckRetries` (default 10) consecutive retries make no progress, the exception is **re-thrown** so a genuine, persistent archive/chain divergence still surfaces as a hard failure (it does not silently mask a real regression). Detection is structural (`isSqdForkException` marker) to avoid adding a dependency on the data-source package. Scope is limited to the resumable (archive, `dest != null`) path and only to `ForkException` — non-fork errors (e.g. EVM assertion crashes) propagate unchanged.

### Verification
- Standalone behavior test of `appendWithForkRecovery`: (1) transient forks that advance progress → recovers without re-throwing; (2) non-fork error → propagates immediately; (3) persistent fork with no progress → re-throws after `maxStuckRetries`.
- Provider cross-check above proves a re-fetch yields consistent finalized data (so the retry converges once a healthy backend is hit).

## Falsification
If the dump still crash-loops after this deploys with a `ForkException` whose **last written block never advances across retries**, then the persisted archive itself diverges from the canonical chain (a real corruption, not transient provider noise) — that is a different problem and this guard will correctly re-throw to surface it.

## Operator note (not part of this PR)
The trigger is a **Helius devnet** ledger/snapshot-jump serving inconsistent finalized data. A provider swap would remove today's trigger but is a temporary mitigation, not a durable fix — handing that to operators rather than shipping it here. This code change is the durable resolution: a single provider hiccup can no longer crash-loop the dump.