### PR TITLE
feat(portal-client): retry transient null heads in getHead/getFinalizedHead

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         version: file:projects/polkavm-erc20.tgz(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))
       '@rush-temp/portal-client':
         specifier: file:./projects/portal-client.tgz
-        version: file:projects/portal-client.tgz
+        version: file:projects/portal-client.tgz(esbuild@0.27.7)(tsx@4.21.0)
       '@rush-temp/rpc-client':
         specifier: file:./projects/rpc-client.tgz
         version: file:projects/rpc-client.tgz
@@ -1554,7 +1554,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/portal-client@file:projects/portal-client.tgz':
-    resolution: {integrity: sha512-FF3zKbafViuzkpP+pX+3x+t+XxA0Hv9TjV8x8DDluBY3qrjbapdnNxwAUiW6xWfikzFCWhmIKEWXTuyuLlA6zA==, tarball: file:projects/portal-client.tgz}
+    resolution: {integrity: sha512-DRHvP1aSfx28Vw9uY99qcjb2Q+crOHbc3Wmg9Ynkup7Fj6lOIPXHd9NXS10nUVOYRsmjSPM5Iq2bBXMO1/kiXA==, tarball: file:projects/portal-client.tgz}
     version: 0.0.0
 
   '@rush-temp/rpc-client@file:projects/rpc-client.tgz':
@@ -6378,10 +6378,34 @@ snapshots:
       - ts-node
       - typeorm-aurora-data-api-driver
 
-  '@rush-temp/portal-client@file:projects/portal-client.tgz':
+  '@rush-temp/portal-client@file:projects/portal-client.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:
       '@types/node': 24.0.15
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@rush-temp/rpc-client@file:projects/rpc-client.tgz':
     dependencies:
@@ -7788,7 +7812,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.6
       '@noble/curves': 1.6.0
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.5.0
       bigint-buffer: 1.1.5

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "bab84a77b54f62dfd63bc0383df07426794650c0"
+  "pnpmShrinkwrapHash": "8671b763acf907e48c2fd897a382fd25c2558009"
 }

--- a/util/portal-client/package.json
+++ b/util/portal-client/package.json
@@ -17,7 +17,8 @@
     "!lib/*.example.*"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@subsquid/util-internal": "^3.3.1",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@subsquid/http-client": "^1.8.1",
     "@types/node": "^24.0.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/util/portal-client/src/client.test.ts
+++ b/util/portal-client/src/client.test.ts
@@ -1,0 +1,64 @@
+import assert from 'assert'
+import {describe, it} from 'vitest'
+import {HttpClient} from '@subsquid/http-client'
+import {PortalClient, type BlockRef} from './client'
+
+const HEAD: BlockRef = {number: 100, hash: '0xabc'}
+
+/**
+ * Build a PortalClient whose HTTP layer replays `bodies` (one per request; the
+ * last entry repeats). A `null` body models the portal's transient null head.
+ */
+function mock(bodies: unknown[], headRetrySchedule: number[] = [1, 1, 1]) {
+    let http = new HttpClient()
+    let urls: string[] = []
+    ;(http as any).request = (_method: string, url: string) => {
+        let body = bodies[Math.min(urls.length, bodies.length - 1)]
+        urls.push(url)
+        return Promise.resolve({body})
+    }
+    let portal = new PortalClient({url: 'http://localhost/datasets/test', http, headRetrySchedule})
+    return {portal, urls}
+}
+
+describe('PortalClient head null-retries', () => {
+    it('retries transient null heads and returns the eventual head', async () => {
+        let {portal, urls} = mock([null, null, HEAD])
+        let head = await portal.getFinalizedHead()
+        assert.deepStrictEqual(head, HEAD)
+        assert.strictEqual(urls.length, 3)
+        assert.ok(urls[0].endsWith('/finalized-head'))
+    })
+
+    it('resolves to undefined after exhausting the schedule on a persistent null', async () => {
+        // schedule length 2 => 3 attempts total
+        let {portal, urls} = mock([null], [1, 1])
+        let head = await portal.getFinalizedHead()
+        assert.strictEqual(head, undefined)
+        assert.strictEqual(urls.length, 3)
+    })
+
+    it('does not retry when the schedule is empty', async () => {
+        let {portal, urls} = mock([null], [])
+        let head = await portal.getHead()
+        assert.strictEqual(head, undefined)
+        assert.strictEqual(urls.length, 1)
+        assert.ok(urls[0].endsWith('/head'))
+    })
+
+    it('returns immediately on a non-null head without retrying', async () => {
+        let {portal, urls} = mock([HEAD])
+        let head = await portal.getHead()
+        assert.deepStrictEqual(head, HEAD)
+        assert.strictEqual(urls.length, 1)
+    })
+
+    it('rejects and stops requesting when aborted during backoff', async () => {
+        let ac = new AbortController()
+        let {portal, urls} = mock([null, HEAD], [1000])
+        let p = portal.getFinalizedHead({abort: ac.signal})
+        setTimeout(() => ac.abort(), 5)
+        await assert.rejects(p)
+        assert.strictEqual(urls.length, 1)
+    })
+})

--- a/util/portal-client/src/client.test.ts
+++ b/util/portal-client/src/client.test.ts
@@ -53,6 +53,13 @@ describe('PortalClient head null-retries', () => {
         assert.strictEqual(urls.length, 1)
     })
 
+    it('does not retry an empty (undefined) body — only JSON null is transient', async () => {
+        let {portal, urls} = mock([undefined, HEAD])
+        let head = await portal.getHead()
+        assert.strictEqual(head, undefined)
+        assert.strictEqual(urls.length, 1)
+    })
+
     it('rejects and stops requesting when aborted during backoff', async () => {
         let ac = new AbortController()
         let {portal, urls} = mock([null, HEAD], [1000])

--- a/util/portal-client/src/client.ts
+++ b/util/portal-client/src/client.ts
@@ -48,6 +48,20 @@ export interface PortalClientOptions {
      * @default 0
      */
     headPollInterval?: number
+
+    /**
+     * Backoff schedule (in milliseconds) for retrying `getHead` / `getFinalizedHead`
+     * when the portal answers with a transient `null` head.
+     *
+     * A `null` head is a successful `200` with an empty body, which the portal returns
+     * for a short window while a dataset's (finalized) head is not yet established —
+     * e.g. right after a store restart/cold-start. The schedule length bounds the number
+     * of retries; once exhausted the call resolves to `undefined`. An empty array disables
+     * retrying.
+     *
+     * @default [100, 500, 1000, 2000]
+     */
+    headRetrySchedule?: number[]
 }
 
 export interface PortalRequestOptions {
@@ -57,6 +71,11 @@ export interface PortalRequestOptions {
     httpTimeout?: number
     bodyTimeout?: number
     abort?: AbortSignal
+
+    /**
+     * Per-request override for {@link PortalClientOptions.headRetrySchedule}.
+     */
+    headRetrySchedule?: number[]
 }
 
 export interface PortalStreamOptions {
@@ -115,6 +134,7 @@ export class PortalClient {
     private maxBytes: number
     private maxIdleTime: number
     private maxWaitTime: number
+    private headRetrySchedule: number[]
 
     constructor(options: PortalClientOptions) {
         this.url = new URL(options.url)
@@ -123,6 +143,7 @@ export class PortalClient {
         this.maxBytes = options.maxBytes ?? 50 * 1024 * 1024
         this.maxIdleTime = options.maxIdleTime ?? 500
         this.maxWaitTime = options.maxWaitTime ?? 5_000
+        this.headRetrySchedule = options.headRetrySchedule ?? [100, 500, 1000, 2000]
     }
 
     private getDatasetUrl(path: string): string {
@@ -136,8 +157,22 @@ export class PortalClient {
     }
 
     async getHead(options?: PortalRequestOptions, finalized?: boolean): Promise<BlockRef | undefined> {
-        const res = await this.request('GET', this.getDatasetUrl(!finalized ? 'head' : 'finalized-head'), options)
-        return res.body ?? undefined
+        let url = this.getDatasetUrl(!finalized ? 'head' : 'finalized-head')
+        let schedule = options?.headRetrySchedule ?? this.headRetrySchedule
+
+        // A `null` head is a successful `200` with an empty body: the portal returns it
+        // transiently while the (finalized) head is not yet established (e.g. store
+        // cold-start). Retry with a short, finite backoff to ride out that window;
+        // transport errors are already retried by the underlying HttpClient. Once the
+        // schedule is exhausted we resolve to `undefined`, so persistently head-less
+        // datasets don't hang.
+        for (let attempt = 0; ; attempt++) {
+            options?.abort?.throwIfAborted()
+            let res = await this.request('GET', url, options)
+            let head: BlockRef | undefined = res.body ?? undefined
+            if (head != null || attempt >= schedule.length) return head
+            await wait(schedule[attempt], options?.abort)
+        }
     }
 
     getFinalizedHead(options?: PortalRequestOptions): Promise<BlockRef | undefined> {

--- a/util/portal-client/src/client.ts
+++ b/util/portal-client/src/client.ts
@@ -53,8 +53,8 @@ export interface PortalClientOptions {
      * Backoff schedule (in milliseconds) for retrying `getHead` / `getFinalizedHead`
      * when the portal answers with a transient `null` head.
      *
-     * A `null` head is a successful `200` with an empty body, which the portal returns
-     * for a short window while a dataset's (finalized) head is not yet established —
+     * A `null` head is a successful `200` whose body is JSON `null`, which the portal
+     * returns for a short window while a dataset's (finalized) head is not yet established —
      * e.g. right after a store restart/cold-start. The schedule length bounds the number
      * of retries; once exhausted the call resolves to `undefined`. An empty array disables
      * retrying.
@@ -160,17 +160,17 @@ export class PortalClient {
         let url = this.getDatasetUrl(!finalized ? 'head' : 'finalized-head')
         let schedule = options?.headRetrySchedule ?? this.headRetrySchedule
 
-        // A `null` head is a successful `200` with an empty body: the portal returns it
-        // transiently while the (finalized) head is not yet established (e.g. store
-        // cold-start). Retry with a short, finite backoff to ride out that window;
+        // The portal signals "no head yet" with a JSON `null` body — a transient
+        // response while the (finalized) head is not yet established (e.g. store
+        // cold-start). Retry only that case with a short, finite backoff to ride out
+        // the window; a real head (or any other body) returns immediately, and
         // transport errors are already retried by the underlying HttpClient. Once the
         // schedule is exhausted we resolve to `undefined`, so persistently head-less
         // datasets don't hang.
         for (let attempt = 0; ; attempt++) {
             options?.abort?.throwIfAborted()
             let res = await this.request('GET', url, options)
-            let head: BlockRef | undefined = res.body ?? undefined
-            if (head != null || attempt >= schedule.length) return head
+            if (res.body !== null || attempt >= schedule.length) return res.body ?? undefined
             await wait(schedule[attempt], options?.abort)
         }
     }


### PR DESCRIPTION
## Problem

`/head` and `/finalized-head` return a **`200` with a `null` body** for a short window while a dataset's (finalized) head is not yet established — e.g. right after a store restart/cold-start (the store's `get_finalized_head()` is transiently `None`, and network-only datasets whose network head isn't tracked yet hit the same path).

`PortalClient.getHead` turns that `null` into `undefined`, and consumers that require a head crash on it. Observed in the wild as:

```
AssertionError: portal has no finalized head
  at PortalEvmDataSource.getFinalizedHead (@subsquid/evm-stream/lib/portal/source.js:37)
```

The null is **transient** — the same dataset returns a real head moments later (once the replica warms up / finality is tracked). It's rare, intermittent, and not something the caller should hard-fail on.

## Change

Add a short, finite retry with backoff to `getHead` (which `getFinalizedHead` delegates to):

- Retries **only** the null-body case. Transport errors (connection/timeout/5xx) are already retried by the underlying `HttpClient` — untouched.
- Default schedule **`[100, 500, 1000, 2000]` ms** (~3.6 s, 5 attempts). Sized to the transient window: the first short step catches load-balancer reselection onto a warm replica; the later steps cover a brief cold-start. Finite by design — once exhausted the call resolves to `undefined`, so *persistently* head-less datasets (e.g. network-only ones with no head) don't hang; the longer horizon stays with the caller's existing poll/throttle loop.
- Abort-aware (honours `options.abort` during backoff).
- Configurable via `PortalClientOptions.headRetrySchedule`, with a per-request override on `PortalRequestOptions`. An empty array opts out.

No signature or type changes — `getHead`/`getFinalizedHead` still resolve to `BlockRef | undefined`.

## Tests

`util/portal-client/src/client.test.ts` covers: retry-then-success, exhaustion → `undefined` (exact request count), empty-schedule opt-out, immediate return on a real head, and abort during backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)