### PR TITLE
test(typeorm-migration): add live-DB e2e harness + characterization tests

### DIFF
--- a/common/changes/@subsquid/typeorm-migration/test-typeorm-migration-harness_2026-07-10-02-10.json
+++ b/common/changes/@subsquid/typeorm-migration/test-typeorm-migration-harness_2026-07-10-02-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-migration",
+      "comment": "Add a live-DB vitest test harness with an end-to-end generate/apply/revert characterization test",
+      "type": "none"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-migration"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -330,7 +330,7 @@ importers:
         version: file:projects/typeorm-config.tgz(esbuild@0.27.7)(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))(tsx@4.21.0)
       '@rush-temp/typeorm-migration':
         specifier: file:./projects/typeorm-migration.tgz
-        version: file:projects/typeorm-migration.tgz(ioredis@5.3.2(supports-color@8.1.1))(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))
+        version: file:projects/typeorm-migration.tgz(esbuild@0.27.7)(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))(tsx@4.21.0)
       '@rush-temp/typeorm-store':
         specifier: file:./projects/typeorm-store.tgz
         version: file:projects/typeorm-store.tgz(esbuild@0.27.7)(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))(tsx@4.21.0)
@@ -1726,7 +1726,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/typeorm-migration@file:projects/typeorm-migration.tgz':
-    resolution: {integrity: sha512-+yVRizHNuzkf8tyK6xGanvHbVwkAV49NhJapT1HtXqI7ppRI4h9TZH1OqLi1eJI4hatWN+nfOW2I2PWVZwtvtw==, tarball: file:projects/typeorm-migration.tgz}
+    resolution: {integrity: sha512-F/v1aycZYUixFV5hFnAwdMZjRiYfFDCN4vBjxkB/2A8wcCccbpvAZ86Holp85poxJ4Hj5WWez91SXGbe07j8zA==, tarball: file:projects/typeorm-migration.tgz}
     version: 0.0.0
 
   '@rush-temp/typeorm-store@file:projects/typeorm-store.tgz':
@@ -6988,32 +6988,56 @@ snapshots:
       - typeorm-aurora-data-api-driver
       - yaml
 
-  '@rush-temp/typeorm-migration@file:projects/typeorm-migration.tgz(ioredis@5.3.2(supports-color@8.1.1))(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))':
+  '@rush-temp/typeorm-migration@file:projects/typeorm-migration.tgz(esbuild@0.27.7)(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))(tsx@4.21.0)':
     dependencies:
       '@types/node': 24.0.15
+      '@types/pg': 8.10.9
       commander: 11.1.0
       dotenv: 16.3.1
+      pg: 8.11.3
       typeorm: 0.3.17(ioredis@5.3.2(supports-color@8.1.1))(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
     transitivePeerDependencies:
+      - '@edge-runtime/vm'
       - '@google-cloud/spanner'
+      - '@opentelemetry/api'
       - '@sap/hana-client'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
       - better-sqlite3
+      - esbuild
+      - happy-dom
       - hdb-pool
       - ioredis
+      - jiti
+      - jsdom
+      - less
       - mongodb
       - mssql
+      - msw
       - mysql2
       - oracledb
-      - pg
       - pg-native
       - pg-query-stream
       - redis
+      - sass
+      - sass-embedded
       - sql.js
       - sqlite3
+      - stylus
+      - sugarss
       - supports-color
+      - terser
       - ts-node
+      - tsx
       - typeorm-aurora-data-api-driver
+      - yaml
 
   '@rush-temp/typeorm-store@file:projects/typeorm-store.tgz(esbuild@0.27.7)(ioredis@5.3.2(supports-color@8.1.1))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@24.0.15)(typescript@5.5.4))(tsx@4.21.0)':
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6834e16bc0a02eddcccb30b70d944c5a633e751b"
+  "pnpmShrinkwrapHash": "e83744dc32b103360eaa2320c7f3a4f6f91ca7f0"
 }

--- a/typeorm/typeorm-migration/.env
+++ b/typeorm/typeorm-migration/.env
@@ -1,0 +1,7 @@
+DB_PORT_PG=23799
+
+DB_PORT=23799
+DB_NAME=postgres
+DB_HOST=localhost
+DB_USER=postgres
+DB_PASS=postgres

--- a/typeorm/typeorm-migration/Makefile
+++ b/typeorm/typeorm-migration/Makefile
@@ -1,0 +1,13 @@
+test:
+	@npx vitest --run
+
+
+up:
+	@docker compose up -d 2>&1
+
+
+down:
+	@docker compose down -v 2>&1
+
+
+.PHONY: test up down

--- a/typeorm/typeorm-migration/docker-compose.yml
+++ b/typeorm/typeorm-migration/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  postgres:
+    image: postgres:12
+    ports:
+      - "${DB_PORT_PG}:5432"
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+    command: ["postgres", "-c", "log_statement=all"]

--- a/typeorm/typeorm-migration/package.json
+++ b/typeorm/typeorm-migration/package.json
@@ -20,7 +20,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "make up && sleep 1 && make test && make down || (make down && exit 1)"
   },
   "dependencies": {
     "@subsquid/typeorm-config": "^4.1.1",
@@ -35,6 +36,9 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "5.5.4"
+    "@types/pg": "^8.10.9",
+    "pg": "^8.11.3",
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/typeorm/typeorm-migration/src/test/migration.test.ts
+++ b/typeorm/typeorm-migration/src/test/migration.test.ts
@@ -1,5 +1,10 @@
 import * as path from 'path'
-import {FixtureProject, tableSchemas, withClient} from './util'
+import {FixtureProject, isolateSchemaEnv, tableSchemas, withClient} from './util'
+
+
+// The CLIs inherit process.env; keep an ambient DB_SCHEMA from redirecting them
+// away from the default (public) schema these tests characterize.
+isolateSchemaEnv()
 
 
 // A compiled squid model, mirroring what squid-typeorm-codegen emits:

--- a/typeorm/typeorm-migration/src/test/migration.test.ts
+++ b/typeorm/typeorm-migration/src/test/migration.test.ts
@@ -1,0 +1,78 @@
+import * as path from 'path'
+import {FixtureProject, tableSchemas, withClient} from './util'
+
+
+// A compiled squid model, mirroring what squid-typeorm-codegen emits:
+// schema-neutral `@Entity` (here an EntitySchema) with enum fields represented
+// as `varchar` — never a native Postgres enum type.
+const MODEL = `
+const {EntitySchema} = require('typeorm')
+
+const Account = new EntitySchema({
+    name: 'Account',
+    columns: {
+        id: {type: 'varchar', primary: true},
+        status: {type: 'varchar', length: 16},
+        balance: {type: 'int'},
+        data: {type: 'jsonb', nullable: true},
+    },
+})
+
+module.exports = {Account}
+`
+
+
+const PROJECT_DIR = path.join(__dirname, '.tmp-migration-project')
+
+
+async function resetDb(): Promise<void> {
+    await withClient(async client => {
+        await client.query('DROP TABLE IF EXISTS "account" CASCADE')
+        await client.query('DROP TABLE IF EXISTS "migrations" CASCADE')
+        await client.query('DROP TABLE IF EXISTS "typeorm_metadata" CASCADE')
+    })
+}
+
+
+describe('squid-typeorm-migration (current behavior, live DB)', () => {
+    let project: FixtureProject
+
+    beforeEach(async () => {
+        await resetDb()
+        project = FixtureProject.create(PROJECT_DIR, MODEL)
+    })
+
+    afterEach(async () => {
+        project.destroy()
+        await resetDb()
+    })
+
+    test('generate emits schema-neutral (unqualified) DDL and no CREATE TYPE for enums', () => {
+        project.generate()
+
+        const files = project.migrationFiles()
+        expect(files).toHaveLength(1)
+
+        const sql = project.readMigration(files[0])
+        expect(sql).toMatch(/CREATE TABLE "account"/)      // unqualified table name
+        expect(sql).not.toMatch(/"public"\."account"/)     // NOT pinned to a schema
+        expect(sql).not.toMatch(/CREATE TYPE/i)            // enums are varchar -> no native type
+        expect(sql).toMatch(/"status" character varying/)  // the enum-typed field is a varchar
+    })
+
+    test('apply creates the data table + migrations ledger; revert drops the data table', async () => {
+        project.generate()
+        project.apply()
+
+        // Both the data table and TypeORM's bookkeeping table land in the
+        // default schema (public) when DB_SCHEMA is unset.
+        expect(await tableSchemas('account')).toEqual(['public'])
+        expect(await tableSchemas('migrations')).toEqual(['public'])
+
+        project.revert()
+
+        expect(await tableSchemas('account')).toEqual([])
+        // the migrations ledger itself persists across a revert
+        expect(await tableSchemas('migrations')).toEqual(['public'])
+    })
+})

--- a/typeorm/typeorm-migration/src/test/util.ts
+++ b/typeorm/typeorm-migration/src/test/util.ts
@@ -1,0 +1,96 @@
+/// <reference types="vitest/globals" />
+import {execFileSync} from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+import {Client as PgClient, ClientBase} from 'pg'
+
+
+export const db_config = {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432'),
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASS || 'postgres',
+    database: process.env.DB_NAME || 'postgres',
+}
+
+
+export async function withClient(block: (client: ClientBase) => Promise<void>): Promise<void> {
+    let client = new PgClient(db_config)
+    await client.connect()
+    try {
+        await block(client)
+    } finally {
+        await client.end()
+    }
+}
+
+
+/** Schemas in which a given (unqualified) table currently exists. */
+export async function tableSchemas(table: string): Promise<string[]> {
+    let schemas: string[] = []
+    await withClient(async client => {
+        let res = await client.query(
+            `SELECT schemaname FROM pg_tables WHERE tablename = $1 ORDER BY schemaname`,
+            [table]
+        )
+        schemas = res.rows.map((r: any) => r.schemaname)
+    })
+    return schemas
+}
+
+
+// The compiled CLI entrypoints live next to this file's parent (lib/), e.g.
+// lib/generate.js. __dirname at runtime is <pkg>/lib/test.
+const LIB_DIR = path.resolve(__dirname, '..')
+
+
+/**
+ * A throwaway squid project dir (under the package tree, so Node resolves
+ * `typeorm` for the model) with a compiled `lib/model` and an empty
+ * `db/migrations`. The CLIs are run with this as their cwd.
+ */
+export class FixtureProject {
+    constructor(readonly dir: string) {}
+
+    static create(dir: string, modelSource: string): FixtureProject {
+        fs.rmSync(dir, {recursive: true, force: true})
+        fs.mkdirSync(path.join(dir, 'lib', 'model'), {recursive: true})
+        fs.mkdirSync(path.join(dir, 'db', 'migrations'), {recursive: true})
+        fs.writeFileSync(path.join(dir, 'lib', 'model', 'index.js'), modelSource)
+        return new FixtureProject(dir)
+    }
+
+    private run(script: string): string {
+        return execFileSync('node', [path.join(LIB_DIR, script)], {
+            cwd: this.dir,
+            env: process.env,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+    }
+
+    generate(): string {
+        return this.run('generate.js')
+    }
+
+    apply(): string {
+        return this.run('apply.js')
+    }
+
+    revert(): string {
+        return this.run('revert.js')
+    }
+
+    migrationFiles(): string[] {
+        let dir = path.join(this.dir, 'db', 'migrations')
+        return fs.readdirSync(dir).filter(f => f.endsWith('.js')).sort()
+    }
+
+    readMigration(file: string): string {
+        return fs.readFileSync(path.join(this.dir, 'db', 'migrations', file), 'utf8')
+    }
+
+    destroy(): void {
+        fs.rmSync(this.dir, {recursive: true, force: true})
+    }
+}

--- a/typeorm/typeorm-migration/src/test/util.ts
+++ b/typeorm/typeorm-migration/src/test/util.ts
@@ -25,6 +25,38 @@ export async function withClient(block: (client: ClientBase) => Promise<void>): 
 }
 
 
+export const SCHEMA_ENV_VARS = ['DB_SCHEMA', 'DB_SCHEMA_INCLUDE_PUBLIC']
+
+
+/**
+ * Registers hooks that clear the schema env vars before each test and restore
+ * them after, leaving the connection vars (`DB_HOST`/`DB_PORT`/...) intact. The
+ * CLIs inherit `process.env`, so this keeps an ambient `DB_SCHEMA` in the shell
+ * or CI from redirecting them to a non-default schema and flaking the
+ * default-behavior assertions.
+ */
+export function isolateSchemaEnv(): void {
+    let saved: Record<string, string | undefined>
+    beforeEach(() => {
+        saved = {}
+        for (let k of SCHEMA_ENV_VARS) {
+            saved[k] = process.env[k]
+            delete process.env[k]
+        }
+    })
+    afterEach(() => {
+        for (let k of SCHEMA_ENV_VARS) {
+            let v = saved[k]
+            if (v === undefined) {
+                delete process.env[k]
+            } else {
+                process.env[k] = v
+            }
+        }
+    })
+}
+
+
 /** Schemas in which a given (unqualified) table currently exists. */
 export async function tableSchemas(table: string): Promise<string[]> {
     let schemas: string[] = []

--- a/typeorm/typeorm-migration/vitest.config.ts
+++ b/typeorm/typeorm-migration/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        include: ['lib/test/**/*.test.js'],
+        exclude: ['**/node_modules/**'],
+        setupFiles: ['dotenv/config'],
+        globals: true,
+        fileParallelism: false,
+        testTimeout: 60_000,
+    },
+})


### PR DESCRIPTION
## What

`@subsquid/typeorm-migration` had **no tests**. Its commands are immediate-exec CLIs (no importable functions), so the harness drives the **real compiled entrypoints** (`lib/generate.js` / `apply.js` / `revert.js`) as subprocesses against a throwaway fixture squid project + a live Postgres — mirroring the house style (docker-compose, `Makefile`, vitest on `lib/test`).

## Why now

Harness-only step 3 of adding a configurable data schema to the SDK. Per the TDD rollout, the harness + characterization of existing migration behavior lands and is reviewed **before** the `DB_SCHEMA`-aware `apply` feature.

## Tests (characterization, live DB)

- **`generate`** emits schema-neutral (unqualified) DDL — `CREATE TABLE "account"`, not `"public"."account"` — and **no `CREATE TYPE`** (the model's enum-typed field is `varchar`, mirroring codegen).
- **`apply`** creates the data table **and** TypeORM's `migrations` bookkeeping table in `public` (default, `DB_SCHEMA` unset).
- **`revert`** drops the data table while the `migrations` ledger persists.

`FixtureProject` (in `src/test/util.ts`) writes a compiled `lib/model` + empty `db/migrations` under the package tree (so Node resolves `typeorm`) and runs the CLIs with that as cwd. `npm test` → **2/2** (`make up` → vitest → `make down`).

## Scope

**No production code changes** — test infrastructure only. `rush change`: `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)