### PR TITLE
fix(typeorm-codegen): prune table names over the Postgres identifier limit

### DIFF
--- a/common/changes/@subsquid/typeorm-codegen/master_2026-07-02-00-00.json
+++ b/common/changes/@subsquid/typeorm-codegen/master_2026-07-02-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-codegen",
+      "comment": "Prune entity table names that exceed the PostgreSQL identifier length limit (63 bytes) instead of letting Postgres truncate them silently. A warning is emitted for every pruned name and codegen now fails if two entities collide within the limit. This keeps generated schema and TypeORM migrations consistent (previously over-long names broke `squid-typeorm-migration generate`/`apply`).",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-codegen"
+}

--- a/common/changes/@subsquid/typeorm-codegen/master_2026-07-03-00-00.json
+++ b/common/changes/@subsquid/typeorm-codegen/master_2026-07-03-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-codegen",
+      "comment": "Add a Vitest test suite covering `resolveTableNames` (identifier-limit truncation, collisions, warnings) and `generateOrmModels`/`generateFtsMigrations` across every schema-file feature (scalars, arrays, indexes, relations, `@derivedFrom` lookups, `@query` interfaces, typed JSON, unions, fulltext).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-codegen"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
         version: file:projects/tron-usdt.tgz(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))
       '@rush-temp/typeorm-codegen':
         specifier: file:./projects/typeorm-codegen.tgz
-        version: file:projects/typeorm-codegen.tgz
+        version: file:projects/typeorm-codegen.tgz(esbuild@0.27.7)(tsx@4.21.0)
       '@rush-temp/typeorm-config':
         specifier: file:./projects/typeorm-config.tgz
         version: file:projects/typeorm-config.tgz(ioredis@5.3.2(supports-color@8.1.1))(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))
@@ -1711,7 +1711,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/typeorm-codegen@file:projects/typeorm-codegen.tgz':
-    resolution: {integrity: sha512-zyN0dRngUyvlwCgPPbSjbBc8QDLXttxT9nF1a9rfll5S9rDx/dMsZkm4/hJMJv6D3ED07qGleIsXzSkHUjVJ0A==, tarball: file:projects/typeorm-codegen.tgz}
+    resolution: {integrity: sha512-v2LGX2UrcvJPrYF7DuDuyzidkRu1XeHarXOPfQ7M/C7qS3ZnKI+urwAon7b4I7sLRycJnUXhinbZBH+/DXLvqg==, tarball: file:projects/typeorm-codegen.tgz}
     version: 0.0.0
 
   '@rush-temp/typeorm-config@file:projects/typeorm-config.tgz':
@@ -6847,11 +6847,35 @@ snapshots:
       - ts-node
       - typeorm-aurora-data-api-driver
 
-  '@rush-temp/typeorm-codegen@file:projects/typeorm-codegen.tgz':
+  '@rush-temp/typeorm-codegen@file:projects/typeorm-codegen.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:
       '@types/node': 24.0.15
       commander: 11.1.0
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@rush-temp/typeorm-config@file:projects/typeorm-config.tgz(ioredis@5.3.2(supports-color@8.1.1))(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))':
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6dac105dcc9ceb9a8a8dd3349fcdb05aea393c6e"
+  "pnpmShrinkwrapHash": "664d1eac7e172a514f113a2f3c0dc622565921a3"
 }

--- a/typeorm/typeorm-codegen/package.json
+++ b/typeorm/typeorm-codegen/package.json
@@ -16,7 +16,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@subsquid/logger": "^1.6.0",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/typeorm/typeorm-codegen/package.json
+++ b/typeorm/typeorm-codegen/package.json
@@ -19,6 +19,7 @@
     "build": "rm -rf lib && tsc"
   },
   "dependencies": {
+    "@subsquid/logger": "^1.6.0",
     "@subsquid/openreader": "^5.5.0",
     "@subsquid/util-internal": "^3.3.1",
     "@subsquid/util-internal-code-printer": "^1.2.2",

--- a/typeorm/typeorm-codegen/src/codegen.support.ts
+++ b/typeorm/typeorm-codegen/src/codegen.support.ts
@@ -1,0 +1,60 @@
+import type {Model} from '@subsquid/openreader/lib/model'
+import {loadModel} from '@subsquid/openreader/lib/tools'
+import {OutDir} from '@subsquid/util-internal-code-printer'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+
+const tmpDirs: string[] = []
+
+
+function tmpDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqd-codegen-'))
+    tmpDirs.push(dir)
+    return dir
+}
+
+
+/**
+ * Build a {@link Model} from an in-memory `schema.graphql` string by writing it
+ * to a temp file and running openreader's `loadModel` — the same path the CLI
+ * uses. openreader's base schema predeclares `@entity`/`@index`/`@unique`/
+ * `@fulltext` and all scalars, so the string only needs the `type X @entity {…}`
+ * definitions.
+ */
+export function modelFromSchema(schema: string): Model {
+    const dir = tmpDir()
+    const file = path.join(dir, 'schema.graphql')
+    fs.writeFileSync(file, schema)
+    return loadModel(file)
+}
+
+
+/**
+ * A fresh {@link OutDir} pointed at a throwaway temp directory. `generateOrmModels`
+ * writes real files, so tests read them back from `root`.
+ */
+export function makeOutDir(): {dir: OutDir; root: string} {
+    const root = tmpDir()
+    return {dir: new OutDir(root), root}
+}
+
+
+export function readGenerated(root: string, file: string): string {
+    return fs.readFileSync(path.join(root, file), 'utf8')
+}
+
+
+export function listGenerated(root: string): string[] {
+    return fs.existsSync(root) ? fs.readdirSync(root) : []
+}
+
+
+/** Remove every temp directory created during the test run. Call from `afterEach`. */
+export function cleanupAll(): void {
+    while (tmpDirs.length > 0) {
+        const dir = tmpDirs.pop()!
+        fs.rmSync(dir, {recursive: true, force: true})
+    }
+}

--- a/typeorm/typeorm-codegen/src/codegen.test.ts
+++ b/typeorm/typeorm-codegen/src/codegen.test.ts
@@ -1,0 +1,339 @@
+import {toCamelCase} from '@subsquid/util-naming'
+import fs from 'fs'
+import path from 'path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {generateOrmModels} from './codegen'
+import {cleanupAll, listGenerated, makeOutDir, modelFromSchema, readGenerated} from './codegen.support'
+
+
+const LONG_ENTITY = 'LevrConfigProviderSchemaLiquidationBufferBpsOverUnderUpdated'
+const LONG_TRUNC = 'levr_config_provider_schema_liquidation_buffer_bps_over_under_u'
+
+
+// Generate models for `schema` into a temp dir and return a reader over the output.
+function generate(schema: string) {
+    const {dir, root} = makeOutDir()
+    generateOrmModels(modelFromSchema(schema), dir)
+    return {
+        root,
+        read: (file: string) => readGenerated(root, file),
+        files: () => listGenerated(root),
+    }
+}
+
+
+// Silence (and capture) the truncation warnings the logger writes to stderr.
+let stderr: ReturnType<typeof vi.spyOn>
+const warned = () => stderr.mock.calls.map((c: any) => String(c[0])).join('')
+
+beforeEach(() => {
+    stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+})
+afterEach(() => {
+    vi.restoreAllMocks()
+    cleanupAll()
+})
+
+
+describe('generateOrmModels — entity table name pruning (PR #514)', () => {
+    it('emits a bare @Entity_() for a normal-length entity', () => {
+        const model = generate(`type Account @entity { id: ID! }`).read('account.model.ts')
+        expect(model).toContain('@Entity_()')
+        expect(model).not.toContain('@Entity_("')
+    })
+
+    it('pins an explicit truncated table name for an over-long entity', () => {
+        const g = generate(`type ${LONG_ENTITY} @entity { id: ID! }`)
+        const model = g.read(`${toCamelCase(LONG_ENTITY)}.model.ts`)
+        expect(model).toContain(`@Entity_("${LONG_TRUNC}")`)
+        // the class keeps the full, untruncated name
+        expect(model).toContain(`export class ${LONG_ENTITY}`)
+    })
+
+    it('warns when it truncates an over-long entity', () => {
+        generate(`type ${LONG_ENTITY} @entity { id: ID! }`)
+        expect(warned()).toContain('exceeds the PostgreSQL identifier')
+        expect(warned()).toContain(LONG_ENTITY)
+    })
+
+    it('copies marshal.ts into the output dir', () => {
+        const {root} = generate(`
+            type Foo @entity { id: ID! meta: Meta }
+            type Meta { tag: String }
+        `)
+        const copied = path.join(root, 'marshal.ts')
+        expect(fs.existsSync(copied)).toBe(true)
+        const source = fs.readFileSync(path.join(__dirname, 'marshal.ts'), 'utf8')
+        expect(fs.readFileSync(copied, 'utf8')).toBe(source)
+    })
+})
+
+
+// docs-beta/en/sdk/squid-sdk/reference/schema-file/entities.mdx (+ intro.mdx)
+describe('scalars, id and nullability', () => {
+    const schema = `
+        type Scalar @entity {
+            id: ID!
+            required: Int!
+            boolean: Boolean
+            string: String
+            int: Int
+            float: Float
+            enum: Enum
+            bigint: BigInt
+            bigdecimal: BigDecimal
+            dateTime: DateTime
+            bytes: Bytes
+            json: JSON
+            deep: DeepScalar
+        }
+        type DeepScalar { bigint: BigInt }
+        enum Enum { A B C }
+    `
+
+    it('maps every scalar to the right column decorator', () => {
+        const m = generate(schema).read('scalar.model.ts')
+        expect(m).toContain('@PrimaryColumn_()')
+        expect(m).toContain('@BooleanColumn_({nullable: true})')
+        expect(m).toContain('@StringColumn_({nullable: true})')
+        expect(m).toContain('@IntColumn_({nullable: true})')
+        expect(m).toContain('@FloatColumn_({nullable: true})')
+        expect(m).toContain('@BigIntColumn_({nullable: true})')
+        expect(m).toContain('@BytesColumn_({nullable: true})')
+        expect(m).toContain('@DateTimeColumn_({nullable: true})')
+        expect(m).toContain('@JSONColumn_({nullable: true})')
+        expect(m).toContain('@BigDecimalColumn_({nullable: true})')
+        expect(m).toContain('import {BigDecimal} from "@subsquid/big-decimal"')
+    })
+
+    it('honors non-null vs nullable fields', () => {
+        const m = generate(schema).read('scalar.model.ts')
+        expect(m).toMatch(/@IntColumn_\(\{nullable: false\}\)\s+required!: number\b/)
+        expect(m).toMatch(/string!: string \| undefined \| null/)
+    })
+
+    it('maps enums to a varchar column and generates the enum module', () => {
+        const g = generate(schema)
+        expect(g.read('scalar.model.ts')).toContain('@Column_("varchar", {length: 1, nullable: true})')
+        expect(g.read('scalar.model.ts')).toContain('import {Enum} from "./_enum"')
+        const en = g.read('_enum.ts')
+        expect(en).toContain('export enum Enum {')
+        expect(en).toContain('A = "A",')
+    })
+
+    it('maps a user-defined (non-entity) type to a jsonb column', () => {
+        const m = generate(schema).read('scalar.model.ts')
+        expect(m).toContain('@Column_("jsonb", {transformer:')
+        expect(m).toContain('import * as marshal from "./marshal"')
+    })
+})
+
+
+// entities.mdx — Arrays
+describe('arrays', () => {
+    const schema = `
+        type Lists @entity {
+            id: ID!
+            intArray: [Int!]!
+            enumArray: [Enum!]
+            datetimeArray: [DateTime!]
+            bytesArray: [Bytes!]
+            listOfListsOfInt: [[Int]]
+            listOfJsonObjects: [Foo!]
+        }
+        enum Enum { A B C }
+        type Foo { foo: Int bar: Int }
+    `
+
+    it('maps scalar and enum arrays to array columns', () => {
+        const m = generate(schema).read('lists.model.ts')
+        expect(m).toContain('@IntColumn_({array: true, nullable: false})')
+        expect(m).toContain('@Column_("varchar", {length: 1, array: true, nullable: true})')
+        expect(m).toContain('@DateTimeColumn_({array: true, nullable: true})')
+        expect(m).toContain('@BytesColumn_({array: true, nullable: true})')
+    })
+
+    it('maps nested lists and object lists to jsonb columns', () => {
+        const m = generate(schema).read('lists.model.ts')
+        const jsonb = m.match(/@Column_\("jsonb"/g) ?? []
+        expect(jsonb.length).toBe(2) // listOfListsOfInt + listOfJsonObjects
+    })
+
+    it('rejects native BigInt / BigDecimal arrays', () => {
+        const {dir} = makeOutDir()
+        const model = modelFromSchema(`type Foo @entity { id: ID! nums: [BigInt!]! }`)
+        expect(() => generateOrmModels(model, dir)).toThrow(/unsupported type.*BigInt/)
+    })
+})
+
+
+// indexes-and-constraints.mdx
+describe('indexes and constraints', () => {
+    it('emits @Index_() for @index and @Index_({unique: true}) for @unique', () => {
+        const m = generate(`
+            type Transfer @entity {
+                id: ID!
+                amount: BigInt! @index
+                fee: BigInt! @index @unique
+            }
+        `).read('transfer.model.ts')
+        expect(m).toContain('@Index_()')
+        expect(m).toContain('@Index_({unique: true})')
+    })
+
+    it('emits type-level composite indexes and skips the redundant single-column index', () => {
+        const m = generate(`
+            type Foo @entity @index(fields: ["foo", "bar"]) @index(fields: ["bar", "baz"]) {
+                id: ID!
+                bar: Int!
+                baz: String!
+                foo: String!
+            }
+        `).read('foo.model.ts')
+        expect(m).toContain('@Index_(["foo", "bar"], {unique: false})')
+        expect(m).toContain('@Index_(["bar", "baz"], {unique: false})')
+        // a column that leads a composite index does not also get a bare @Index_()
+        expect(m).not.toContain('@Index_()')
+    })
+
+    it('supports unique composite indexes', () => {
+        const m = generate(`
+            type Extrinsic @entity @index(fields: ["hash", "block"], unique: true) {
+                id: ID!
+                hash: String! @unique
+                block: String!
+            }
+        `).read('extrinsic.model.ts')
+        expect(m).toContain('@Index_(["hash", "block"], {unique: true})')
+    })
+})
+
+
+// entity-relations.mdx
+describe('entity relations and inverse lookups', () => {
+    const schema = `
+        type Account @entity {
+            id: ID!
+            balance: BigInt!
+            user: User @derivedFrom(field: "account")
+            transfersTo: [Transfer!] @derivedFrom(field: "to")
+        }
+        type User @entity {
+            id: ID!
+            account: Account! @unique
+            username: String!
+        }
+        type Transfer @entity {
+            id: ID!
+            to: Account!
+            from: Account!
+            amount: BigInt!
+        }
+    `
+
+    it('maps a many-to-one FK to @Index_() + @ManyToOne_', () => {
+        const m = generate(schema).read('transfer.model.ts')
+        expect(m).toContain('@Index_()')
+        expect(m).toContain('@ManyToOne_(() => Account, {nullable: true})')
+    })
+
+    it('maps an owning @unique relation to @OneToOne_ + @JoinColumn_', () => {
+        const m = generate(schema).read('user.model.ts')
+        expect(m).toContain('@Index_({unique: true})')
+        expect(m).toContain('@OneToOne_(() => Account, {nullable: true})')
+        expect(m).toContain('@JoinColumn_()')
+    })
+
+    it('maps @derivedFrom to virtual @OneToMany_ / @OneToOne_ lookups (no columns)', () => {
+        const m = generate(schema).read('account.model.ts')
+        expect(m).toContain('@OneToMany_(() => Transfer, e => e.to)')
+        expect(m).toContain('@OneToOne_(() => User, e => e.account)')
+        // inverse-lookup fields are virtual — no stored column / join column here
+        expect(m).not.toContain('@Column_')
+        expect(m).not.toContain('@JoinColumn_')
+    })
+
+    it('models a many-to-many join entity as two many-to-one FKs', () => {
+        const m = generate(`
+            type TradeToken @entity {
+                id: ID!
+                trade: Trade!
+                token: Token!
+            }
+            type Token @entity {
+                id: ID!
+                symbol: String!
+                trades: [TradeToken!]! @derivedFrom(field: "token")
+            }
+            type Trade @entity {
+                id: ID!
+                tokens: [TradeToken!]! @derivedFrom(field: "trade")
+            }
+        `).read('tradeToken.model.ts')
+        expect(m).toContain('@ManyToOne_(() => Trade, {nullable: true})')
+        expect(m).toContain('@ManyToOne_(() => Token, {nullable: true})')
+    })
+})
+
+
+// interfaces.mdx
+describe('@query interfaces', () => {
+    const g = () => generate(`
+        interface MyEntity @query {
+            id: ID!
+            name: String
+        }
+        type Foo implements MyEntity @entity {
+            id: ID!
+            name: String
+            foo: Int
+        }
+    `)
+
+    it('produces no model file for the interface', () => {
+        const files = g().files()
+        expect(files).toContain('foo.model.ts')
+        expect(files.some(f => /myentity/i.test(f))).toBe(false)
+    })
+
+    it('still generates entities that implement the interface, and the barrel omits it', () => {
+        const gen = g()
+        expect(gen.read('foo.model.ts')).toContain('export class Foo')
+        const index = gen.read('index.ts')
+        expect(index).toContain('export * from "./foo.model"')
+        expect(index).not.toMatch(/myentity/i)
+    })
+})
+
+
+// unions-and-typed-json.mdx
+describe('unions and typed JSON', () => {
+    const schema = `
+        type User @entity { id: ID! login: String! }
+        type Farmer { user: User! crop: Int }
+        type Degen { user: User! bag: String }
+        union Owner = Farmer | Degen
+        type NFT @entity { id: ID! name: String! owner: Owner! }
+    `
+
+    it('generates a discriminated union module', () => {
+        const u = generate(schema).read('_owner.ts')
+        expect(u).toContain('export type Owner = Farmer | Degen')
+        expect(u).toContain('export function fromJsonOwner(')
+        expect(u).toContain(`case 'Farmer': return new Farmer(undefined, json)`)
+    })
+
+    it('generates typed-JSON classes with an isTypeOf discriminator', () => {
+        const f = generate(schema).read('_farmer.ts')
+        expect(f).toContain(`public readonly isTypeOf = 'Farmer'`)
+        expect(f).toContain('toJSON()')
+        // a JSON type may reference an entity (User) — emitted as its id string
+        expect(f).toContain('import {User} from "./user.model"')
+    })
+
+    it('stores a union-typed field as a jsonb column using the union marshaller', () => {
+        const m = generate(schema).read('nft.model.ts')
+        expect(m).toContain('@Column_("jsonb", {transformer:')
+        expect(m).toContain('fromJsonOwner(obj)')
+    })
+})

--- a/typeorm/typeorm-codegen/src/codegen.ts
+++ b/typeorm/typeorm-codegen/src/codegen.ts
@@ -516,13 +516,14 @@ function getEnumMaxLength(model: Model, enumName: string): number {
  */
 export function resolveTableNames(model: Model): Map<string, string> {
     const tableNames = new Map<string, string>()
-    const owners = new Map<string, string>()
+    const owners = new Map<string, {name: string; truncated: boolean}>()
     for (const name in model) {
         if (model[name].kind !== 'entity') continue
         const fullName = toSnakeCase(name)
         let tableName = fullName
-        if (tableName.length > POSTGRES_MAX_IDENTIFIER_LENGTH) {
-            tableName = tableName.slice(0, POSTGRES_MAX_IDENTIFIER_LENGTH)
+        const truncated = fullName.length > POSTGRES_MAX_IDENTIFIER_LENGTH
+        if (truncated) {
+            tableName = fullName.slice(0, POSTGRES_MAX_IDENTIFIER_LENGTH)
             log.warn(
                 `Table name "${fullName}" (entity "${name}") exceeds the PostgreSQL identifier ` +
                 `length limit of ${POSTGRES_MAX_IDENTIFIER_LENGTH} bytes and will be truncated to ` +
@@ -531,14 +532,17 @@ export function resolveTableNames(model: Model): Map<string, string> {
         }
         const owner = owners.get(tableName)
         if (owner != null) {
+            // The clash is truncation-related if *either* entity was truncated —
+            // e.g. a long name pruned onto an existing natural 63-char name.
+            const viaTruncation = truncated || owner.truncated
             throw new Error(
-                `Entities "${owner}" and "${name}" both map to table name "${tableName}"` +
-                (tableName === fullName ? '' : ` after truncation to ${POSTGRES_MAX_IDENTIFIER_LENGTH} bytes`) +
+                `Entities "${owner.name}" and "${name}" both map to table name "${tableName}"` +
+                (viaTruncation ? ` after truncation to ${POSTGRES_MAX_IDENTIFIER_LENGTH} bytes` : '') +
                 `. Table names must be unique within the PostgreSQL identifier length limit — ` +
                 `rename one of the entities.`
             )
         }
-        owners.set(tableName, name)
+        owners.set(tableName, {name, truncated})
         tableNames.set(name, tableName)
     }
     return tableNames

--- a/typeorm/typeorm-codegen/src/codegen.ts
+++ b/typeorm/typeorm-codegen/src/codegen.ts
@@ -1,13 +1,35 @@
 import type {Entity, Enum, JsonObject, Model, Prop, Union} from '@subsquid/openreader/lib/model'
+import {createLogger} from '@subsquid/logger'
 import {unexpectedCase} from '@subsquid/util-internal'
 import {OutDir, Output} from '@subsquid/util-internal-code-printer'
-import {toCamelCase} from '@subsquid/util-naming'
+import {toCamelCase, toSnakeCase} from '@subsquid/util-naming'
 import assert from 'assert'
 import * as path from 'path'
 
 
+const log = createLogger('sqd:typeorm-codegen')
+
+/**
+ * PostgreSQL silently truncates any identifier longer than `NAMEDATALEN - 1`
+ * (63 bytes with the default build) when it is stored in the catalog. That
+ * breaks TypeORM migrations: the name the ORM derives from the entity no longer
+ * matches the truncated name in the database, so `squid-typeorm-migration
+ * generate` keeps re-emitting `CREATE TABLE` for the affected entity and
+ * `apply` then fails with `relation "..." already exists`.
+ *
+ * To keep the generated schema self-consistent we prune over-long table names
+ * ourselves, deterministically and identically to Postgres' own truncation, and
+ * surface the situation to the user instead of letting it fail downstream.
+ *
+ * GraphQL type names are restricted to ASCII letters, digits and underscores,
+ * and `toSnakeCase` keeps them ASCII, so byte length equals string length here.
+ */
+const POSTGRES_MAX_IDENTIFIER_LENGTH = 63
+
+
 export function generateOrmModels(model: Model, dir: OutDir): void {
     const variants = collectVariants(model)
+    const tableNames = resolveTableNames(model)
     const index = dir.file('index.ts')
 
     for (const name in model) {
@@ -44,7 +66,14 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
             imports.useTypeormStore('Index')
             out.line(`@Index_([${index.fields.map(f => `"${f.name}"`).join(', ')}], {unique: ${!!index.unique}})`)
         })
-        out.line('@Entity_()')
+        const tableName = tableNames.get(name)!
+        if (tableName === toSnakeCase(name)) {
+            out.line('@Entity_()')
+        } else {
+            // Name was pruned to fit the PostgreSQL identifier limit; pin it
+            // explicitly so the ORM and the database agree on it.
+            out.line(`@Entity_("${tableName}")`)
+        }
         out.block(`export class ${name}`, () => {
             out.block(`constructor(props?: Partial<${name}>)`, () => {
                 out.line('Object.assign(this, props)')
@@ -476,6 +505,43 @@ function getEnumMaxLength(model: Model, enumName: string): number {
     const e = model[enumName]
     assert(e.kind === 'enum')
     return Object.keys(e.values).reduce((max, v) => Math.max(max, v.length), 0)
+}
+
+
+/**
+ * Resolve the database table name for every entity, pruning any name that would
+ * overflow PostgreSQL's identifier length limit. Emits a warning for each pruned
+ * name and throws if two entities end up mapped to the same table name — a
+ * collision Postgres could not have disambiguated either.
+ */
+export function resolveTableNames(model: Model): Map<string, string> {
+    const tableNames = new Map<string, string>()
+    const owners = new Map<string, string>()
+    for (const name in model) {
+        if (model[name].kind !== 'entity') continue
+        const fullName = toSnakeCase(name)
+        let tableName = fullName
+        if (tableName.length > POSTGRES_MAX_IDENTIFIER_LENGTH) {
+            tableName = tableName.slice(0, POSTGRES_MAX_IDENTIFIER_LENGTH)
+            log.warn(
+                `Table name "${fullName}" (entity "${name}") exceeds the PostgreSQL identifier ` +
+                `length limit of ${POSTGRES_MAX_IDENTIFIER_LENGTH} bytes and will be truncated to ` +
+                `"${tableName}". Consider shortening the entity name.`
+            )
+        }
+        const owner = owners.get(tableName)
+        if (owner != null) {
+            throw new Error(
+                `Entities "${owner}" and "${name}" both map to table name "${tableName}"` +
+                (tableName === fullName ? '' : ` after truncation to ${POSTGRES_MAX_IDENTIFIER_LENGTH} bytes`) +
+                `. Table names must be unique within the PostgreSQL identifier length limit — ` +
+                `rename one of the entities.`
+            )
+        }
+        owners.set(tableName, name)
+        tableNames.set(name, tableName)
+    }
+    return tableNames
 }
 
 

--- a/typeorm/typeorm-codegen/src/fts.test.ts
+++ b/typeorm/typeorm-codegen/src/fts.test.ts
@@ -1,0 +1,31 @@
+import fs from 'fs'
+import path from 'path'
+import {afterEach, describe, expect, it} from 'vitest'
+import {generateFtsMigrations} from './fts'
+import {cleanupAll, makeOutDir, modelFromSchema} from './codegen.support'
+
+
+afterEach(() => cleanupAll())
+
+
+describe('generateFtsMigrations', () => {
+    it('generates a deterministic fulltext-search migration', () => {
+        const {dir, root} = makeOutDir()
+        const model = modelFromSchema(`
+            type Comment @entity {
+                id: ID!
+                text: String! @fulltext(query: "commentSearch")
+            }
+        `)
+        generateFtsMigrations(model, dir)
+
+        const file = path.join(root, 'commentSearch.search.js')
+        expect(fs.existsSync(file)).toBe(true)
+        const migration = fs.readFileSync(file, 'utf8')
+        // fixed timestamp keeps the class/migration name stable across runs
+        expect(migration).toContain('64060578000000')
+        expect(migration).toContain('ALTER TABLE "comment" ADD COLUMN')
+        expect(migration).toContain('tsvector GENERATED ALWAYS AS')
+        expect(migration).toContain('CREATE INDEX')
+    })
+})

--- a/typeorm/typeorm-codegen/src/resolveTableNames.test.ts
+++ b/typeorm/typeorm-codegen/src/resolveTableNames.test.ts
@@ -1,0 +1,121 @@
+import type {Model} from '@subsquid/openreader/lib/model'
+import {toSnakeCase} from '@subsquid/util-naming'
+import assert from 'assert'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {resolveTableNames} from './codegen'
+
+
+// `resolveTableNames` only reads `model[name].kind` and the key, so we can feed
+// it bare literals instead of building full openreader models.
+function model(...names: string[]): Model {
+    const m: Model = {}
+    for (const n of names) m[n] = {kind: 'entity'} as any
+    return m
+}
+
+// The real over-long entity from PR #514: 69-char snake table name, pinned here.
+const LONG_ENTITY = 'LevrConfigProviderSchemaLiquidationBufferBpsOverUnderUpdated'
+const LONG_FULL = 'levr_config_provider_schema_liquidation_buffer_bps_over_under_updated'
+const LONG_TRUNC = 'levr_config_provider_schema_liquidation_buffer_bps_over_under_u'
+
+
+describe('resolveTableNames', () => {
+    // Silence (and capture) the truncation warnings the logger writes to stderr.
+    let stderr: ReturnType<typeof vi.spyOn>
+    const warned = () => stderr.mock.calls.map((c: any) => String(c[0])).join('')
+
+    beforeEach(() => {
+        stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    })
+    afterEach(() => vi.restoreAllMocks())
+
+    it('maps entity names to snake_case', () => {
+        const r = resolveTableNames(model('MyEntity', 'TokenTransfer'))
+        expect(r.size).toBe(2)
+        expect(r.get('MyEntity')).toBe('my_entity')
+        expect(r.get('TokenTransfer')).toBe('token_transfer')
+    })
+
+    it('excludes non-entity kinds', () => {
+        const m: Model = {
+            Real: {kind: 'entity'} as any,
+            Obj: {kind: 'object'} as any,
+            En: {kind: 'enum'} as any,
+            Uni: {kind: 'union'} as any,
+            Search: {kind: 'fts'} as any,
+        }
+        const r = resolveTableNames(m)
+        expect(r.size).toBe(1)
+        expect([...r.keys()]).toEqual(['Real'])
+    })
+
+    it('keeps a 63-char table name unchanged (boundary)', () => {
+        const name = 'A' + 'a'.repeat(62) // snake length 63
+        assert.strictEqual(toSnakeCase(name).length, 63)
+        const r = resolveTableNames(model(name))
+        const table = r.get(name)!
+        expect(table).toBe(toSnakeCase(name))
+        expect(table.length).toBe(63)
+    })
+
+    it('truncates a 64-char table name to 63 (boundary)', () => {
+        const name = 'A' + 'a'.repeat(63) // snake length 64
+        assert.strictEqual(toSnakeCase(name).length, 64)
+        const table = resolveTableNames(model(name)).get(name)!
+        expect(table.length).toBe(63)
+        expect(table).toBe(toSnakeCase(name).slice(0, 63))
+    })
+
+    it('truncation is the 63-char prefix of the full name', () => {
+        const name = 'A' + 'a'.repeat(63)
+        const full = toSnakeCase(name)
+        const table = resolveTableNames(model(name)).get(name)!
+        expect(full.startsWith(table)).toBe(true)
+        expect(table).toBe(full.slice(0, 63))
+    })
+
+    it('truncates the real-world 69-char name to the exact expected value', () => {
+        assert.strictEqual(toSnakeCase(LONG_ENTITY), LONG_FULL)
+        assert.strictEqual(LONG_FULL.length, 69)
+        const table = resolveTableNames(model(LONG_ENTITY)).get(LONG_ENTITY)!
+        expect(table).toBe(LONG_TRUNC)
+        expect(table.length).toBe(63)
+    })
+
+    it('throws on collision after truncation', () => {
+        // Two distinct 64+/65-char names that both truncate to `a`.repeat(63).
+        const a = 'A' + 'a'.repeat(63) // snake `a`*64
+        const b = 'A' + 'a'.repeat(64) // snake `a`*65
+        const fn = () => resolveTableNames(model(a, b))
+        expect(fn).toThrow(/both map to table name/)
+        expect(fn).toThrow(/after truncation to 63 bytes/)
+        expect(fn).toThrow(new RegExp(`"${a}"`))
+        expect(fn).toThrow(new RegExp(`"${b}"`))
+    })
+
+    it('throws on collision without truncation', () => {
+        // FooBar and Foo_bar both snake to `foo_bar`.
+        assert.strictEqual(toSnakeCase('FooBar'), toSnakeCase('Foo_bar'))
+        let err: Error | undefined
+        try {
+            resolveTableNames(model('FooBar', 'Foo_bar'))
+        } catch (e) {
+            err = e as Error
+        }
+        expect(err).toBeInstanceOf(Error)
+        expect(err!.message).toMatch(/both map to table name "foo_bar"/)
+        expect(err!.message).not.toContain('after truncation')
+    })
+
+    it('warns on truncation', () => {
+        const overLong = 'A' + 'a'.repeat(63)
+        resolveTableNames(model(overLong))
+        expect(warned()).toContain('exceeds the PostgreSQL identifier')
+        expect(warned()).toContain(overLong)
+    })
+
+    it('stays silent when nothing is truncated', () => {
+        resolveTableNames(model('A' + 'a'.repeat(62))) // 63 chars, not truncated
+        expect(warned()).toBe('')
+    })
+})

--- a/typeorm/typeorm-codegen/src/resolveTableNames.test.ts
+++ b/typeorm/typeorm-codegen/src/resolveTableNames.test.ts
@@ -93,6 +93,18 @@ describe('resolveTableNames', () => {
         expect(fn).toThrow(new RegExp(`"${b}"`))
     })
 
+    it('reports truncation context even when only the prior owner was truncated', () => {
+        // Owner truncates to `a`*63; the colliding entity is a *natural* 63-char
+        // name (not truncated), processed second. The message must still mention
+        // truncation, since the clash is caused by the owner being pruned.
+        const truncated = 'A' + 'a'.repeat(63) // snake `a`*64 -> `a`*63
+        const natural = 'A' + 'a'.repeat(62) // snake `a`*63, not truncated
+        assert.strictEqual(toSnakeCase(natural), toSnakeCase(truncated).slice(0, 63))
+        const fn = () => resolveTableNames(model(truncated, natural))
+        expect(fn).toThrow(/both map to table name/)
+        expect(fn).toThrow(/after truncation to 63 bytes/)
+    })
+
     it('throws on collision without truncation', () => {
         // FooBar and Foo_bar both snake to `foo_bar`.
         assert.strictEqual(toSnakeCase('FooBar'), toSnakeCase('Foo_bar'))


### PR DESCRIPTION
## Problem

PostgreSQL silently truncates any identifier longer than `NAMEDATALEN - 1` (63 bytes by default). When an entity's snake_cased table name exceeds that limit, the name TypeORM derives from the entity (full length) no longer matches the truncated name Postgres actually stored in the catalog. The migration tooling then never converges:

1. `apply` runs `CREATE TABLE "long_name_...updated"` → Postgres stores it truncated to 63 bytes (`long_name_...u`).
2. `squid-typeorm-migration generate` introspects the catalog, reads the *truncated* name, compares it to the ORM's full-length expected name, decides the table is **missing**, and re-emits a full `CREATE TABLE` (+ PK + indexes) for it. The "incremental" migration is never empty.
3. Re-applying that migration runs `CREATE TABLE` again → truncates again → collides with the table already there → **`relation "long_name_...u" already exists`**.

Production squids with long entity names (e.g. event tables like `LevrConfigProviderSchemaLiquidationBufferBpsOverUnderUpdated`, 69 chars snake-cased) hit this and cannot generate an incremental index migration without a full DB reset. Column/index auto-names (`IDX_<hash>`) are short and unaffected — only the entity **table** names overflow.

## Fix

Prune over-long table names at codegen time, deterministically and identically to Postgres' own truncation, and pin the result with an explicit `@Entity_("...")` name so the ORM and the database always agree on it:

- **Warn** for every pruned name (via `@subsquid/logger`, matching `typeorm-config`'s house style), pointing the user at the entity to shorten.
- **Throw** at codegen time if two entities collide within the 63-byte limit — a clash Postgres could not have disambiguated either — instead of emitting silently-broken output.
- Short names are untouched: they still emit a bare `@Entity_()`, so existing generated models don't churn.

Because the truncation point (`slice(0, 63)`) matches Postgres' own, **already-deployed squids with over-long names become consistent on the next `codegen` run** — `generate` returns empty and no DB reset is required.

## Verification

Built with `tsc` (clean). Exercised the compiled output directly:

- normal entity → `account`
- `LevrConfigProviderSchemaLiquidationBufferBpsOverUnderUpdated` (69 chars) → warning + `levr_config_provider_schema_liquidation_buffer_bps_over_under_u` (exactly 63, matching what Postgres already stores)
- two entities sharing the first 63 chars → clear `Error` at codegen time

End-to-end `squid-typeorm-codegen` run confirms the over-long entity's model gets `@Entity_("levr_config_provider_schema_liquidation_buffer_bps_over_under_u")` while a normal entity keeps `@Entity_()`.

## Notes

- `@subsquid/logger` is added as a dependency; it is an in-repo workspace package (already pulled in transitively via `@subsquid/openreader`), so the pnpm lockfile's external-dependency graph is unchanged.
- Scope is intentionally limited to entity table names — the reported failure mode. Column names and join-table names could in principle overflow too, but those are not the observed problem and would be a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)