### PR TITLE
ci(release): pin npm to 11.18.0 (avoid npm 12 stderr notices)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,11 @@ jobs:
           node-version: '24'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        # Pinned to the latest 11.x. npm 12.0.0 prints `npm notice run ...` diagnostics
+        # to stderr when running scripts/`npx`, which Rush's built-in `build` treats as a
+        # warning and fails on (graphql-server builds via `make` -> `npx tsc`). Unpin once
+        # that's resolved (e.g. `@npx tsc` -> `@tsc`, or NPM_CONFIG_LOGLEVEL=warn).
+        run: npm install -g npm@11.18.0
 
       - name: Configure git user
         run: |


### PR DESCRIPTION
## Why

The `release` workflow's `Update npm` step runs the unpinned `npm install -g npm@latest`. On 2026-07-08 that resolved to **npm 12.0.0** (published ~1h before the failing run), which added `npm notice run …` diagnostics printed to **stderr** on `npm exec`/`npx`.

`@subsquid/graphql-server` is the only package whose build shells out — `make build` → `@npx tsc` — so it's the only one that writes those notices to stderr. Rush's built-in `build` command classifies any stderr as a warning (`SUCCESS WITH WARNINGS`) and, unlike the repo's custom `test` command, does **not** set `allowWarningsInSuccessfulBuild`, so it exits non-zero — failing **Build project** before **Publish npm packages**.

Verified by bisection: npm 11.16.0 / 11.17.0 / 11.18.0 are clean; 12.0.0 emits the notices. npm 12.0.0 itself is a legitimate, signed official release (registry signature verified, integrity matches) — this is just a behavior change, not a compromise.

## Change

Pin the upgrade to the latest 11.x (`npm@11.18.0`) until the underlying build shell-out is addressed. A comment in the workflow points at the follow-ups (`@npx tsc` → `@tsc`, or `NPM_CONFIG_LOGLEVEL=warn`) for unpinning later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)