### PR TITLE
fix(evm-rpc): keep finalizer queue contiguous so finalized head advances past probe window

### DIFF
--- a/common/changes/@subsquid/evm-rpc/alert-fix-1suVP6-evm-finalizer-gap_2026-07-03-02-36.json
+++ b/common/changes/@subsquid/evm-rpc/alert-fix-1suVP6-evm-finalizer-gap_2026-07-03-02-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "Fix finalizer freezing the reported finalized head when finality lag exceeds the probe window",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-rpc/src/data-source/finalizer.test.ts
+++ b/evm/evm-rpc/src/data-source/finalizer.test.ts
@@ -1,0 +1,104 @@
+import {describe, expect, it} from 'vitest'
+import type {Rpc} from '../rpc'
+import type {Block} from '../types'
+import {finalize} from './finalizer'
+import type {IngestBatch} from './ingest'
+
+function wait(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function createFuture<T>(): {promise(): Promise<T>; resolve(value: T): void} {
+    let resolve!: (value: T) => void
+    let promise = new Promise<T>((res) => (resolve = res))
+    return {promise: () => promise, resolve}
+}
+
+// A block whose top-level hash matches block.block.hash, as real blocks do.
+// getBlockRef reads block.block.hash; the finalizer probe compares info.hash.
+function mkBlock(number: number): Block {
+    return {
+        number,
+        hash: '0x' + number,
+        block: {hash: '0x' + number, parentHash: '0x' + (number - 1)} as Block['block'],
+    }
+}
+
+// Stub Rpc exposing only getFinalizedBlockBatch, mirroring the real one:
+// it keeps the ascending prefix of requested numbers that are <= the current
+// finalized head and returns those blocks index-aligned with that prefix.
+function mkRpc(finalizedHead: () => number): Rpc {
+    return {
+        async getFinalizedBlockBatch(numbers: number[]): Promise<Block[]> {
+            let head = finalizedHead()
+            return numbers.filter((n) => n <= head).map(mkBlock)
+        },
+    } as unknown as Rpc
+}
+
+// Feed all hot (non-finalized) batches, then hold the input stream open so the
+// finalization loop can keep probing, until we observe the target finalized head
+// (fixed behaviour) or no new finalization arrives within `idleMs` (frozen).
+async function maxFinalized(
+    rpc: Rpc,
+    batches: IngestBatch[],
+    target: number,
+    idleMs = 2000
+): Promise<number> {
+    let stop = createFuture<void>()
+    async function* input(): AsyncIterable<IngestBatch> {
+        for (let b of batches) yield b
+        await stop.promise()
+    }
+
+    let max = 0
+    let it = finalize(rpc, input())[Symbol.asyncIterator]()
+    try {
+        while (true) {
+            let step = await Promise.race([
+                it.next().then((r) => ({r}) as const),
+                wait(idleMs).then(() => ({idle: true}) as const),
+            ])
+            if ('idle' in step) break
+            if (step.r.done) break
+            let fh = step.r.value.finalizedHead
+            if (fh) max = Math.max(max, fh.number)
+            if (max >= target) break
+        }
+    } finally {
+        stop.resolve()
+        await it.return?.()
+    }
+    return max
+}
+
+describe('EvmRpcDataSource finalizer', () => {
+    // Regression: when more than the internal probe-window's worth of hot blocks
+    // arrive before they finalize (large finality lag, as on L2s/rollups), the
+    // finalizer must still reach the true finalized head. Feeding them as one
+    // batch fills the queue in a single pass, reproducing the freeze.
+    it('reaches the finalized head when the lag exceeds the probe window', async () => {
+        let COUNT = 300
+        let FINALIZED = 120 // > the historical 50-block cap
+        let rpc = mkRpc(() => FINALIZED)
+
+        let batch: IngestBatch = {
+            blocks: Array.from({length: COUNT}, (_, i) => mkBlock(i + 1)),
+            finalized: undefined,
+        }
+
+        let max = await maxFinalized(rpc, [batch], FINALIZED)
+        expect(max).toBe(FINALIZED)
+    })
+
+    // Sanity: a small lag (fits the window) keeps working.
+    it('reaches the finalized head when the lag is small', async () => {
+        let rpc = mkRpc(() => 10)
+        let batch: IngestBatch = {
+            blocks: Array.from({length: 20}, (_, i) => mkBlock(i + 1)),
+            finalized: undefined,
+        }
+        let max = await maxFinalized(rpc, [batch], 10)
+        expect(max).toBe(10)
+    })
+})

--- a/evm/evm-rpc/src/data-source/finalizer.ts
+++ b/evm/evm-rpc/src/data-source/finalizer.ts
@@ -88,12 +88,10 @@ class Finalizer {
                 finalizedHead: batch.finalized
             }
         } else {
+            // Keep the queue contiguous: capping it by overwriting the last slot
+            // dropped middle refs, freezing finalization when the lag exceeded the cap.
             for (let block of batch.blocks) {
-                if (this.queue.length > 50) {
-                    this.queue[this.queue.length - 1] = getBlockRef(block)
-                } else {
-                    this.queue.push(getBlockRef(block))
-                }
+                this.queue.push(getBlockRef(block))
             }
             this.checks.forcePut(null)
             return {


### PR DESCRIPTION
## Problem

For chains whose **finalized head advances in large jumps** (L2 / rollup batch finality — e.g. zksync-mainnet, worldchain-mainnet, alpen-testnet, robinhood-mainnet), the hot-block data service stops advancing its reported finalized head. `hotblocks_last_finalized_block` freezes while `hotblocks_last_block` (unfinalized head) keeps advancing, and the data service logs `block finalization lags behind and prevents cache purging` on every new head. This fires the `Portal_Hotblocks_Head_Metrics_Absent_*` alert (`increase(hotblocks_last_finalized_block[12h]) == 0`).

Observed in production: zksync-mainnet reported finalized frozen at `71020159` while the chain's real finalized head (`eth_getBlockByNumber("finalized")`, agreed by two independent providers) was `71027108` — a ~6,900-block gap that only grows.

## Root cause

`Finalizer.visit()` in `evm/evm-rpc/src/data-source/finalizer.ts` bounds its probe queue by **overwriting the last slot** once it exceeds ~50 entries:

```ts
if (this.queue.length > 50) {
    this.queue[this.queue.length - 1] = getBlockRef(block)   // drops the middle
} else {
    this.queue.push(getBlockRef(block))
}
```

This keeps only the oldest ~50 unfinalized refs plus the single latest block, leaving a **gap** in between. The finalizer probes from the front and can only advance the finalized head through contiguous refs. When the finality lag exceeds the window, it finalizes the ~50 contiguous refs, hits the gap, and can never reach the true finalized head — so the reported finalized head freezes.

Chains with smooth, incremental finality (Ethereum PoS, most L1s) slide within the window and are unaffected — matching the fact that only large-jump-finality networks froze.

## Fix

Keep the queue contiguous — always `push`. The queue is now bounded by the finality lag (the range we must track anyway), and it holds tiny `BlockRef`s (number + hash), so memory is negligible relative to the full-block buffer the data service already keeps.

## Test

Added `evm/evm-rpc/src/data-source/finalizer.test.ts`. The regression test feeds >50 unfinalized blocks in one batch with the finalized head beyond the old cap and asserts the finalizer reaches the true finalized head.

- **pre-fix:** `expected 50 to be 120` (frozen at the 50-block cap)
- **post-fix:** passes; full `evm-rpc` suite green (154 passed, 27 skipped), `tsc` build and `tsc --noEmit -p tsconfig.test.json` clean.

## Falsification

If, after deploying an `evm-data-service` image built from this commit, a large-jump-finality network's `hotblocks_last_finalized_block` still stops advancing while its RPC `finalized` tag advances, this fix is insufficient. (Note: running pods must be redeployed to a rebuilt image — the fix cannot take effect via restart alone, since the same code re-freezes once the lag re-exceeds the window.)
