### PR TITLE
fix(typeorm): preserve DB_SCHEMA case so it can equal stateSchema

### DIFF
--- a/common/changes/@subsquid/typeorm-config/fix-data-schema-case_2026-07-10-04-15.json
+++ b/common/changes/@subsquid/typeorm-config/fix-data-schema-case_2026-07-10-04-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-config",
+      "comment": "Double-quote DB_SCHEMA in the search_path so its case is preserved, matching how typeorm-store qualifies stateSchema (lets DB_SCHEMA and stateSchema be the same value)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-config"
+}

--- a/common/changes/@subsquid/typeorm-migration/fix-data-schema-case_2026-07-10-04-15.json
+++ b/common/changes/@subsquid/typeorm-migration/fix-data-schema-case_2026-07-10-04-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-migration",
+      "comment": "Double-quote the schema in apply's CREATE SCHEMA so its case matches the quoted search_path (data and state resolve to the same schema)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-migration"
+}

--- a/common/changes/@subsquid/typeorm-store/test-shared-schema_2026-07-10-04-15.json
+++ b/common/changes/@subsquid/typeorm-store/test-shared-schema_2026-07-10-04-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/typeorm-store",
+      "comment": "Add a test for the DB_SCHEMA === stateSchema case (entity data and processor state sharing one schema)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-store"
+}

--- a/typeorm/typeorm-config/src/connectionOptions.ts
+++ b/typeorm/typeorm-config/src/connectionOptions.ts
@@ -253,6 +253,12 @@ export function getDataSchema(): string | undefined {
  * in which case the connection keeps the server's default `search_path` (which
  * usually includes `public`).
  *
+ * The schema name is double-quoted so Postgres preserves its case exactly —
+ * matching how `@subsquid/typeorm-store` qualifies its `stateSchema` (via the
+ * driver's identifier escaping). This keeps the data schema and the state
+ * schema resolving identically, so `DB_SCHEMA` and `stateSchema` may be set to
+ * the same value.
+ *
  * The schema defaults to being the sole entry in `search_path`. Set
  * `DB_SCHEMA_INCLUDE_PUBLIC=true` to append `,public` — needed only when the
  * squid references objects (e.g. extensions) that live in `public`.
@@ -261,7 +267,7 @@ export function getDataSchemaSearchPath(): string | undefined {
     let schema = getDataSchema()
     if (!schema) return undefined
 
-    let searchPath = schema
+    let searchPath = `"${schema}"`
     if (getIncludePublicInSearchPath()) {
         searchPath += ',public'
     }

--- a/typeorm/typeorm-config/src/test/schema.test.ts
+++ b/typeorm/typeorm-config/src/test/schema.test.ts
@@ -28,23 +28,23 @@ describe('DB_SCHEMA -> connection search_path', () => {
     test('DB_SCHEMA sets search_path=<schema> (schema only) on TypeORM `extra` and pg `options`', () => {
         process.env.DB_SCHEMA = 'eth_v3'
         const con = createConnectionOptions() as unknown as Record<string, any>
-        expect(con.extra).toEqual({options: '-c search_path=eth_v3'})
-        expect((toPgClientConfig(con as any) as unknown as Record<string, any>).options).toBe('-c search_path=eth_v3')
+        expect(con.extra).toEqual({options: '-c search_path="eth_v3"'})
+        expect((toPgClientConfig(con as any) as unknown as Record<string, any>).options).toBe('-c search_path="eth_v3"')
     })
 
     test('DB_SCHEMA_INCLUDE_PUBLIC=true appends ,public', () => {
         process.env.DB_SCHEMA = 'eth_v3'
         process.env.DB_SCHEMA_INCLUDE_PUBLIC = 'true'
         const con = createConnectionOptions() as unknown as Record<string, any>
-        expect(con.extra).toEqual({options: '-c search_path=eth_v3,public'})
+        expect(con.extra).toEqual({options: '-c search_path="eth_v3",public'})
     })
 
     test('applies to DB_URL connections as well', () => {
         process.env.DB_URL = 'postgres://u:p@h:5432/db'
         process.env.DB_SCHEMA = 'eth_v3'
         const con = createConnectionOptions() as unknown as Record<string, any>
-        expect(con.extra).toEqual({options: '-c search_path=eth_v3'})
-        expect((toPgClientConfig(con as any) as unknown as Record<string, any>).options).toBe('-c search_path=eth_v3')
+        expect(con.extra).toEqual({options: '-c search_path="eth_v3"'})
+        expect((toPgClientConfig(con as any) as unknown as Record<string, any>).options).toBe('-c search_path="eth_v3"')
     })
 
     test('rejects an invalid DB_SCHEMA (injection guard)', () => {
@@ -56,6 +56,6 @@ describe('DB_SCHEMA -> connection search_path', () => {
         process.env.DB_SCHEMA = 'eth_v3'
         const pg = toPgClientConfig(createConnectionOptions()) as unknown as Record<string, any>
         expect(pg.extra).toBeUndefined()
-        expect(pg.options).toBe('-c search_path=eth_v3')
+        expect(pg.options).toBe('-c search_path="eth_v3"')
     })
 })

--- a/typeorm/typeorm-migration/src/apply.ts
+++ b/typeorm/typeorm-migration/src/apply.ts
@@ -31,13 +31,13 @@ runProgram(async () => {
         // there. The schema must exist first: with a schema-only search_path
         // Postgres has nowhere to create tables otherwise.
         //
-        // Left unquoted so Postgres folds the name exactly as it does in the
-        // (unquoted) search_path — quoting here would preserve case and could
-        // create a different schema than the one migrations target. Safe from
-        // injection: getDataSchema() validates DB_SCHEMA as a plain identifier.
+        // Double-quoted to preserve case, matching the (also quoted) search_path
+        // built by @subsquid/typeorm-config — both resolve to the same schema.
+        // Safe from injection: getDataSchema() validates DB_SCHEMA as a plain
+        // identifier.
         let schema = getDataSchema()
         if (schema) {
-            await connection.query(`CREATE SCHEMA IF NOT EXISTS ${schema}`)
+            await connection.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
         }
         await connection.runMigrations({transaction: 'all'})
     } finally {

--- a/typeorm/typeorm-migration/src/test/schema.test.ts
+++ b/typeorm/typeorm-migration/src/test/schema.test.ts
@@ -78,12 +78,11 @@ describe('squid-typeorm-migration with DB_SCHEMA (feature, live DB)', () => {
 })
 
 
-// Regression: `apply` creates the schema unquoted, so Postgres folds the name
-// exactly as it does in the (unquoted) search_path. A mixed-case DB_SCHEMA must
-// therefore resolve to the same (folded) schema — quoting the CREATE would
-// create "MixedCaseSchema" while search_path targets "mixedcaseschema", and
-// apply would fail to find/create tables there.
-describe('squid-typeorm-migration DB_SCHEMA case folding (live DB)', () => {
+// `apply` creates the schema double-quoted, matching the (also quoted)
+// search_path from @subsquid/typeorm-config, so Postgres preserves case exactly.
+// A mixed-case DB_SCHEMA therefore resolves to the exact-cased schema in both
+// the CREATE and the search_path — never splitting into a folded variant.
+describe('squid-typeorm-migration DB_SCHEMA case preservation (live DB)', () => {
     const MIXED = 'MixedCaseSchema'
     const FOLDED = 'mixedcaseschema'
     const DIR = path.join(__dirname, '.tmp-migration-fold-project')
@@ -96,6 +95,7 @@ describe('squid-typeorm-migration DB_SCHEMA case folding (live DB)', () => {
         process.env.DB_SCHEMA = MIXED
         delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
         await withClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${MIXED}" CASCADE`)
             await client.query(`DROP SCHEMA IF EXISTS ${FOLDED} CASCADE`)
         })
     })
@@ -112,18 +112,19 @@ describe('squid-typeorm-migration DB_SCHEMA case folding (live DB)', () => {
             process.env.DB_SCHEMA_INCLUDE_PUBLIC = savedIncludePublic
         }
         await withClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${MIXED}" CASCADE`)
             await client.query(`DROP SCHEMA IF EXISTS ${FOLDED} CASCADE`)
         })
     })
 
-    test('a mixed-case DB_SCHEMA folds consistently, so migrations land in the folded schema', async () => {
+    test('a mixed-case DB_SCHEMA is preserved, so migrations land in the exact schema', async () => {
         const project = FixtureProject.create(DIR, ACCOUNT_MODEL)
         try {
             project.generate()
             project.apply()
             const account = await tableSchemas('account')
-            expect(account).toContain(FOLDED)
-            expect(account).not.toContain(MIXED)
+            expect(account).toContain(MIXED)
+            expect(account).not.toContain(FOLDED)
             expect(account).not.toContain('public')
         } finally {
             project.destroy()

--- a/typeorm/typeorm-store/src/test/schema.test.ts
+++ b/typeorm/typeorm-store/src/test/schema.test.ts
@@ -121,3 +121,78 @@ describe('TypeormDatabase data schema (DB_SCHEMA) vs state schema', function () 
         expect(DATA_SCHEMA).not.toBe(STATE_SCHEMA)
     })
 })
+
+
+// DB_SCHEMA === stateSchema: entity data and processor state share ONE schema
+// (as the pancakeindexer fork does). A mixed-case name proves the two mechanisms
+// agree on case — data via the quoted search_path, state via the quoted
+// escapedSchema — so they never split into two schemas.
+describe('TypeormDatabase with DB_SCHEMA === stateSchema (shared schema)', function () {
+    const SHARED = 'SharedSchemaV1'
+    const FOLDED = 'sharedschemav1'
+    let db!: TypeormDatabase
+    let savedSchema: string | undefined
+    let savedIncludePublic: string | undefined
+
+    beforeEach(async () => {
+        savedSchema = process.env.DB_SCHEMA
+        savedIncludePublic = process.env.DB_SCHEMA_INCLUDE_PUBLIC
+        process.env.DB_SCHEMA = SHARED
+        delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
+
+        await withClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${SHARED}" CASCADE`)
+            await client.query(`DROP SCHEMA IF EXISTS ${FOLDED} CASCADE`)
+            await client.query(`CREATE SCHEMA "${SHARED}"`)
+            await client.query(`SET search_path TO "${SHARED}"`)
+            for (let sql of CREATE_TABLES) {
+                await client.query(sql)
+            }
+        })
+
+        db = new TypeormDatabase({projectDir: __dirname, stateSchema: SHARED, supportHotBlocks: true})
+    })
+
+    afterEach(async () => {
+        await db?.disconnect()
+        if (savedSchema === undefined) {
+            delete process.env.DB_SCHEMA
+        } else {
+            process.env.DB_SCHEMA = savedSchema
+        }
+        if (savedIncludePublic === undefined) {
+            delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
+        } else {
+            process.env.DB_SCHEMA_INCLUDE_PUBLIC = savedIncludePublic
+        }
+        await withClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${SHARED}" CASCADE`)
+            await client.query(`DROP SCHEMA IF EXISTS ${FOLDED} CASCADE`)
+        })
+    })
+
+    it('keeps entity data and processor state together in the one shared schema', async () => {
+        await db.connect()
+        await db.transact({
+            prevHead: {height: -1, hash: '0x'},
+            nextHead: {height: 10, hash: '0x10'}
+        }, async store => {
+            await store.insert(new Data({id: '1', text: 'hello', integer: 10}))
+        })
+        await db.disconnect()
+
+        // data and both state tables all live in the single shared schema...
+        expect(await tableSchemas('data')).toContain(SHARED)
+        expect(await tableSchemas('status')).toContain(SHARED)
+        expect(await tableSchemas('hot_block')).toContain(SHARED)
+
+        // ...with case preserved — never split into a folded variant
+        expect(await tableSchemas('data')).not.toContain(FOLDED)
+        expect(await tableSchemas('status')).not.toContain(FOLDED)
+
+        let rows = await withClient(client =>
+            client.query(`SELECT id FROM "${SHARED}"."data"`).then(r => r.rows)
+        )
+        expect(rows).toEqual([{id: '1'}])
+    })
+})


### PR DESCRIPTION
## What

Makes `DB_SCHEMA === stateSchema` work for **any** schema name (the pattern the pancakeindexer fork uses — entity data and processor state in one schema).

## The bug

The data schema was threaded through `search_path` **unquoted**, so Postgres folds its case (`MySchema` → `myschema`). But `@subsquid/typeorm-store` qualifies `stateSchema` via the driver's identifier escaping, which **quotes** it (case preserved). For a lowercase name the two agree; for a mixed-case name set to both `DB_SCHEMA` and `stateSchema`, the data tables would land in the folded schema and the state tables in the case-preserved schema — **silently splitting into two schemas**.

## Fix

Quote the schema everywhere it's built, so it's case-preserving and consistent with `stateSchema`:
- `typeorm-config`: `-c search_path="<schema>"` (was unquoted)
- `typeorm-migration` `apply`: `CREATE SCHEMA IF NOT EXISTS "<schema>"` (was unquoted)

Empirically verified that a quoted value in the pg `options`/`search_path` string preserves case and that the `,public` tail still resolves. Still injection-safe — `DB_SCHEMA` is validated as a plain identifier, so no `"` can appear.

## Tests

- `typeorm-config`: assertions updated to the quoted `-c search_path="eth_v3"` form.
- `typeorm-migration`: the case test now asserts **preservation** (mixed-case `DB_SCHEMA` lands in the exact-cased schema, not a folded one).
- `typeorm-store`: **new** test drives a mixed-case `DB_SCHEMA === stateSchema` and asserts `data` + `status` + `hot_block` all share the one schema, case preserved.

All green: config 15/15, migration 6/6, store 62/62 on **both Postgres and CockroachDB**.

## Scope

`typeorm-config` / `typeorm-migration`: `patch` (refine the unreleased search_path handling). `typeorm-store`: `none` (test-only).

## Known limitation (documented, not fixed here)

When `DB_SCHEMA === stateSchema`, entity tables and the store's state tables (`status`, `hot_block`, `hot_change_log`, `template_registry`) share a namespace — an entity named e.g. `Status` would collide. Inherent to sharing a schema; will note it in the Phase 6 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)