### PR TITLE
feat(typeorm-codegen): generate stable, readable index names

### DIFF
--- a/common/changes/@subsquid/typeorm-codegen/master_2026-07-03-12-00.json
+++ b/common/changes/@subsquid/typeorm-codegen/master_2026-07-03-12-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-codegen",
+      "comment": "Generate stable, readable index names of the form `idx_<entity>_<fields>_<hash>` instead of relying on TypeORM's opaque `IDX_<hash>` names. The default names are derived from the table name, so they change whenever a table name changes (e.g. when it is pruned to fit the identifier limit), forcing migrations to drop and recreate indexes. The generated names are derived from the entity/field identity and capped at the PostgreSQL identifier limit with a deterministic hash suffix that guarantees uniqueness. NOTE: upgrading an existing squid renames all of its indexes once (a one-time drop/recreate on the next migration), after which migrations stay stable.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-codegen"
+}

--- a/typeorm/typeorm-codegen/src/codegen.test.ts
+++ b/typeorm/typeorm-codegen/src/codegen.test.ts
@@ -169,7 +169,7 @@ describe('arrays', () => {
 
 // indexes-and-constraints.mdx
 describe('indexes and constraints', () => {
-    it('emits @Index_() for @index and @Index_({unique: true}) for @unique', () => {
+    it('emits a named index for @index and a named unique index for @unique', () => {
         const m = generate(`
             type Transfer @entity {
                 id: ID!
@@ -177,8 +177,8 @@ describe('indexes and constraints', () => {
                 fee: BigInt! @index @unique
             }
         `).read('transfer.model.ts')
-        expect(m).toContain('@Index_()')
-        expect(m).toContain('@Index_({unique: true})')
+        expect(m).toMatch(/@Index_\("idx_transfer_amount_[0-9a-f]{8}"\)/)
+        expect(m).toMatch(/@Index_\("idx_transfer_fee_[0-9a-f]{8}", \{unique: true\}\)/)
     })
 
     it('emits type-level composite indexes and skips the redundant single-column index', () => {
@@ -190,10 +190,10 @@ describe('indexes and constraints', () => {
                 foo: String!
             }
         `).read('foo.model.ts')
-        expect(m).toContain('@Index_(["foo", "bar"], {unique: false})')
-        expect(m).toContain('@Index_(["bar", "baz"], {unique: false})')
-        // a column that leads a composite index does not also get a bare @Index_()
-        expect(m).not.toContain('@Index_()')
+        expect(m).toMatch(/@Index_\("idx_foo_foo_bar_[0-9a-f]{8}", \["foo", "bar"\], \{unique: false\}\)/)
+        expect(m).toMatch(/@Index_\("idx_foo_bar_baz_[0-9a-f]{8}", \["bar", "baz"\], \{unique: false\}\)/)
+        // columns that only lead composites get no extra single-column index
+        expect(m.match(/@Index_\(/g)).toHaveLength(2)
     })
 
     it('supports unique composite indexes', () => {
@@ -204,7 +204,7 @@ describe('indexes and constraints', () => {
                 block: String!
             }
         `).read('extrinsic.model.ts')
-        expect(m).toContain('@Index_(["hash", "block"], {unique: true})')
+        expect(m).toMatch(/@Index_\("idx_extrinsic_hash_block_[0-9a-f]{8}", \["hash", "block"\], \{unique: true\}\)/)
     })
 })
 
@@ -231,15 +231,15 @@ describe('entity relations and inverse lookups', () => {
         }
     `
 
-    it('maps a many-to-one FK to @Index_() + @ManyToOne_', () => {
+    it('maps a many-to-one FK to a named @Index_ + @ManyToOne_', () => {
         const m = generate(schema).read('transfer.model.ts')
-        expect(m).toContain('@Index_()')
+        expect(m).toMatch(/@Index_\("idx_transfer_to_[0-9a-f]{8}"\)/)
         expect(m).toContain('@ManyToOne_(() => Account, {nullable: true})')
     })
 
     it('maps an owning @unique relation to @OneToOne_ + @JoinColumn_', () => {
         const m = generate(schema).read('user.model.ts')
-        expect(m).toContain('@Index_({unique: true})')
+        expect(m).toMatch(/@Index_\("idx_user_account_[0-9a-f]{8}", \{unique: true\}\)/)
         expect(m).toContain('@OneToOne_(() => Account, {nullable: true})')
         expect(m).toContain('@JoinColumn_()')
     })
@@ -335,5 +335,75 @@ describe('unions and typed JSON', () => {
         const m = generate(schema).read('nft.model.ts')
         expect(m).toContain('@Column_("jsonb", {transformer:')
         expect(m).toContain('fromJsonOwner(obj)')
+    })
+})
+
+
+// Stable, readable, collision-free index names across every index-producing
+// schema-file feature (field @index/@unique, composite @index, FK, unique FK).
+describe('stable index names', () => {
+    // one schema exercising every kind of generated index
+    const schema = `
+        type Order @entity @index(fields: ["seller", "createdAt"]) @index(fields: ["region", "createdAt"], unique: true) {
+            id: ID!
+            status: Status! @index
+            price: BigInt! @index @unique
+            region: String!
+            createdAt: DateTime!
+            seller: Account!
+            shipper: Account!
+            invoice: Invoice! @unique
+        }
+        type Account @entity { id: ID! }
+        type Invoice @entity { id: ID! }
+        enum Status { OPEN FILLED }
+    `
+
+    const NAME = /"(idx_[a-z0-9_]+_[0-9a-f]{8})"/g
+
+    function indexNames(model: string): string[] {
+        return [...model.matchAll(NAME)].map(m => m[1])
+    }
+
+    it('names every generated index as idx_<readable>_<8-hex-hash>', () => {
+        const m = generate(schema).read('order.model.ts')
+        const names = indexNames(m)
+        // two composites + enum field @index + scalar field @unique + m2o FK + unique FK
+        expect(names).toHaveLength(6)
+        expect(names).toEqual(expect.arrayContaining([
+            expect.stringMatching(/^idx_order_seller_created_at_[0-9a-f]{8}$/), // composite
+            expect.stringMatching(/^idx_order_region_created_at_[0-9a-f]{8}$/), // unique composite
+            expect.stringMatching(/^idx_order_status_[0-9a-f]{8}$/),            // enum field @index
+            expect.stringMatching(/^idx_order_price_[0-9a-f]{8}$/),             // scalar field @index @unique
+            expect.stringMatching(/^idx_order_shipper_[0-9a-f]{8}$/),           // m2o FK
+            expect.stringMatching(/^idx_order_invoice_[0-9a-f]{8}$/),           // unique FK (o2o)
+        ]))
+    })
+
+    it('keeps every index name within the PostgreSQL identifier limit', () => {
+        const m = generate(schema).read('order.model.ts')
+        for (const name of indexNames(m)) expect(name.length).toBeLessThanOrEqual(63)
+    })
+
+    it('produces unique names for every index in the schema', () => {
+        const m = generate(schema).read('order.model.ts')
+        const names = indexNames(m)
+        expect(new Set(names).size).toBe(names.length)
+    })
+
+    it('is stable — regenerating the same schema yields identical names', () => {
+        const first = indexNames(generate(schema).read('order.model.ts'))
+        const second = indexNames(generate(schema).read('order.model.ts'))
+        expect(second).toEqual(first)
+    })
+
+    it('stays within 63 bytes for an entity whose name already overflows', () => {
+        const m = generate(`
+            type ${LONG_ENTITY} @entity { id: ID! amount: BigInt! @index }
+        `).read(`${toCamelCase(LONG_ENTITY)}.model.ts`)
+        const names = indexNames(m)
+        expect(names).toHaveLength(1)
+        expect(names[0].length).toBeLessThanOrEqual(63)
+        expect(names[0]).toMatch(/^idx_.+_[0-9a-f]{8}$/)
     })
 })

--- a/typeorm/typeorm-codegen/src/codegen.ts
+++ b/typeorm/typeorm-codegen/src/codegen.ts
@@ -4,6 +4,7 @@ import {unexpectedCase} from '@subsquid/util-internal'
 import {OutDir, Output} from '@subsquid/util-internal-code-printer'
 import {toCamelCase, toSnakeCase} from '@subsquid/util-naming'
 import assert from 'assert'
+import {createHash} from 'crypto'
 import * as path from 'path'
 
 
@@ -26,11 +27,59 @@ const log = createLogger('sqd:typeorm-codegen')
  */
 const POSTGRES_MAX_IDENTIFIER_LENGTH = 63
 
+/**
+ * Length of the deterministic hash suffix appended to every generated index
+ * name. It keeps names unique even after the readable part is truncated to fit
+ * the identifier limit.
+ */
+const INDEX_NAME_HASH_LENGTH = 8
+
+
+/**
+ * Build a stable, readable index name of the form `idx_<entity>_<fields>_<hash>`,
+ * capped at the PostgreSQL identifier limit.
+ *
+ * By default TypeORM names an unnamed index `IDX_<sha1(table + columns)>`, which
+ * is opaque and — because it is derived from the *table* name — silently changes
+ * whenever the table name does (e.g. when it is pruned to fit the identifier
+ * limit), forcing migrations to drop and recreate the index. Here the name is
+ * derived from the entity and field identity instead, so it stays put across
+ * codegen runs and table-name changes, while the hash suffix guarantees
+ * uniqueness even when the readable prefix is truncated.
+ */
+export function makeIndexName(entity: string, fields: string[], unique: boolean): string {
+    const identity = `${entity}|${fields.join(',')}|${unique ? 'unique' : ''}`
+    const hash = createHash('sha1').update(identity).digest('hex').slice(0, INDEX_NAME_HASH_LENGTH)
+    const readable = ['idx', toSnakeCase(entity), ...fields.map(toSnakeCase)].join('_')
+    const budget = POSTGRES_MAX_IDENTIFIER_LENGTH - INDEX_NAME_HASH_LENGTH - 1 // room for `_<hash>`
+    const prefix = readable.length > budget ? readable.slice(0, budget) : readable
+    return `${prefix}_${hash}`
+}
+
 
 export function generateOrmModels(model: Model, dir: OutDir): void {
     const variants = collectVariants(model)
     const tableNames = resolveTableNames(model)
     const index = dir.file('index.ts')
+
+    // Index names must be unique across the whole database schema, not just per
+    // table. Compute them once through here so a (vanishingly unlikely) hash
+    // collision fails loudly at codegen time instead of at migration time.
+    const indexNamesByName = new Map<string, string>()
+    function indexNameFor(entity: string, fields: string[], unique: boolean): string {
+        const name = makeIndexName(entity, fields, unique)
+        const identity = `${entity}(${fields.join(', ')})${unique ? ' unique' : ''}`
+        const previous = indexNamesByName.get(name)
+        if (previous != null && previous !== identity) {
+            throw new Error(
+                `Index name "${name}" is generated for two different indexes — ${previous} and ` +
+                `${identity}. This is an extremely unlikely hash collision; rename a field or ` +
+                `entity to work around it.`
+            )
+        }
+        indexNamesByName.set(name, identity)
+        return name
+    }
 
     for (const name in model) {
         const item = model[name]
@@ -61,10 +110,13 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
         out.lazy(() => imports.render(model, out))
         out.line()
         printComment(entity, out)
+        const nameIndex = (fields: string[], unique: boolean) => indexNameFor(name, fields, unique)
         entity.indexes?.forEach(index => {
             if (index.fields.length < 2) return
             imports.useTypeormStore('Index')
-            out.line(`@Index_([${index.fields.map(f => `"${f.name}"`).join(', ')}], {unique: ${!!index.unique}})`)
+            const fields = index.fields.map(f => f.name)
+            const indexName = nameIndex(fields, !!index.unique)
+            out.line(`@Index_("${indexName}", [${fields.map(f => `"${f}"`).join(', ')}], {unique: ${!!index.unique}})`)
         })
         const tableName = tableNames.get(name)!
         if (tableName === toSnakeCase(name)) {
@@ -91,12 +143,12 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                             const decorator = getDecorator(prop.type.name)
                             imports.useTypeormStore(decorator)
 
-                            addIndexAnnotation(entity, key, imports, out)
+                            addIndexAnnotation(entity, key, imports, out, nameIndex)
                             out.line(`@${decorator}_({nullable: ${prop.nullable}})`)
                         }
                         break
                     case 'enum':
-                        addIndexAnnotation(entity, key, imports, out)
+                        addIndexAnnotation(entity, key, imports, out, nameIndex)
                         out.line(
                             `@Column_("varchar", {length: ${getEnumMaxLength(
                                 model,
@@ -110,7 +162,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                             : ''
                         if (getFieldIndex(entity, key)?.unique) {
                             imports.useTypeormStore('OneToOne', 'Index', 'JoinColumn')
-                            out.line(`@Index_({unique: true})`)
+                            out.line(`@Index_("${nameIndex([key], true)}", {unique: true})`)
                             out.line(
                                 `@OneToOne_(() => ${prop.type.entity}, {nullable: true${fkOptions}})`
                             )
@@ -118,7 +170,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                         } else {
                             imports.useTypeormStore('ManyToOne', 'Index')
                             if (!entity.indexes?.some(index => index.fields[0]?.name == key && index.fields.length > 1)) {
-                                out.line(`@Index_()`)
+                                out.line(`@Index_("${nameIndex([key], false)}")`)
                             }
                             // Make foreign entity references always nullable
                             out.line(
@@ -561,14 +613,21 @@ function collectVariants(model: Model): Set<string> {
 }
 
 
-function addIndexAnnotation(entity: Entity, field: string, imports: ImportRegistry, out: Output): void {
+function addIndexAnnotation(
+    entity: Entity,
+    field: string,
+    imports: ImportRegistry,
+    out: Output,
+    nameIndex: (fields: string[], unique: boolean) => string
+): void {
     let index = getFieldIndex(entity, field)
     if (index == null) return
     imports.useTypeormStore('Index')
+    const indexName = nameIndex([field], !!index.unique)
     if (index.unique) {
-        out.line(`@Index_({unique: true})`)
+        out.line(`@Index_("${indexName}", {unique: true})`)
     } else {
-        out.line(`@Index_()`)
+        out.line(`@Index_("${indexName}")`)
     }
 }
 

--- a/typeorm/typeorm-codegen/src/indexName.test.ts
+++ b/typeorm/typeorm-codegen/src/indexName.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest'
+import {makeIndexName} from './codegen'
+
+
+describe('makeIndexName', () => {
+    it('has the form idx_<entity>_<fields>_<8-hex-hash>', () => {
+        const name = makeIndexName('Transfer', ['amount'], false)
+        expect(name).toMatch(/^idx_transfer_amount_[0-9a-f]{8}$/)
+    })
+
+    it('snake_cases the entity and field names in the readable prefix', () => {
+        const name = makeIndexName('TokenTransfer', ['blockNumber', 'logIndex'], false)
+        expect(name).toMatch(/^idx_token_transfer_block_number_log_index_[0-9a-f]{8}$/)
+    })
+
+    it('is deterministic', () => {
+        expect(makeIndexName('Foo', ['a', 'b'], false)).toBe(makeIndexName('Foo', ['a', 'b'], false))
+    })
+
+    it('distinguishes unique from non-unique indexes on the same fields', () => {
+        expect(makeIndexName('Foo', ['a'], true)).not.toBe(makeIndexName('Foo', ['a'], false))
+    })
+
+    it('distinguishes column order', () => {
+        expect(makeIndexName('Foo', ['a', 'b'], false)).not.toBe(makeIndexName('Foo', ['b', 'a'], false))
+    })
+
+    it('distinguishes different entities with the same fields', () => {
+        expect(makeIndexName('Foo', ['a'], false)).not.toBe(makeIndexName('Bar', ['a'], false))
+    })
+
+    it('never exceeds the PostgreSQL identifier limit, even for very long names', () => {
+        const entity = 'A'.repeat(80)
+        const fields = ['someVeryLongColumnName', 'anotherVeryLongColumnName', 'yetAnotherOne']
+        const name = makeIndexName(entity, fields, false)
+        expect(name.length).toBeLessThanOrEqual(63)
+        expect(name).toMatch(/_[0-9a-f]{8}$/) // hash suffix survives truncation
+    })
+
+    it('stays unique after the readable prefix is truncated', () => {
+        // Two entities sharing a long common prefix but differing past the cutoff
+        // still get distinct names thanks to the hash of the full identity.
+        const a = makeIndexName('X'.repeat(70) + 'Alpha', ['f'], false)
+        const b = makeIndexName('X'.repeat(70) + 'Beta', ['f'], false)
+        expect(a).not.toBe(b)
+    })
+})


### PR DESCRIPTION
## Problem

TypeORM names an unnamed index `IDX_<sha1(table + sorted columns)>` (via `DefaultNamingStrategy.indexName`; `SnakeNamingStrategy` doesn't override it). Those names are:

- **opaque** — they carry no table/column info, so a migration diff is unreadable, and
- **coupled to the table name** — the hash input includes the table name, so the index name silently changes whenever the table name does. In particular, when a table name is pruned to fit the 63-byte identifier limit (see #514), every index on that table gets a new `IDX_` hash → `squid-typeorm-migration generate` drops and recreates them. Regenerating against a different TypeORM version can shift *all* of them.

This is what caused the "regenerated migration recreated all indexes without discrimination" behavior after the table-name-truncation fix shipped.

## Change

Codegen now emits an **explicit, stable name at every index site** — field `@index`/`@unique`, type-level composite `@index`, many-to-one FK, and unique (one-to-one) FK:

```
idx_<entity>_<fields>_<8-hex-hash>
```

- Derived from the **entity/field identity**, not the resolved table name → stable across codegen runs *and* table-name changes.
- Capped at the PostgreSQL identifier limit (63 bytes); the readable prefix is truncated to make room for the hash.
- The deterministic hash suffix keeps names **unique** even after the prefix is truncated, and encodes the field list + uniqueness so distinct indexes never share a name. A (vanishingly unlikely) collision throws at codegen time rather than silently at migration time.

Example: `@Index_("idx_transfer_amount_6eb4bb5d")`, `@Index_("idx_order_seller_created_at_4bb50e5a", ["seller", "createdAt"], {unique: false})`.

### Where this lives

The naming is emitted by **`typeorm-codegen`** (into the generated `@Index_` decorators), because that's the layer that knows how each schema-file construct maps to an index — which also keeps it decoupled from the table-name truncation. `typeorm-migration` is unchanged; it simply serializes the names TypeORM now has in the entity metadata.

### One-time cost

Upgrading an existing squid renames all of its indexes once — a one-time drop/recreate on the next migration. After that, migrations stay stable. Called out in the changelog.

## Tests

Anticipating the tests request: extended the (pure, no-DB) Vitest suite — **48 tests total**.

- `indexName.test.ts` — unit tests for the name builder: format, snake-casing, determinism, unique-vs-non-unique, column order, cross-entity distinctness, ≤63-byte cap on very long names, and uniqueness after prefix truncation.
- `codegen.test.ts` — a `stable index names` block covering **every index-producing schema-file feature** (field `@index`, field `@unique`, enum field index, type-level composite, unique composite, many-to-one FK, unique FK), asserting the `idx_…_<hash>` shape, the ≤63-byte cap, uniqueness across the schema, and **stability across regeneration**. The existing per-feature index/relation assertions were updated to the named forms.

`npm test` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)