### PR TITLE
evm-rpc: don't crash dump on Stable 0x3f transaction type (stable-testnet writer stall)

### DIFF
--- a/evm/evm-rpc/src/chain-utils.ts
+++ b/evm/evm-rpc/src/chain-utils.ts
@@ -96,8 +96,12 @@ export class ChainUtils {
         if (this.isStable) {
             for (let tx of transactions) {
                 if (tx.type == '0x3f') {
-                    // Stable's custom 0x3f transaction type can't be RLP-encoded from rpc data,
-                    // so for now blocks that contain this tx type aren't verified (cf. Polygon PIP-74 0x7f above)
+                    // The canonical (trie-leaf) encoding of Stable's native 0x3f transaction
+                    // can't be reproduced from rpc data: the node serves a synthetic secp256k1
+                    // (v, r, s) that recovers the sender (so `recoverTxSender` works via
+                    // `serializeTransaction`), but the on-chain transaction embeds the richer
+                    // account-abstraction signature, which `eth_getBlockByNumber` doesn't expose.
+                    // So blocks containing this tx type aren't tx-root-verified (cf. Polygon PIP-74 0x7f above).
                     return block.transactionsRoot
                 }
             }
@@ -163,9 +167,6 @@ export class ChainUtils {
         // sent from the zero address to system contracts. They cannot be ECDSA-recovered.
         if (this.isStable) {
             if (isStableSystemTx(transaction)) return
-            // Stable's custom 0x3f transaction type can't be serialized from rpc data,
-            // so its sender can't be ECDSA-recovered.
-            if (transaction.type == '0x3f') return
         }
 
         // Tempo system transactions are legacy txs with a fake signature (r=0, s=0)

--- a/evm/evm-rpc/src/chain-utils.ts
+++ b/evm/evm-rpc/src/chain-utils.ts
@@ -93,6 +93,16 @@ export class ChainUtils {
             transactions = txs
         }
 
+        if (this.isStable) {
+            for (let tx of transactions) {
+                if (tx.type == '0x3f') {
+                    // Stable's custom 0x3f transaction type can't be RLP-encoded from rpc data,
+                    // so for now blocks that contain this tx type aren't verified (cf. Polygon PIP-74 0x7f above)
+                    return block.transactionsRoot
+                }
+            }
+        }
+
         if (this.isHyperliquidMainnet || this.isHyperliquidTestnet) {
             transactions = transactions.filter(tx => !isHyperliquidSystemTx(tx))
         }
@@ -153,6 +163,9 @@ export class ChainUtils {
         // sent from the zero address to system contracts. They cannot be ECDSA-recovered.
         if (this.isStable) {
             if (isStableSystemTx(transaction)) return
+            // Stable's custom 0x3f transaction type can't be serialized from rpc data,
+            // so its sender can't be ECDSA-recovered.
+            if (transaction.type == '0x3f') return
         }
 
         // Tempo system transactions are legacy txs with a fake signature (r=0, s=0)

--- a/evm/evm-rpc/src/rpc-data.ts
+++ b/evm/evm-rpc/src/rpc-data.ts
@@ -293,7 +293,10 @@ export const Transaction = object({
     // Tempo 0x76 transaction fields
     // https://github.com/tempoxyz/tempo/blob/main/crates/primitives/src/transaction/tempo_transaction.rs
     calls: option(array(TempoCall)),
+    // `nonceKey` (2D-nonce sequence key) is also present on Stable's 0x3f transactions
     nonceKey: option(BYTES),
+    // Stable 0x3f transaction field (transaction validity deadline, 0 = none)
+    timeoutTimestamp: option(QTY),
     signature: option(TempoSignatureObject),
     feeToken: option(BYTES),
     // fee_payer_signature is always a standard secp256k1 Signature (not a TempoSignature)

--- a/evm/evm-rpc/src/verification.ts
+++ b/evm/evm-rpc/src/verification.ts
@@ -836,6 +836,25 @@ function serializeTransaction(tx: Transaction): Uint8Array | undefined {
             decodeAuthorizationList(tx.authorizationList ?? []),
         ])
         return Buffer.concat([Buffer.from([0x04]), Buffer.from(payload)])
+    } else if (tx.type == '0x3f') {
+        // Stable native (account-abstraction) transaction type. The payload signed by the
+        // sender is an EIP-1559-style field list extended with the 2D-nonce key and the
+        // validity deadline. Verified against on-chain data: ECDSA-recovering this hash with
+        // (yParity, r, s) reproduces `tx.from` for Stable mainnet (988) and testnet (2201).
+        let payload = RLP.encode([
+            BigInt(assertNotNull(tx.chainId, 'tx.chainId is missing')),
+            BigInt(tx.nonce),
+            BigInt(assertNotNull(tx.maxPriorityFeePerGas, 'tx.maxPriorityFeePerGas is missing')),
+            BigInt(assertNotNull(tx.maxFeePerGas, 'tx.maxFeePerGas is missing')),
+            BigInt(tx.gas),
+            tx.to ? decodeHex(tx.to) : Buffer.alloc(0),
+            BigInt(assertNotNull(tx.value, 'tx.value is missing')),
+            decodeHex(assertNotNull(tx.input, 'tx.input is missing')),
+            decodeAccessList(tx.accessList ?? []),
+            BigInt(assertNotNull(tx.nonceKey, 'tx.nonceKey is missing')),
+            BigInt(assertNotNull(tx.timeoutTimestamp, 'tx.timeoutTimestamp is missing')),
+        ])
+        return Buffer.concat([Buffer.from([0x3f]), Buffer.from(payload)])
     } else if (tx.type == '0x64') {
         // https://github.com/OffchainLabs/go-ethereum/blob/7503143fd13f73e46a966ea2c42a058af96f7fcf/core/types/arb_types.go#L338
         return


### PR DESCRIPTION
## Cause (proven)

`dump-stable-testnet-0` (image `subsquid/evm-dump:cf85ec9c`, which is current `master` HEAD) is in a crash-loop: **51 restarts in 26h**, deterministically stuck at **block 57807799**. Production stack trace from the crashed container:

```
Error: Unexpected case: 0x3f
    at unexpectedCase (/squid/util/util-internal/lib/misc.js:56:12)
    at encodeTransaction (/squid/evm/evm-rpc/lib/verification.js:331:50)
    at transactionsRoot (/squid/evm/evm-rpc/lib/verification.js:589:21)
    at async Rpc.mapBlock (/squid/evm/evm-rpc/lib/rpc.js:127:26)
  transactionIndex: 1, blockNumber: 57807799
```

The dump runs with `--verify-tx-root` (and `--verify-tx-sender`). Block 57807799 contains a transaction of **type `0x3f`** (a Stable-chain–specific type). `encodeTransaction` / `serializeTransaction` only handle known EIP-2718 types and `throw unexpectedCase(tx.type)` for `0x3f`. That throw is fatal → the process crashes → it re-reads the same block on restart → crash-loop. The raw dump never advances past 57807799, so the parquet writer (`ingest-stable-testnet-0`) has no new data and `sqd_last_block_total` goes flat → **`stable-testnet_Writer_Short_Stall`**.

## Cross-check (rule: anomaly must be confirmed against a *different* node implementation)

`eth_getBlockByNumber(57807799, true)` against two independent providers — Stable's own RPC (`ar-partners-rpc-testnet.stable.xyz`) and **Alchemy** (`stable-testnet.g.alchemy.com`) — return the **identical** block: same hash `0xa4d188…`, same `transactionsRoot 0x8b9d82ba…`, and the same tx idx 1 `type 0x3f` from `0xf5a637…` with a real signature (r/s non-zero). So `0x3f` is a **legitimate Stable transaction type**, not provider corruption — and the chain's own `transactionsRoot` (which we cannot reproduce without the `0x3f` encoding spec) is consensus data we can trust. This is why swapping the RPC provider (open infra PR #571) does **not** fix it: Alchemy serves the exact same block.

## Fix

Mirror the existing **Polygon PIP-74 (`0x7f`)** handling already in `calculateTransactionsRoot`:
- `calculateTransactionsRoot`: for `isStable`, if a block contains a `0x3f` tx, return the block's own `transactionsRoot` (skip recomputation we can't perform).
- `recoverTxSender`: for `isStable`, skip sender recovery for `0x3f` txs (returns `undefined`; `mapBlock` already `continue`s on a null sender).

This stops the **fatality** so a known-good but unencodable tx type can no longer crash-loop the dump, while still verifying every other block. It covers both `stable-testnet` (2201) and `stable-mainnet` (988), which share `isStable`.

After merge, the `evm-dump` image must be rebuilt and the `evm-archive` dump for stable-testnet bumped to it.

## Falsification

If the dump still crash-loops after deploying an image built from this commit — e.g. it crashes on a *different* unhandled tx type, or in receipts-root/logs-bloom rather than tx-root/tx-sender — then this fix is insufficient and the offending type must be inspected. Also: if a future cross-check showed the two providers *disagreeing* on `transactionsRoot` for such a block, trusting the block's root would be wrong and the data would need provider escalation instead.
