### PR TITLE
test(typeorm-store): verify DB_SCHEMA data vs stateSchema separation

### DIFF
--- a/common/changes/@subsquid/typeorm-store/test-typeorm-store-data-schema_2026-07-10-03-30.json
+++ b/common/changes/@subsquid/typeorm-store/test-typeorm-store-data-schema_2026-07-10-03-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-store",
+      "comment": "Add a test verifying entity data lands in DB_SCHEMA while processor state stays in stateSchema (two independent dials)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-store"
+}

--- a/typeorm/typeorm-store/src/test/schema.test.ts
+++ b/typeorm/typeorm-store/src/test/schema.test.ts
@@ -1,0 +1,122 @@
+import {Client} from 'pg'
+import {TypeormDatabase} from '../database'
+import {Data} from './lib/model'
+import {db_config} from './util'
+
+
+// Feature (typeorm-config search_path): entity DATA follows the connection's
+// search_path into DB_SCHEMA, while the processor STATE tables stay explicitly
+// qualified with `stateSchema`. The two are independent dials; this proves they
+// resolve to different schemas at the same time, with no leakage between them.
+const DATA_SCHEMA = 'store_data_v1'
+const STATE_SCHEMA = 'store_state_v1'
+
+
+const CREATE_TABLES = [
+    `CREATE TABLE item (id text primary key, name text)`,
+    `CREATE TABLE "data" (
+        id text primary key,
+        "text" text,
+        text_array text[],
+        "integer" int4,
+        integer_array int4[],
+        big_integer numeric,
+        date_time timestamp with time zone,
+        "bytes" bytea,
+        "json" jsonb,
+        item_id text references item
+    )`,
+]
+
+
+async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+    let client = new Client(db_config)
+    await client.connect()
+    try {
+        return await fn(client)
+    } finally {
+        await client.end()
+    }
+}
+
+
+async function tableSchemas(table: string): Promise<string[]> {
+    return withClient(async client => {
+        let res = await client.query(
+            `SELECT schemaname FROM pg_tables WHERE tablename = $1 ORDER BY schemaname`,
+            [table]
+        )
+        return res.rows.map((r: any) => r.schemaname)
+    })
+}
+
+
+describe('TypeormDatabase data schema (DB_SCHEMA) vs state schema', function () {
+    let db!: TypeormDatabase
+    let savedSchema: string | undefined
+    let savedIncludePublic: string | undefined
+
+    beforeEach(async () => {
+        savedSchema = process.env.DB_SCHEMA
+        savedIncludePublic = process.env.DB_SCHEMA_INCLUDE_PUBLIC
+        process.env.DB_SCHEMA = DATA_SCHEMA
+        delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
+
+        // The data schema + entity tables are what migrations would create.
+        await withClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${DATA_SCHEMA}" CASCADE`)
+            await client.query(`DROP SCHEMA IF EXISTS "${STATE_SCHEMA}" CASCADE`)
+            await client.query(`CREATE SCHEMA "${DATA_SCHEMA}"`)
+            await client.query(`SET search_path TO "${DATA_SCHEMA}"`)
+            for (let sql of CREATE_TABLES) {
+                await client.query(sql)
+            }
+        })
+
+        db = new TypeormDatabase({projectDir: __dirname, stateSchema: STATE_SCHEMA, supportHotBlocks: true})
+    })
+
+    afterEach(async () => {
+        await db?.disconnect()
+        if (savedSchema === undefined) {
+            delete process.env.DB_SCHEMA
+        } else {
+            process.env.DB_SCHEMA = savedSchema
+        }
+        if (savedIncludePublic === undefined) {
+            delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
+        } else {
+            process.env.DB_SCHEMA_INCLUDE_PUBLIC = savedIncludePublic
+        }
+        await withClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${DATA_SCHEMA}" CASCADE`)
+            await client.query(`DROP SCHEMA IF EXISTS "${STATE_SCHEMA}" CASCADE`)
+        })
+    })
+
+    it('writes entity data into DB_SCHEMA and processor state into stateSchema', async () => {
+        await db.connect()
+        await db.transact({
+            prevHead: {height: -1, hash: '0x'},
+            nextHead: {height: 10, hash: '0x10'}
+        }, async store => {
+            await store.insert(new Data({id: '1', text: 'hello', integer: 10}))
+        })
+        await db.disconnect()
+
+        // entity data -> DATA_SCHEMA, and not in the state schema
+        expect(await tableSchemas('data')).toContain(DATA_SCHEMA)
+        expect(await tableSchemas('data')).not.toContain(STATE_SCHEMA)
+        let rows = await withClient(client =>
+            client.query(`SELECT id, "text" FROM "${DATA_SCHEMA}"."data" ORDER BY id`).then(r => r.rows)
+        )
+        expect(rows).toEqual([{id: '1', text: 'hello'}])
+
+        // processor state -> STATE_SCHEMA, and not in the data schema
+        expect(await tableSchemas('status')).toContain(STATE_SCHEMA)
+        expect(await tableSchemas('status')).not.toContain(DATA_SCHEMA)
+        expect(await tableSchemas('hot_block')).toContain(STATE_SCHEMA)
+
+        expect(DATA_SCHEMA).not.toBe(STATE_SCHEMA)
+    })
+})

--- a/typeorm/typeorm-store/src/test/schema.test.ts
+++ b/typeorm/typeorm-store/src/test/schema.test.ts
@@ -43,7 +43,7 @@ async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
 async function tableSchemas(table: string): Promise<string[]> {
     return withClient(async client => {
         let res = await client.query(
-            `SELECT schemaname FROM pg_tables WHERE tablename = $1 ORDER BY schemaname`,
+            `SELECT schemaname FROM pg_catalog.pg_tables WHERE tablename = $1 ORDER BY schemaname`,
             [table]
         )
         return res.rows.map((r: any) => r.schemaname)
@@ -116,6 +116,7 @@ describe('TypeormDatabase data schema (DB_SCHEMA) vs state schema', function () 
         expect(await tableSchemas('status')).toContain(STATE_SCHEMA)
         expect(await tableSchemas('status')).not.toContain(DATA_SCHEMA)
         expect(await tableSchemas('hot_block')).toContain(STATE_SCHEMA)
+        expect(await tableSchemas('hot_block')).not.toContain(DATA_SCHEMA)
 
         expect(DATA_SCHEMA).not.toBe(STATE_SCHEMA)
     })


### PR DESCRIPTION
## What

Adds a two-dial integration test proving `@subsquid/typeorm-store` correctly separates:
- **entity data** → `DB_SCHEMA` (follows the connection `search_path`, from typeorm-config), and
- **processor state** (`status` / `hot_block`) → `stateSchema` (explicitly qualified),

at the same time, with no leakage between them.

## Why no production change

The store's DataSource is built from `createOrmConfig`, so it already inherits the `-c search_path=<DB_SCHEMA>` option (#527). Entity writes are unqualified → they land in `DB_SCHEMA`; every state table is qualified via `escapedSchema(stateSchema)` → unaffected by `search_path`. So the two dials are already independent — this PR just proves it end-to-end. **No `typeorm-store` code changed.**

## Test

Drives a real `TypeormDatabase` (`stateSchema` ≠ `DB_SCHEMA`): creates the data schema + entity tables (as migrations would), runs a `transact`, then asserts the `data` row lives in `DB_SCHEMA` and `status`/`hot_block` live in `stateSchema` — each absent from the other. Passes on **both Postgres and CockroachDB** (full suite: 14 files / 61 tests green on both).

## Scope

Test-only. `rush change`: `none`. Builds on #527 (search_path) and #529 (schema-aware migrations), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)