### PR TITLE
[fix] Worker threads leaking in `belowQuery` (`util-internal-data-service`)

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
         version: file:projects/util-internal-counters.tgz
       '@rush-temp/util-internal-data-service':
         specifier: file:./projects/util-internal-data-service.tgz
-        version: file:projects/util-internal-data-service.tgz
+        version: file:projects/util-internal-data-service.tgz(esbuild@0.27.7)(tsx@4.21.0)
       '@rush-temp/util-internal-data-source':
         specifier: file:./projects/util-internal-data-source.tgz
         version: file:projects/util-internal-data-source.tgz(esbuild@0.27.7)(tsx@4.21.0)
@@ -1351,11 +1351,11 @@ packages:
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
 
   '@rush-temp/astar-erc20@file:projects/astar-erc20.tgz':
-    resolution: {integrity: sha512-SGkGjZMIHJLcLl31qW0PeGzfOvkMSqaolLQYGZaYpLfs+tebTejEmshgVJQoUGQYI/WvtPpVr72Y+hSUEiVJyA==, tarball: file:projects/astar-erc20.tgz}
+    resolution: {integrity: sha512-4oVI6RjCCzW3luYLmJkYgICnt0h785p+K74sNYzuuwzI+3qzhhCzgBfXWXaa+MbZWAdXRRMXmzZdEktqpAgr5w==, tarball: file:projects/astar-erc20.tgz}
     version: 0.0.0
 
   '@rush-temp/balances@file:projects/balances.tgz':
-    resolution: {integrity: sha512-LNNdLjWHYY/+7YJHQS340tnXBU3y8uAudKWetRJVTdvyORrksF/2ju52vWMwANOx9YwQITQimV7ezCSNeBMojA==, tarball: file:projects/balances.tgz}
+    resolution: {integrity: sha512-6xkQbPIGlxceQ+rDak4eNLI1Yu3Bq2tmMYdxkb0uromjhRe2YG24ZwTcwd8DVwZpL8m66EPrgTzjBIisG5pYcQ==, tarball: file:projects/balances.tgz}
     version: 0.0.0
 
   '@rush-temp/batch-processor@file:projects/batch-processor.tgz':
@@ -1403,7 +1403,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/erc20-transfers@file:projects/erc20-transfers.tgz':
-    resolution: {integrity: sha512-Neo63VOxFTmYQiS9zsGEsHuPv0xFnL3+/0WY/Qqdk5+PBUaR9L+bBBhBYLsMZuHPahghpGHYD88Z9yP/LZL1CQ==, tarball: file:projects/erc20-transfers.tgz}
+    resolution: {integrity: sha512-qxFeP5FiAvxod9XL/CM5qtmHhs633hmAT/GDt4jdIseD1q+4XMF162o1LFYFcSxtcj0Xbej9Wa8lfxO/eA1YVg==, tarball: file:projects/erc20-transfers.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-abi@file:projects/evm-abi.tgz':
@@ -1487,7 +1487,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/graphql-server@file:projects/graphql-server.tgz':
-    resolution: {integrity: sha512-8ZNtd77GPIIhjcoDdqEq4+PdbCny8GNCl2O1c0I3krJo2Mn55Hpm/ETECNwhVRGXm3LcFSW1cXWCWrI7KnlcIA==, tarball: file:projects/graphql-server.tgz}
+    resolution: {integrity: sha512-DfQHf0EybKZXFS34kSsOu7RYu+EFVzAOD8k9jM10EV4/y1vY9urXFxwFkzXBNw20/mhstStKUx/ppyPUR8abKw==, tarball: file:projects/graphql-server.tgz}
     version: 0.0.0
 
   '@rush-temp/http-client@file:projects/http-client.tgz':
@@ -1547,7 +1547,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/polkavm-erc20@file:projects/polkavm-erc20.tgz':
-    resolution: {integrity: sha512-bCTo1NxdXgH/52HWYB+joE+IZFW0Vf5SuEvlrJltP6Pzj4Cu3qasYiNq7gkptSMxH5zPGgND3aEilEleEkMGwA==, tarball: file:projects/polkavm-erc20.tgz}
+    resolution: {integrity: sha512-JxxbU1WKTGQvjSaIAJaJFwILdpC0swRC2NoH9LwTRBdYXNVjHOZW5nLJoiRAYts7OuSkkIBfBXGYM+4yJjb6Nw==, tarball: file:projects/polkavm-erc20.tgz}
     version: 0.0.0
 
   '@rush-temp/portal-client@file:projects/portal-client.tgz':
@@ -1567,11 +1567,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/shibuya-erc20@file:projects/shibuya-erc20.tgz':
-    resolution: {integrity: sha512-MKUAzYRr+bD2NzYPN0/f+CDBuCyPjejBvwuAYNygvasOCquNO8DRq+38qQPS2ERVkJA05H50hG76F6X7Nb5BGw==, tarball: file:projects/shibuya-erc20.tgz}
+    resolution: {integrity: sha512-KgAoHqXKK+HPPM4VchaPUpSJMIALqgN45YAv+h68GtLKBHIdhUuSxyteOusxMO20ikyjHzlZi78ftK7OFoyMVA==, tarball: file:projects/shibuya-erc20.tgz}
     version: 0.0.0
 
   '@rush-temp/shibuya-psp22@file:projects/shibuya-psp22.tgz':
-    resolution: {integrity: sha512-r19MO3p/wiOVlfON8QYgbCsETz6feIQ/e6ZBpX6wKZrZwGm2AKJ/MqbWOixQu2b8YZ/JQ+QZZrYx+YtzS5osHw==, tarball: file:projects/shibuya-psp22.tgz}
+    resolution: {integrity: sha512-ZRryi5lLN3qzUU9BqfinQYInBBynn2oC4zy2+ZLrfzMGKfm6UkPVpxUFUZTGv+V1nQGVtGBtSIBcUkhSg6+EsA==, tarball: file:projects/shibuya-psp22.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-data-service@file:projects/solana-data-service.tgz':
@@ -1707,11 +1707,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/tron-usdt@file:projects/tron-usdt.tgz':
-    resolution: {integrity: sha512-JUrHazzpRzZQMnljnahq2Fx0aJlK6kLLB56oODMe03Xsimz2ID3Hzb1V9T6AkVA28UOrKllQqgtmFwgq218bCw==, tarball: file:projects/tron-usdt.tgz}
+    resolution: {integrity: sha512-X7GwKQxDmMFypIImnSSilnIy0aIcD2ZfeZ/aEjzO6vY8AORAFwHYIDPNo8utKNhCGD96icQ+tnHrbgioO3mAGA==, tarball: file:projects/tron-usdt.tgz}
     version: 0.0.0
 
   '@rush-temp/typeorm-codegen@file:projects/typeorm-codegen.tgz':
-    resolution: {integrity: sha512-v2LGX2UrcvJPrYF7DuDuyzidkRu1XeHarXOPfQ7M/C7qS3ZnKI+urwAon7b4I7sLRycJnUXhinbZBH+/DXLvqg==, tarball: file:projects/typeorm-codegen.tgz}
+    resolution: {integrity: sha512-m7JySlewtz84M10J50GKWNKnyjDv70RVx/NgzO6FeaZl1enLREea3NHI2pwHK1+HytAB3YgkZZLpCXDoPnURow==, tarball: file:projects/typeorm-codegen.tgz}
     version: 0.0.0
 
   '@rush-temp/typeorm-config@file:projects/typeorm-config.tgz':
@@ -1759,7 +1759,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/util-internal-data-service@file:projects/util-internal-data-service.tgz':
-    resolution: {integrity: sha512-nCmHyWfCKJp+Y7vZ0TQmAKw4tdiFOdNNQh00fTLsZv1QaOqxPSOTOAB3Nez1CPidkJ6dGJBYr/nRk47XeNMonA==, tarball: file:projects/util-internal-data-service.tgz}
+    resolution: {integrity: sha512-kZgTp/R1IhaPSR9GluA1u5MTEzhwEeA/l/Lp0Js2m6vSmwip46s1ZQN5J80TvWyFb9VOlxgyOWrIsDWQ5zYKMg==, tarball: file:projects/util-internal-data-service.tgz}
     version: 0.0.0
 
   '@rush-temp/util-internal-data-source@file:projects/util-internal-data-source.tgz':
@@ -7019,11 +7019,35 @@ snapshots:
       '@types/node': 24.0.15
       typescript: 5.5.4
 
-  '@rush-temp/util-internal-data-service@file:projects/util-internal-data-service.tgz':
+  '@rush-temp/util-internal-data-service@file:projects/util-internal-data-service.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:
       '@types/node': 24.0.15
       prom-client: 14.2.0
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@rush-temp/util-internal-data-source@file:projects/util-internal-data-source.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "664d1eac7e172a514f113a2f3c0dc622565921a3"
+  "pnpmShrinkwrapHash": "9dd6ca224740da169c26f12c92ee43b240a87361"
 }

--- a/solana/solana-data-service/src/main.ts
+++ b/solana/solana-data-service/src/main.ts
@@ -50,6 +50,7 @@ runProgram(async () => {
     }
 
     let mainWorker = new MainDataSource(dataSourceOptions)
+    let service: Awaited<ReturnType<typeof runDataService>> | undefined
 
     let dataSource: DataSource<Block> = {
         getHead() {
@@ -60,9 +61,11 @@ runProgram(async () => {
         },
         async *getFinalizedStream(req: StreamRequest): BlockStream<Block> {
             let worker = new SecondaryDataSource(dataSourceOptions)
+            service?.metrics.incActiveWorkers()
             try {
                 yield* worker.getFinalizedStream(req)
             } finally {
+                service?.metrics.decActiveWorkers()
                 worker.close()
             }
         },
@@ -71,7 +74,7 @@ runProgram(async () => {
         }
     }
 
-    let service = await runDataService({
+    service = await runDataService({
         source: dataSource,
         blockCacheSize: args.blockCacheSize,
         port: args.port

--- a/util/util-internal-data-service/package.json
+++ b/util/util-internal-data-service/package.json
@@ -13,7 +13,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@subsquid/logger": "^1.6.0",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/util/util-internal-data-service/src/data-service.test.ts
+++ b/util/util-internal-data-service/src/data-service.test.ts
@@ -1,0 +1,135 @@
+import {describe, expect, it} from 'vitest'
+import {DataSource} from '@subsquid/util-internal-data-source'
+import {DataService} from './data-service'
+import {Block, DataResponse, InvalidBaseBlock} from './types'
+
+
+const HEAD = 200
+
+
+function mkBlock(number: number): Block {
+    return {
+        number,
+        hash: `h${number}`,
+        parentNumber: number - 1,
+        parentHash: `h${number - 1}`,
+        timestamp: Date.now(),
+        jsonLineZstd: new Uint8Array(0)
+    }
+}
+
+
+interface StreamCounters {
+    opened: number
+    closed: number
+}
+
+
+// Mirrors the data services' setup (e.g. solana-data-service/src/main.ts),
+// where each getFinalizedStream() call spawns a dedicated worker thread
+// and relies on the generator's finally block to close it.
+// `counters.closed` stands for worker.close().
+function mkSource(counters: StreamCounters): DataSource<Block> {
+    return {
+        async getHead() {
+            return {number: HEAD, hash: `h${HEAD}`}
+        },
+        async getFinalizedHead() {
+            return {number: HEAD, hash: `h${HEAD}`}
+        },
+        async *getFinalizedStream(req) {
+            counters.opened += 1
+            try {
+                for (let number = req.from; number <= (req.to ?? req.from); number++) {
+                    yield {blocks: [mkBlock(number)]}
+                }
+            } finally {
+                counters.closed += 1
+            }
+        },
+        async *getStream(req) {
+            yield {blocks: [mkBlock(req.from)]}
+        }
+    }
+}
+
+
+// Creates a service holding a single block (HEAD) in its cache,
+// so that queries below HEAD trigger the below-query (backfill) code path.
+async function setup(): Promise<{service: DataService, counters: StreamCounters}> {
+    let counters = {opened: 0, closed: 0}
+    let service = new DataService(mkSource(counters), 10)
+    await service.init()
+    // init() fully consumes one finalized stream
+    expect(counters).toEqual({opened: 1, closed: 1})
+    counters.opened = 0
+    counters.closed = 0
+    return {service, counters}
+}
+
+
+async function belowQuery(service: DataService): Promise<DataResponse> {
+    let res = await service.query(HEAD - 10)
+    expect(res).not.toBeInstanceOf(InvalidBaseBlock)
+    return res as DataResponse
+}
+
+
+describe('DataService below query resource management', () => {
+    it('closes the source stream on full consumption', async () => {
+        let {service, counters} = await setup()
+
+        let res = await belowQuery(service)
+        let blocks: Block[] = []
+        for await (let batch of res.head!) {
+            blocks.push(...batch)
+        }
+        await res.close?.()
+
+        expect(blocks.map(b => b.number)).toEqual([190, 191, 192, 193, 194, 195, 196, 197, 198, 199])
+        expect(res.tail?.map(b => b.number)).toEqual([HEAD])
+        expect(counters).toEqual({opened: 1, closed: 1})
+    })
+
+    it('closes the source stream when the consumer stops at the first batch', async () => {
+        // Regression test: the first yield of the below-query head generator
+        // used to sit outside its try/finally block, so terminating the consumer
+        // during the first batch skipped the cleanup and leaked the source stream
+        // (a whole set of worker threads in the real services)
+        let {service, counters} = await setup()
+
+        let res = await belowQuery(service)
+        for await (let _batch of res.head!) {
+            break
+        }
+        await res.close?.()
+
+        expect(counters).toEqual({opened: 1, closed: 1})
+    })
+
+    it('closes the source stream when the consumer stops at a later batch', async () => {
+        let {service, counters} = await setup()
+
+        let res = await belowQuery(service)
+        let batches = 0
+        for await (let _batch of res.head!) {
+            batches += 1
+            if (batches >= 2) break
+        }
+        await res.close?.()
+
+        expect(counters).toEqual({opened: 1, closed: 1})
+    })
+
+    it('closes the source stream via close() when head is never iterated', async () => {
+        // .return() on a never started generator does not execute its body,
+        // so the head generator alone can't guarantee cleanup - close() must
+        let {service, counters} = await setup()
+
+        let res = await belowQuery(service)
+        expect(res.close).toBeDefined()
+        await res.close!()
+
+        expect(counters).toEqual({opened: 1, closed: 1})
+    })
+})

--- a/util/util-internal-data-service/src/data-service.ts
+++ b/util/util-internal-data-service/src/data-service.ts
@@ -123,14 +123,18 @@ export class DataService {
         async function* head(): AsyncIterable<Block[]> {
             let prev: Block | undefined
 
-            for (let block of firstBatch.blocks) {
-                assertChainContinuity(parentHash, prev, block)
-                prev = block
-            }
-
-            yield firstBatch.blocks
-
+            // The entire body, including the very first yield, must stay inside
+            // this try block. A consumer terminating the generator while it is
+            // suspended at a yield placed before the try would skip the finally,
+            // leaving `it` (and the worker threads behind it) alive forever.
             try {
+                for (let block of firstBatch.blocks) {
+                    assertChainContinuity(parentHash, prev, block)
+                    prev = block
+                }
+
+                yield firstBatch.blocks
+
                 while (true) {
                     let item = await it.next()
                     if (item.done) break
@@ -153,7 +157,12 @@ export class DataService {
         return {
             finalizedHead,
             head: head(),
-            tail
+            tail,
+            close: async () => {
+                // safety net for the case when `head` is never iterated:
+                // an unstarted generator's .return() does not execute its finally
+                await it.return?.().catch(err => log.error(err))
+            }
         }
     }
 

--- a/util/util-internal-data-service/src/http-app.test.ts
+++ b/util/util-internal-data-service/src/http-app.test.ts
@@ -1,0 +1,88 @@
+import * as net from 'node:net'
+import * as zlib from 'node:zlib'
+import {describe, expect, it, vi} from 'vitest'
+import {DataSource} from '@subsquid/util-internal-data-source'
+import {runDataService} from './index'
+import {Block} from './types'
+
+
+const HEAD = 1000
+
+
+function mkBlock(number: number): Block {
+    return {
+        number,
+        hash: `h${number}`,
+        parentNumber: number - 1,
+        parentHash: `h${number - 1}`,
+        timestamp: Date.now(),
+        jsonLineZstd: zlib.zstdCompressSync(Buffer.from(`{"number":${number}}\n`))
+    }
+}
+
+
+// Serves finalized batches of 1 block each with a small delay,
+// so that a below query backfill stays in flight long enough
+// for the test to cancel it mid-stream.
+// `state.backfillClosed` stands for the release of backfill resources
+// (worker threads in the real services).
+function mkSource(state: {backfillClosed: boolean}): DataSource<Block> {
+    return {
+        async getHead() {
+            return {number: HEAD, hash: `h${HEAD}`}
+        },
+        async getFinalizedHead() {
+            return {number: HEAD, hash: `h${HEAD}`}
+        },
+        async *getFinalizedStream(req) {
+            try {
+                for (let number = req.from; number <= (req.to ?? req.from); number++) {
+                    await new Promise(resolve => setTimeout(resolve, 10))
+                    yield {blocks: [mkBlock(number)]}
+                }
+            } finally {
+                if (req.from < HEAD) {
+                    // not the service init stream, must be a below query
+                    state.backfillClosed = true
+                }
+            }
+        },
+        async *getStream(req) {
+            yield {blocks: [mkBlock(req.from)]}
+            // keep the ingestion session open
+            await new Promise(() => {})
+        }
+    }
+}
+
+
+describe('/stream', () => {
+    it('promptly releases the backfill stream when the client disconnects without consuming the response', async () => {
+        // Regression test: a client disconnect leaves ctx.response.writable equal to true,
+        // while writes are silently discarded. The response loop used to notice the disconnect
+        // only via the max duration limit, keeping the backfill (and its worker threads)
+        // running at full speed for up to a minute after the client was gone
+        let state = {backfillClosed: false}
+        let service = await runDataService({source: mkSource(state), blockCacheSize: 100, port: 0})
+        try {
+            let socket = net.connect(service.port, '127.0.0.1')
+            let body = JSON.stringify({fromBlock: 0})
+            socket.write(
+                `POST /stream HTTP/1.1\r\n` +
+                `Host: test\r\n` +
+                `Content-Type: application/json\r\n` +
+                `Content-Length: ${body.length}\r\n` +
+                `\r\n` +
+                body
+            )
+
+            // let the below query start streaming, then cancel without reading the response
+            await new Promise(resolve => setTimeout(resolve, 200))
+            socket.destroy()
+
+            await vi.waitFor(() => expect(state.backfillClosed).toBe(true), {timeout: 2000, interval: 25})
+        } finally {
+            await service.close()
+        }
+    })
+})

--- a/util/util-internal-data-service/src/http-app.ts
+++ b/util/util-internal-data-service/src/http-app.ts
@@ -1,10 +1,10 @@
 import {waitDrain} from '@subsquid/util-internal'
-import {HttpApp} from '@subsquid/util-internal-http-server'
+import {HttpApp, HttpContext} from '@subsquid/util-internal-http-server'
 import {NAT, object, option, STRING, ValidationFailure} from '@subsquid/util-internal-validation'
 import {promisify} from 'node:util'
 import * as zlib from 'node:zlib'
 import {DataService} from './data-service'
-import {Block, InvalidBaseBlock} from './types'
+import {Block, DataResponse, InvalidBaseBlock} from './types'
 import {getBlockIngestionTimestamp} from './metrics'
 
 
@@ -52,59 +52,11 @@ export function createHttpApp(service: DataService): HttpApp {
                 return ctx.send(409, {previousBlocks: res.prev})
             }
 
-            if (res.finalizedHead) {
-                ctx.response.setHeader('x-sqd-finalized-head-number', res.finalizedHead.number+'')
-                ctx.response.setHeader('x-sqd-finalized-head-hash', res.finalizedHead.hash)
+            try {
+                await writeBlocks(ctx, res, start, maxDuration)
+            } finally {
+                await res.close?.()
             }
-
-            if (res.head == null && res.tail == null) {
-                return ctx.send(204)
-            }
-
-            let useZstd = acceptsZstd(ctx.request.headers['accept-encoding'] as string)
-            let getPayload = useZstd
-                ? (block: Block) => Promise.resolve(block.jsonLineZstd)
-                : (block: Block) => toGzip(block)
-
-            ctx.response.setHeader('content-type', 'text/plain; charset=UTF-8')
-
-            if (res.head || res.tail?.length) {
-                ctx.response.setHeader('content-encoding', useZstd ? 'zstd' : 'gzip')
-                ctx.response.setHeader('vary', 'Accept-Encoding')
-            }
-
-            if (res.head) {
-                for await (let batch of res.head) {
-                    for (let block of batch) {
-                        if (ctx.response.writableNeedDrain || !ctx.response.writable) {
-                            if (Date.now() - start > maxDuration) {
-                                break
-                            }
-                            await waitDrain(ctx.response)
-                        }
-                        ctx.response.write(await getPayload(block))
-                    }
-                    // check after each batch to ensure,
-                    // that time limits are checked in case of slow arriving tiny batches
-                    if (Date.now() - start > maxDuration) {
-                        break
-                    }
-                }
-            }
-
-            if (res.tail) {
-                for (let block of res.tail) {
-                    if (ctx.response.writableNeedDrain || !ctx.response.writable) {
-                        if (Date.now() - start > maxDuration) {
-                            break
-                        }
-                        await waitDrain(ctx.response)
-                    }
-                    ctx.response.write(await getPayload(block))
-                }
-            }
-
-            ctx.response.end()
         }
     })
 
@@ -174,4 +126,61 @@ export function createHttpApp(service: DataService): HttpApp {
     app.setMaxRequestBody(1024)
 
     return app
+}
+
+
+async function writeBlocks(ctx: HttpContext, res: DataResponse, start: number, maxDuration: number): Promise<void> {
+    if (res.finalizedHead) {
+        ctx.response.setHeader('x-sqd-finalized-head-number', res.finalizedHead.number+'')
+        ctx.response.setHeader('x-sqd-finalized-head-hash', res.finalizedHead.hash)
+    }
+
+    if (res.head == null && res.tail == null) {
+        return ctx.send(204)
+    }
+
+    let useZstd = acceptsZstd(ctx.request.headers['accept-encoding'] as string)
+    let getPayload = useZstd
+        ? (block: Block) => Promise.resolve(block.jsonLineZstd)
+        : (block: Block) => toGzip(block)
+
+    ctx.response.setHeader('content-type', 'text/plain; charset=UTF-8')
+
+    if (res.head || res.tail?.length) {
+        ctx.response.setHeader('content-encoding', useZstd ? 'zstd' : 'gzip')
+        ctx.response.setHeader('vary', 'Accept-Encoding')
+    }
+
+    if (res.head) {
+        for await (let batch of res.head) {
+            for (let block of batch) {
+                if (ctx.response.writableNeedDrain || !ctx.response.writable) {
+                    if (Date.now() - start > maxDuration) {
+                        break
+                    }
+                    await waitDrain(ctx.response)
+                }
+                ctx.response.write(await getPayload(block))
+            }
+            // check after each batch to ensure,
+            // that time limits are checked in case of slow arriving tiny batches
+            if (Date.now() - start > maxDuration) {
+                break
+            }
+        }
+    }
+
+    if (res.tail) {
+        for (let block of res.tail) {
+            if (ctx.response.writableNeedDrain || !ctx.response.writable) {
+                if (Date.now() - start > maxDuration) {
+                    break
+                }
+                await waitDrain(ctx.response)
+            }
+            ctx.response.write(await getPayload(block))
+        }
+    }
+
+    ctx.response.end()
 }

--- a/util/util-internal-data-service/src/http-app.ts
+++ b/util/util-internal-data-service/src/http-app.ts
@@ -154,6 +154,11 @@ async function writeBlocks(ctx: HttpContext, res: DataResponse, start: number, m
     if (res.head) {
         for await (let batch of res.head) {
             for (let block of batch) {
+                // .destroyed is the only property that reflects a client disconnect:
+                // .writable stays true and writes are silently discarded,
+                // so without this check an abandoned backfill would keep running
+                // at full speed until the maxDuration limit
+                if (ctx.response.destroyed) return
                 if (ctx.response.writableNeedDrain || !ctx.response.writable) {
                     if (Date.now() - start > maxDuration) {
                         break
@@ -162,6 +167,7 @@ async function writeBlocks(ctx: HttpContext, res: DataResponse, start: number, m
                 }
                 ctx.response.write(await getPayload(block))
             }
+            if (ctx.response.destroyed) return
             // check after each batch to ensure,
             // that time limits are checked in case of slow arriving tiny batches
             if (Date.now() - start > maxDuration) {
@@ -172,6 +178,7 @@ async function writeBlocks(ctx: HttpContext, res: DataResponse, start: number, m
 
     if (res.tail) {
         for (let block of res.tail) {
+            if (ctx.response.destroyed) return
             if (ctx.response.writableNeedDrain || !ctx.response.writable) {
                 if (Date.now() - start > maxDuration) {
                     break

--- a/util/util-internal-data-service/src/types.ts
+++ b/util/util-internal-data-service/src/types.ts
@@ -25,4 +25,11 @@ export interface DataResponse {
     finalizedHead?: BlockRef
     head?: AsyncIterable<Block[]>
     tail?: Block[]
+    /**
+     * Releases resources backing `head` (e.g. backfill worker threads).
+     *
+     * Must be called when the response processing ends, no matter how,
+     * as `head` might never be iterated (hence never get a chance to clean up after itself).
+     */
+    close?: () => Promise<void>
 }


### PR DESCRIPTION
Connected to Solana data service incidents where large worker thread leaks (60+ threads) were causing OOM erros. 


**Data service fixes:**
- Prevent worker threads from leaking in `belowQuery` by closing upstream iterator in case:
  - the generator is terminated while suspended at first yield
  - `.head` is never iterated
- Added `incActiveWorkers`/`decActiveWorkers` calls in Solana data service (already present in EVM/TRON data service)

## Claude summary

### What changed
[data-service.ts:123-160](vscode-webview://15kk3mbif4aq7mjk97uvs11mvh4mtqcf941841n6dv216guec1mv/util/util-internal-data-service/src/data-service.ts#L123-L160) — the core fix. In belowQuery's head() generator, the first yield (and the continuity checks preceding it, which can also throw) moved inside the try/finally that closes the upstream iterator. Previously, terminating the generator while suspended at that first yield skipped the finally, so the SecondaryDataSource and its 6 worker threads were never closed. The response also now carries a close() method that closes the upstream iterator directly.

[types.ts:24-35](vscode-webview://15kk3mbif4aq7mjk97uvs11mvh4mtqcf941841n6dv216guec1mv/util/util-internal-data-service/src/types.ts#L24-L35) — added optional close() to DataResponse, documented as mandatory to call because head may never be iterated (an unstarted generator's .return() doesn't run its finally, so the generator can't clean up after itself in that case).

[http-app.ts:55-59](vscode-webview://15kk3mbif4aq7mjk97uvs11mvh4mtqcf941841n6dv216guec1mv/util/util-internal-data-service/src/http-app.ts#L55-L59) — the /stream handler now wraps response writing in try/finally { await res.close?.() }. The writing logic itself is unchanged, just extracted into a writeBlocks helper so the cleanup structure stays readable. close() swallows its own errors internally, so the finally can't mask a real handler error.

[solana main.ts:53-79](vscode-webview://15kk3mbif4aq7mjk97uvs11mvh4mtqcf941841n6dv216guec1mv/solana/solana-data-service/src/main.ts#L53-L79) — ported the incActiveWorkers/decActiveWorkers wiring from the EVM service, so leaked or piled-up backfill workers are now visible as sqd_hotblocks_active_workers in Prometheus.

Both packages (util-internal-data-service, solana-data-service) build cleanly. Since the fix lives in the shared package, evm-data-service and tron-data-service are fixed by the same change — they just need a rebuild/release against the updated dependency. The IDE lint warnings you may see in those files (node: protocol imports, type-only imports, string concatenation) are pre-existing style rules the whole repo trips; I matched the surrounding code style rather than introducing drive-by changes.

One deployment note: after rolling this out, watch sqd_hotblocks_active_workers — if it hovers above ~0-2 for long stretches, many clients are backfilling concurrently, and each still costs 6 worker threads plus in-flight raw blocks legitimately. If that turns out to be significant, a follow-up worth considering is a shared/pooled secondary source instead of per-request spawning — but that's a design change, not a leak.