### PR TITLE
fix(openreader): truncate table names to the Postgres identifier limit

### DIFF
--- a/common/changes/@subsquid/openreader/master_2026-07-03-13-00.json
+++ b/common/changes/@subsquid/openreader/master_2026-07-03-13-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/openreader",
+      "comment": "Truncate generated table names to the PostgreSQL identifier limit (63 bytes) so queries target the same table `@subsquid/typeorm-codegen` creates for over-long entity names. Previously OpenReader emitted the full untruncated name and relied on the server truncating it to match — which only holds when the server's NAMEDATALEN equals the default. On a build with a larger NAMEDATALEN the reference would miss the (already-pruned) table; it now works regardless of NAMEDATALEN. No effect on entity names within the limit.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/openreader"
+}

--- a/graphql/openreader/src/test/util.test.ts
+++ b/graphql/openreader/src/test/util.test.ts
@@ -1,0 +1,34 @@
+import {toSnakeCase} from '@subsquid/util-naming'
+import {POSTGRES_MAX_IDENTIFIER_LENGTH, toTable} from '../util/util'
+
+
+describe('toTable', function() {
+    it('snake_cases short entity names unchanged', function() {
+        expect(toTable('Account')).toBe('account')
+        expect(toTable('TokenTransfer')).toBe('token_transfer')
+    })
+
+    it('truncates names that exceed the identifier limit, matching typeorm-codegen', function() {
+        // The physical table typeorm-codegen creates for this entity.
+        const entity = 'LevrConfigProviderSchemaLiquidationBufferBpsOverUnderUpdated'
+        const full = toSnakeCase(entity)
+        expect(full.length).toBeGreaterThan(POSTGRES_MAX_IDENTIFIER_LENGTH)
+
+        const table = toTable(entity)
+        expect(table.length).toBe(POSTGRES_MAX_IDENTIFIER_LENGTH)
+        expect(table).toBe(full.slice(0, POSTGRES_MAX_IDENTIFIER_LENGTH))
+        expect(table).toBe('levr_config_provider_schema_liquidation_buffer_bps_over_under_u')
+    })
+
+    it('leaves a name exactly at the limit unchanged (boundary)', function() {
+        const entity = 'A' + 'a'.repeat(62) // snake length 63
+        expect(toSnakeCase(entity).length).toBe(POSTGRES_MAX_IDENTIFIER_LENGTH)
+        expect(toTable(entity)).toBe(toSnakeCase(entity))
+    })
+
+    it('truncates a name one byte over the limit (boundary)', function() {
+        const entity = 'A' + 'a'.repeat(63) // snake length 64
+        expect(toSnakeCase(entity).length).toBe(POSTGRES_MAX_IDENTIFIER_LENGTH + 1)
+        expect(toTable(entity).length).toBe(POSTGRES_MAX_IDENTIFIER_LENGTH)
+    })
+})

--- a/graphql/openreader/src/util/util.ts
+++ b/graphql/openreader/src/util/util.ts
@@ -15,6 +15,10 @@ import {Prop} from "../model"
  * (already-pruned) table. Truncating here makes the generated SQL target the
  * right table regardless of the server's `NAMEDATALEN`.
  *
+ * GraphQL type names are restricted to ASCII letters, digits and underscores,
+ * and `toSnakeCase` keeps them ASCII, so `name.length` below equals the byte
+ * length — the unit PostgreSQL's limit is actually measured in.
+ *
  * Keep this value in sync with `typeorm-codegen`'s `POSTGRES_MAX_IDENTIFIER_LENGTH`.
  */
 export const POSTGRES_MAX_IDENTIFIER_LENGTH = 63

--- a/graphql/openreader/src/util/util.ts
+++ b/graphql/openreader/src/util/util.ts
@@ -3,6 +3,30 @@ import assert from "assert"
 import {Prop} from "../model"
 
 
+/**
+ * PostgreSQL truncates any identifier longer than `NAMEDATALEN - 1` (63 bytes on
+ * a default build) when it is stored in the catalog. `@subsquid/typeorm-codegen`
+ * prunes over-long table names to this limit when generating the schema, so the
+ * physical table is created with at most this many bytes.
+ *
+ * We must apply the *same* truncation when building queries, otherwise on a
+ * server whose `NAMEDATALEN` is larger than the default we would emit the full,
+ * untruncated name — which Postgres would not truncate — and it would miss the
+ * (already-pruned) table. Truncating here makes the generated SQL target the
+ * right table regardless of the server's `NAMEDATALEN`.
+ *
+ * Keep this value in sync with `typeorm-codegen`'s `POSTGRES_MAX_IDENTIFIER_LENGTH`.
+ */
+export const POSTGRES_MAX_IDENTIFIER_LENGTH = 63
+
+
+function truncateIdentifier(name: string): string {
+    return name.length > POSTGRES_MAX_IDENTIFIER_LENGTH
+        ? name.slice(0, POSTGRES_MAX_IDENTIFIER_LENGTH)
+        : name
+}
+
+
 export function toColumn(gqlFieldName: string): string {
     return toSnakeCase(gqlFieldName)
 }
@@ -14,7 +38,7 @@ export function toFkColumn(gqlFieldName: string): string {
 
 
 export function toTable(entityName: string): string {
-    return toSnakeCase(entityName)
+    return truncateIdentifier(toSnakeCase(entityName))
 }
 
 


### PR DESCRIPTION
## Problem

`@subsquid/typeorm-codegen` prunes an entity's table name to PostgreSQL's identifier limit (63 bytes / `NAMEDATALEN - 1`) when it exceeds it, and pins the pruned name via `@Entity_("…")` (see #514). So the **physical** table for an over-long entity is at most 63 bytes.

OpenReader, however, derives the table name independently in `toTable(entityName)` as plain `toSnakeCase(entityName)` — **no length cap**. For an over-long entity it emits the full untruncated name in its SQL and relied on PostgreSQL truncating that identifier at parse time to land on the same table.

That only holds when the server's `NAMEDATALEN` is the default 64. On a build with a **larger `NAMEDATALEN`**, Postgres would *not* truncate the reference, so `SELECT … FROM "<full 69-byte name>"` would miss the (already-pruned, 63-byte) table — `relation does not exist`.

## Fix

Apply the same 63-byte truncation in `toTable`, so the generated SQL targets the exact table `typeorm-codegen` created, independent of the server's `NAMEDATALEN`:

```ts
export function toTable(entityName: string): string {
    return truncateIdentifier(toSnakeCase(entityName))
}
```

- **No-op for entity names within the limit** — every normal schema is unaffected (byte-identical output), so no regression risk for existing deployments.
- For the common default-`NAMEDATALEN` case it also changes nothing observable: previously the full name was truncated by Postgres to the same 63 bytes; now it's truncated by us to the same value first.

`toTable` is the single chokepoint for table references (used only in `sql/cursor.ts`), so this covers all generated queries.

The `POSTGRES_MAX_IDENTIFIER_LENGTH` constant must stay in sync with `typeorm-codegen`'s; it's commented as such and exported so it can be unified later.

## Tests

Added a pure (no-DB) unit test for `toTable`: short names unchanged, over-long names truncated to exactly 63 bytes matching the physical table `typeorm-codegen` produces, and the 63/64-byte boundary. Verified the truncated output equals the real production table name.

Verified against the live prod endpoint that the over-long entities resolve today (they do, via Postgres truncation on the default build); this change makes that resolution independent of `NAMEDATALEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)