### PR TITLE
worker-thread: make serializeError structured-clone-safe (transient errors must not crash the stream)

### DIFF
--- a/common/changes/@subsquid/util-internal-worker-thread/alert-fix-B4TUWF-worker-thread-error-serialization_2026-06-25-02-44.json
+++ b/common/changes/@subsquid/util-internal-worker-thread/alert-fix-B4TUWF-worker-thread-error-serialization_2026-06-25-02-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/util-internal-worker-thread",
+      "comment": "Make serializeError produce a structured-clone-safe payload so a transient upstream error (e.g. HTTP 429) thrown out of a worker-thread stream cannot crash it with an opaque \"unserializable error\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/util-internal-worker-thread"
+}

--- a/util/util-internal-worker-thread/package.json
+++ b/util/util-internal-worker-thread/package.json
@@ -13,7 +13,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@subsquid/logger": "^1.6.0",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/util/util-internal-worker-thread/src/error.test.ts
+++ b/util/util-internal-worker-thread/src/error.test.ts
@@ -1,0 +1,71 @@
+import assert from 'assert'
+import {it} from 'vitest'
+import {RemoteError, serializeError} from './error'
+
+
+// Mirrors `@subsquid/http-client`'s `HttpResponse`/`HttpError`: an `HttpError`
+// carries a `response` whose `headers` is a `Headers` instance. `Headers` (and
+// other host objects: sockets, streams) cannot be passed through the structured
+// clone algorithm used by `MessagePort.postMessage`. `serializeError` must
+// therefore project error payloads into a clone-safe shape, otherwise a single
+// transient upstream error (e.g. a 429) thrown out of a worker-thread stream
+// crashes the stream with an opaque "unserializable error" instead of being
+// delivered to the host as a proper, classifiable error.
+class HttpResponse {
+    constructor(
+        public readonly status: number,
+        public readonly url: string,
+        public readonly headers: Headers,
+        public readonly body: unknown
+    ) {}
+
+    toJSON() {
+        return {
+            status: this.status,
+            url: this.url,
+            headers: Array.from(this.headers),
+            body: this.body,
+        }
+    }
+}
+
+class HttpError extends Error {
+    constructor(public readonly response: HttpResponse) {
+        super(`Got ${response.status} from ${response.url}`)
+    }
+
+    get name(): string {
+        return 'HttpError'
+    }
+}
+
+function makeHttpError(): HttpError {
+    let headers = new Headers({'content-type': 'text/plain', 'cf-ray': 'deadbeef'})
+    let response = new HttpResponse(429, 'https://rpc.example/vip/key', headers, '{"error":429}')
+    return new HttpError(response)
+}
+
+
+it('serializes an error carrying non-cloneable host objects (Headers) into a structured-clone-safe payload', () => {
+    let ser = serializeError(makeHttpError())
+
+    // `MessagePort.postMessage` uses the structured clone algorithm; this must
+    // not throw a DataCloneError.
+    let cloned = structuredClone(ser)
+
+    assert.strictEqual(cloned.name, 'HttpError')
+    assert.strictEqual(cloned.message, 'Got 429 from https://rpc.example/vip/key')
+    // diagnostic context survives the round-trip
+    assert.strictEqual((cloned as any).response.status, 429)
+    assert.strictEqual((cloned as any).response.url, 'https://rpc.example/vip/key')
+})
+
+
+it('round-trips through RemoteError preserving the response payload', () => {
+    let ser = structuredClone(serializeError(makeHttpError()))
+    let remote = new RemoteError(ser)
+
+    assert.strictEqual(remote.name, 'HttpError')
+    assert.strictEqual(remote.message, 'Got 429 from https://rpc.example/vip/key')
+    assert.strictEqual((remote as any).response.status, 429)
+})

--- a/util/util-internal-worker-thread/src/error.ts
+++ b/util/util-internal-worker-thread/src/error.ts
@@ -13,9 +13,45 @@ export function serializeError(err: Error): SerializedError {
     }
     let key: keyof Error
     for (key in err) {
-        ;(ser as any)[key] = err[key]
+        ;(ser as any)[key] = toTransferable(err[key])
     }
     return ser
+}
+
+
+/**
+ * Project an error's custom property into a value that survives
+ * `MessagePort.postMessage`'s structured clone algorithm.
+ *
+ * Some errors carry non-cloneable payloads — e.g. `@subsquid/http-client`'s
+ * `HttpError` holds a `response` whose `headers` is a `Headers` instance, and
+ * `Headers` (like sockets and streams) cannot be structured-cloned. Left as-is,
+ * a single transient upstream error (a 429, a 5xx) thrown out of a worker-thread
+ * stream would make `Server.send` throw a `DataCloneError`, collapsing into an
+ * opaque "unserializable error" that crashes the stream instead of being
+ * delivered to the host as a proper, retryable error. We flatten such values via
+ * a JSON projection (which honours any `toJSON()`, so diagnostic context like the
+ * HTTP status/url/body is preserved) and drop anything that still can't travel.
+ */
+function toTransferable(value: unknown): unknown {
+    switch (typeof value) {
+        case 'function':
+        case 'symbol':
+            return undefined
+        case 'object':
+            if (value === null) return value
+            try {
+                return structuredClone(value)
+            } catch {
+                try {
+                    return JSON.parse(JSON.stringify(value))
+                } catch {
+                    return String(value)
+                }
+            }
+        default:
+            return value
+    }
 }
 
 


### PR DESCRIPTION
## Problem

A transient upstream error thrown out of a worker-thread stream can crash the
stream with an opaque error instead of being delivered to the host as a proper,
retryable error.

The data-source of an EVM hotblocks ingester runs in a worker thread. When the
upstream RPC returns an intermittent error — e.g. HTTP `429 Too Many Requests` —
an `HttpError` propagates out of the stream. `Server` reports it via
`Server.send`, which `postMessage`s the serialized error across the worker
boundary using the **structured clone** algorithm.

`serializeError` copied the error's own enumerable properties verbatim:

```ts
for (key in err) {
    (ser as any)[key] = err[key]
}
```

`@subsquid/http-client`'s `HttpError` carries a `response` whose `headers` is a
`Headers` instance. `Headers` (like sockets and streams) **cannot be
structured-cloned**, so `postMessage` throws `DataCloneError`.
`Server.handleSerializationFailure` then replaces it with a generic
`Error("stream failed with unserializable error, …")`, which terminates the
ingestion stream.

Observed in production as a tight crash-loop on a rate-limited endpoint:

```
sqd:evm-data-service/data-source  connection failure  HttpError: Got 429 …  method: eth_getBlockByNumber["finalized"]
sqd:data-service  data ingestion terminated, will restart in 0 seconds
  err.stack: Error: stream failed with unserializable error, stack: HttpError: Got 429 …
             at Server.handleSerializationFailure (util-internal-worker-thread/lib/server.js)
```

i.e. an *intermittent* upstream error is turned into a *fatal* stream crash, and
the real error (a retryable 429) is lost.

## Fix

Project each copied error property into a structured-clone-safe value: try
`structuredClone`, fall back to a JSON projection (which honours any `toJSON()`,
so an `HttpError`'s status/url/body survive), and finally drop anything that
still can't travel. `name`/`message`/`stack` are unchanged. The payload is now
guaranteed to cross the worker boundary, so the host receives a faithful,
classifiable error instead of an opaque crash.

## Test

`util/util-internal-worker-thread/src/error.test.ts` builds an `HttpError`-shaped
error whose `response.headers` is a real `Headers` instance and asserts the
`serializeError` output survives `structuredClone` (and round-trips through
`RemoteError` preserving the response payload).

- **Before:** `DataCloneError: Cannot clone object of unsupported type.` (red)
- **After:** passes (green)

```
cd util/util-internal-worker-thread && vitest --run src/error.test.ts
```

This is a long-standing latent defect (the serialization path dates to 2025); it
only manifests under sustained transient upstream errors.

## Scope / falsification

This fixes the **fatality** — a single provider hiccup can no longer crash-loop a
worker-thread stream. It is *not* a fix for the upstream rate-limiting that
triggered the crash-loop in the incident: the offchainlabs RPC serving
`robinhood-mainnet` hotblocks is returning sustained `429`s, which is why
`hotblocks_last_finalized_block` stopped advancing. That trigger needs an
operator action (a second data source / rate-limit relief for the network) and
is handled separately — a provider swap is a temporary mitigation, not a code
change.

Falsified if: after this change, a worker-thread stream still terminates with an
"unserializable error" on a transient `HttpError`, or `serializeError` output
still throws `DataCloneError` for an error carrying host objects.
