### PR TITLE
fix(rpc-client): treat Cloudflare 5xx (521-524) as retryable connection errors

### DIFF
--- a/common/changes/@subsquid/rpc-client/alert-fix-SgDu2H-svm-bnb-522-crash_2026-07-07-12-38.json
+++ b/common/changes/@subsquid/rpc-client/alert-fix-SgDu2H-svm-bnb-522-crash_2026-07-07-12-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/rpc-client",
+      "comment": "Treat Cloudflare-origin 5xx (521-524) as retryable connection errors so a transient upstream error is backed off and retried instead of being thrown as fatal and crashing the process",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/rpc-client"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
         version: file:projects/portal-client.tgz
       '@rush-temp/rpc-client':
         specifier: file:./projects/rpc-client.tgz
-        version: file:projects/rpc-client.tgz
+        version: file:projects/rpc-client.tgz(esbuild@0.27.7)(tsx@4.21.0)
       '@rush-temp/scale-codec':
         specifier: file:./projects/scale-codec.tgz
         version: file:projects/scale-codec.tgz(esbuild@0.27.7)(tsx@4.21.0)
@@ -1351,11 +1351,11 @@ packages:
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
 
   '@rush-temp/astar-erc20@file:projects/astar-erc20.tgz':
-    resolution: {integrity: sha512-SGkGjZMIHJLcLl31qW0PeGzfOvkMSqaolLQYGZaYpLfs+tebTejEmshgVJQoUGQYI/WvtPpVr72Y+hSUEiVJyA==, tarball: file:projects/astar-erc20.tgz}
+    resolution: {integrity: sha512-4oVI6RjCCzW3luYLmJkYgICnt0h785p+K74sNYzuuwzI+3qzhhCzgBfXWXaa+MbZWAdXRRMXmzZdEktqpAgr5w==, tarball: file:projects/astar-erc20.tgz}
     version: 0.0.0
 
   '@rush-temp/balances@file:projects/balances.tgz':
-    resolution: {integrity: sha512-LNNdLjWHYY/+7YJHQS340tnXBU3y8uAudKWetRJVTdvyORrksF/2ju52vWMwANOx9YwQITQimV7ezCSNeBMojA==, tarball: file:projects/balances.tgz}
+    resolution: {integrity: sha512-6xkQbPIGlxceQ+rDak4eNLI1Yu3Bq2tmMYdxkb0uromjhRe2YG24ZwTcwd8DVwZpL8m66EPrgTzjBIisG5pYcQ==, tarball: file:projects/balances.tgz}
     version: 0.0.0
 
   '@rush-temp/batch-processor@file:projects/batch-processor.tgz':
@@ -1403,7 +1403,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/erc20-transfers@file:projects/erc20-transfers.tgz':
-    resolution: {integrity: sha512-Neo63VOxFTmYQiS9zsGEsHuPv0xFnL3+/0WY/Qqdk5+PBUaR9L+bBBhBYLsMZuHPahghpGHYD88Z9yP/LZL1CQ==, tarball: file:projects/erc20-transfers.tgz}
+    resolution: {integrity: sha512-qxFeP5FiAvxod9XL/CM5qtmHhs633hmAT/GDt4jdIseD1q+4XMF162o1LFYFcSxtcj0Xbej9Wa8lfxO/eA1YVg==, tarball: file:projects/erc20-transfers.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-abi@file:projects/evm-abi.tgz':
@@ -1487,7 +1487,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/graphql-server@file:projects/graphql-server.tgz':
-    resolution: {integrity: sha512-8ZNtd77GPIIhjcoDdqEq4+PdbCny8GNCl2O1c0I3krJo2Mn55Hpm/ETECNwhVRGXm3LcFSW1cXWCWrI7KnlcIA==, tarball: file:projects/graphql-server.tgz}
+    resolution: {integrity: sha512-DfQHf0EybKZXFS34kSsOu7RYu+EFVzAOD8k9jM10EV4/y1vY9urXFxwFkzXBNw20/mhstStKUx/ppyPUR8abKw==, tarball: file:projects/graphql-server.tgz}
     version: 0.0.0
 
   '@rush-temp/http-client@file:projects/http-client.tgz':
@@ -1547,7 +1547,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/polkavm-erc20@file:projects/polkavm-erc20.tgz':
-    resolution: {integrity: sha512-bCTo1NxdXgH/52HWYB+joE+IZFW0Vf5SuEvlrJltP6Pzj4Cu3qasYiNq7gkptSMxH5zPGgND3aEilEleEkMGwA==, tarball: file:projects/polkavm-erc20.tgz}
+    resolution: {integrity: sha512-JxxbU1WKTGQvjSaIAJaJFwILdpC0swRC2NoH9LwTRBdYXNVjHOZW5nLJoiRAYts7OuSkkIBfBXGYM+4yJjb6Nw==, tarball: file:projects/polkavm-erc20.tgz}
     version: 0.0.0
 
   '@rush-temp/portal-client@file:projects/portal-client.tgz':
@@ -1555,7 +1555,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/rpc-client@file:projects/rpc-client.tgz':
-    resolution: {integrity: sha512-HqxZAlZm1oF+GIAFZkFlt8M4+Qv7weOM1EztrdFZ4rfaNuPGWL2JwKko1uERvcRfcVDuq0baZ15d8lPoo8OJfQ==, tarball: file:projects/rpc-client.tgz}
+    resolution: {integrity: sha512-K8Kvjux5qNebvJ1E8PP4tK0NDS7ygTYI+UsoOe1pHgrrYXOx31weW9FsaLxfUFg5BLrllaf3bIJ2QG52TnNqOg==, tarball: file:projects/rpc-client.tgz}
     version: 0.0.0
 
   '@rush-temp/scale-codec@file:projects/scale-codec.tgz':
@@ -1567,11 +1567,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/shibuya-erc20@file:projects/shibuya-erc20.tgz':
-    resolution: {integrity: sha512-MKUAzYRr+bD2NzYPN0/f+CDBuCyPjejBvwuAYNygvasOCquNO8DRq+38qQPS2ERVkJA05H50hG76F6X7Nb5BGw==, tarball: file:projects/shibuya-erc20.tgz}
+    resolution: {integrity: sha512-KgAoHqXKK+HPPM4VchaPUpSJMIALqgN45YAv+h68GtLKBHIdhUuSxyteOusxMO20ikyjHzlZi78ftK7OFoyMVA==, tarball: file:projects/shibuya-erc20.tgz}
     version: 0.0.0
 
   '@rush-temp/shibuya-psp22@file:projects/shibuya-psp22.tgz':
-    resolution: {integrity: sha512-r19MO3p/wiOVlfON8QYgbCsETz6feIQ/e6ZBpX6wKZrZwGm2AKJ/MqbWOixQu2b8YZ/JQ+QZZrYx+YtzS5osHw==, tarball: file:projects/shibuya-psp22.tgz}
+    resolution: {integrity: sha512-ZRryi5lLN3qzUU9BqfinQYInBBynn2oC4zy2+ZLrfzMGKfm6UkPVpxUFUZTGv+V1nQGVtGBtSIBcUkhSg6+EsA==, tarball: file:projects/shibuya-psp22.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-data-service@file:projects/solana-data-service.tgz':
@@ -1707,11 +1707,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/tron-usdt@file:projects/tron-usdt.tgz':
-    resolution: {integrity: sha512-JUrHazzpRzZQMnljnahq2Fx0aJlK6kLLB56oODMe03Xsimz2ID3Hzb1V9T6AkVA28UOrKllQqgtmFwgq218bCw==, tarball: file:projects/tron-usdt.tgz}
+    resolution: {integrity: sha512-X7GwKQxDmMFypIImnSSilnIy0aIcD2ZfeZ/aEjzO6vY8AORAFwHYIDPNo8utKNhCGD96icQ+tnHrbgioO3mAGA==, tarball: file:projects/tron-usdt.tgz}
     version: 0.0.0
 
   '@rush-temp/typeorm-codegen@file:projects/typeorm-codegen.tgz':
-    resolution: {integrity: sha512-v2LGX2UrcvJPrYF7DuDuyzidkRu1XeHarXOPfQ7M/C7qS3ZnKI+urwAon7b4I7sLRycJnUXhinbZBH+/DXLvqg==, tarball: file:projects/typeorm-codegen.tgz}
+    resolution: {integrity: sha512-m7JySlewtz84M10J50GKWNKnyjDv70RVx/NgzO6FeaZl1enLREea3NHI2pwHK1+HytAB3YgkZZLpCXDoPnURow==, tarball: file:projects/typeorm-codegen.tgz}
     version: 0.0.0
 
   '@rush-temp/typeorm-config@file:projects/typeorm-config.tgz':
@@ -6376,12 +6376,36 @@ snapshots:
       '@types/node': 24.0.15
       typescript: 5.5.4
 
-  '@rush-temp/rpc-client@file:projects/rpc-client.tgz':
+  '@rush-temp/rpc-client@file:projects/rpc-client.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:
       '@types/node': 24.0.15
       '@types/websocket': 1.0.10
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
       websocket: 1.0.34
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@rush-temp/scale-codec@file:projects/scale-codec.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "664d1eac7e172a514f113a2f3c0dc622565921a3"
+  "pnpmShrinkwrapHash": "51afce8903f6628d28b10f5eea3f75fb07fd2904"
 }

--- a/util/rpc-client/package.json
+++ b/util/rpc-client/package.json
@@ -13,7 +13,8 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@subsquid/http-client": "^1.8.1",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@types/websocket": "^1.0.10",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/util/rpc-client/src/client.test.ts
+++ b/util/rpc-client/src/client.test.ts
@@ -1,0 +1,32 @@
+import {HttpError, HttpResponse} from '@subsquid/http-client'
+import {describe, expect, it} from 'vitest'
+import {RpcClient} from './client'
+
+// A transient Cloudflare 5xx (521-524) must be treated as a retryable connection
+// error, matching @subsquid/http-client's isRetryableError. Otherwise it is thrown
+// as fatal and crashes the ingestion process instead of being backed off and retried.
+function httpError(status: number): HttpError {
+    return new HttpError(new HttpResponse(1, 'https://rpc.example/rpc', status, new Headers() as any, '', false))
+}
+
+describe('RpcClient.isConnectionError', () => {
+    const client = new RpcClient({url: 'http://localhost:1/', log: null})
+
+    it('treats Cloudflare 5xx (521-524) as retryable connection errors', () => {
+        for (let status of [521, 522, 523, 524]) {
+            expect(client.isConnectionError(httpError(status)), `status ${status}`).toBe(true)
+        }
+    })
+
+    it('keeps existing retryable statuses', () => {
+        for (let status of [408, 429, 502, 503, 504]) {
+            expect(client.isConnectionError(httpError(status)), `status ${status}`).toBe(true)
+        }
+    })
+
+    it('does not treat genuine client/server errors as connection errors', () => {
+        for (let status of [400, 404, 500]) {
+            expect(client.isConnectionError(httpError(status)), `status ${status}`).toBe(false)
+        }
+    })
+})

--- a/util/rpc-client/src/client.ts
+++ b/util/rpc-client/src/client.ts
@@ -536,6 +536,10 @@ export class RpcClient {
                 case 502:
                 case 503:
                 case 504:
+                case 521:
+                case 522:
+                case 523:
+                case 524:
                     return true
                 default:
                     return false


### PR DESCRIPTION
## Problem

The `svm-bnb_No_Dumper_Data` alert fired: `dump-svm-bnb-0` (ns `solana-archive`) crash-looped (exit 1) with `call failed with unserializable error` originating from a transient Cloudflare `522` returned by the sole endpoint `rpc.svmbnbmainnet.soo.network`.

Root cause is in `RpcClient.isConnectionError` (`util/rpc-client/src/client.ts`): it classifies `408/429/502/503/504` as retryable connection errors but **omits Cloudflare-origin `521-524`** — even though `@subsquid/http-client`'s own `isRetryableError` already treats `521-524` as retryable. A `522` is therefore classified **fatal**, thrown out of the worker-thread stream, and crashes the dumper (the opaque `unserializable error` is the error then failing structured-clone at the worker boundary). `429` is in the set, so the post-restart pod stalls-and-retries rather than crashing.

## Fix

Add `521/522/523/524` to the retryable-status switch in `isConnectionError`, so a transient Cloudflare 5xx is backed off and retried in-worker instead of escaping as fatal.

## Relationship to #509

Complementary, not duplicate. This PR stops a `522` **before** it escapes the worker (retried in-place). #509 hardens `serializeError` so any error that *does* escape the worker boundary is delivered as a classifiable error rather than an opaque `unserializable error`. Both are needed for full defence-in-depth; this PR is the primary fix for the observed `522` crash.

## Test

Adds `util/rpc-client/src/client.test.ts` — unit-tests `isConnectionError` across statuses (RED before fix on 521-524, GREEN after). `vitest --run`: 3/3 passing. Rush change file added; `rush update` lockfile churn verified deterministic/CI-consistent.

## Operational follow-up (escalate)

The endpoint is up + archival (direct probe: HTTP 200, slot 74143670; burst of 10 concurrent full-block reqs all 200), but the dumper's client is being `429`-throttled specifically (`requests_served_total` = 0 for 3h+). The code fix stops the crash-loop but does not restore throughput — the single `rpc.svmbnbmainnet.soo.network` endpoint (`stride_concurrency: 10`, no rate limit configured) needs a provider-side rate-limit / additional endpoint. Escalate to the infra/provider owner.