### PR TITLE
ci(release): sync release/arrowsquid to master before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,19 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
 
+      # In `release` mode we build and publish from `release/arrowsquid`, but changes land
+      # on `master`. Fast-forward the release branch to `master` (and push it) so a release
+      # picks up the latest `master` — e.g. version-policy changes — instead of republishing
+      # a stale tree. `--ff-only` fails loudly if `release/arrowsquid` has commits not on
+      # `master` (which should be merged back via the bump workflow first) rather than
+      # force-moving the branch.
+      - name: Sync release branch with master
+        if: ${{ inputs.mode == 'release' }}
+        run: |
+          git fetch origin master
+          git merge --ff-only origin/master
+          git push origin HEAD:release/arrowsquid
+
       - name: Install dependencies
         run: node common/scripts/install-run-rush.js install
 


### PR DESCRIPTION
## Root cause

In `release` mode the workflow checks out and publishes from **`release/arrowsquid`**:

```yaml
ref: ${{ inputs.mode == 'release' && 'release/arrowsquid' || github.ref_name }}
```

But changes land on **`master`**, and **no workflow ever advances `release/arrowsquid` from `master`** (`bump.yml` only merges the release branch *back into* master and pushes master; `release.yml` never pushes the release branch). `release/arrowsquid` is normally kept a fast-forward of `master` out of band, so releases usually "just work" — but any commit made directly to `master` after the last sync is invisible to a release.

That's exactly what happened: `@subsquid/squid-sdk` was moved to the `docker` policy on `master`, but `release/arrowsquid` still had it on `npm`, so the release kept publishing it (→ `ENEEDAUTH`). At the time of the failing run, `release/arrowsquid` lagged `master` by 3 commits (the npm pin merge + the policy change).

## Fix

Add a release-mode step that fast-forwards `release/arrowsquid` to `master` and pushes it, before install/build/publish — so a release always publishes `master`'s current state. `--ff-only` fails loudly if the release branch has commits not on `master` (those should be merged back via the bump workflow first) rather than force-moving it.

## Notes
- `prerelease` mode is unaffected (it already builds from `github.ref_name`).
- Requires `contents: write` (already granted).
- The workflow rework that introduced the merged release/prerelease shape: `1df6272e` (2026-03-13, "chore: merge release and prerelease actions"), followed by `56c21aa0` (2026-03-17, OIDC trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)