### PR TITLE
feat(graphql-server): honor DB_SCHEMA on the TypeORM context path

### DIFF
--- a/common/changes/@subsquid/graphql-server/feat-data-schema_2026-07-10-06-40.json
+++ b/common/changes/@subsquid/graphql-server/feat-data-schema_2026-07-10-06-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/graphql-server",
+      "comment": "Honor DB_SCHEMA on the TypeORM context path: stop overwriting the connection `extra`, so the search_path from @subsquid/typeorm-config is preserved",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/graphql-server"
+}

--- a/graphql/graphql-server/Makefile
+++ b/graphql/graphql-server/Makefile
@@ -18,5 +18,7 @@ build:
 	@npx tsc
 	@cp src/test/resolvers-extension/schema.graphql lib/test/resolvers-extension
 	@cp src/test/check-extension/schema.graphql lib/test/check-extension
+	@mkdir -p lib/test/schema-plain
+	@cp src/test/schema-plain/schema.graphql lib/test/schema-plain
 
 .PHONY: up down logs test test-cockroach build

--- a/graphql/graphql-server/src/server.ts
+++ b/graphql/graphql-server/src/server.ts
@@ -269,9 +269,13 @@ export class Server {
     private async createTypeormConnection(options?: ConnectionOptions): Promise<DataSource> {
         let {createOrmConfig} = await import('@subsquid/typeorm-config')
         let {DataSource} = await import('typeorm')
+        let ormConfig = createOrmConfig({projectDir: this.dir})
         let cfg = {
-            ...createOrmConfig({projectDir: this.dir}),
+            ...ormConfig,
+            // Preserve any `extra` from the config (notably `options` carrying the
+            // DB_SCHEMA search_path) instead of overwriting it wholesale.
             extra: {
+                ...ormConfig.extra,
                 statement_timeout: options?.sqlStatementTimeout || undefined,
                 max: this.connectionPoolSize(),
                 min: this.connectionPoolSize()

--- a/graphql/graphql-server/src/test/schema-plain/schema.graphql
+++ b/graphql/graphql-server/src/test/schema-plain/schema.graphql
@@ -1,0 +1,4 @@
+type Item @entity {
+  id: ID!
+  name: String
+}

--- a/graphql/graphql-server/src/test/schema-pool.test.ts
+++ b/graphql/graphql-server/src/test/schema-pool.test.ts
@@ -1,0 +1,21 @@
+import {useSchema} from './util/schema'
+import {useServer} from './util/server'
+
+
+// Feature: with DB_SCHEMA set, a server that runs through the plain pg Pool
+// context (selected because the project has no custom resolvers) must read
+// entity data from that schema. This exercises `createPgPool`.
+describe('graphql-server with DB_SCHEMA (Pool context, live DB)', () => {
+    useSchema('gql_pool_schema', [
+        `create table item (id text primary key, name text)`,
+        `insert into item (id, name) values ('1', 'hello')`,
+    ])
+
+    const client = useServer('lib/test/schema-plain')
+
+    it('openreader reads entities from DB_SCHEMA', () => {
+        return client.test(`query { items { id name } }`, {
+            items: [{id: '1', name: 'hello'}]
+        })
+    })
+})

--- a/graphql/graphql-server/src/test/schema-typeorm.test.ts
+++ b/graphql/graphql-server/src/test/schema-typeorm.test.ts
@@ -1,0 +1,28 @@
+import {useSchema} from './util/schema'
+import {useServer} from './util/server'
+
+
+// Feature: with DB_SCHEMA set, a server that runs through the TypeORM context
+// (selected because the project defines custom resolvers) must read entity data
+// from that schema. This exercises `createTypeormConnection`, whose `extra` used
+// to clobber the search_path carried by @subsquid/typeorm-config.
+describe('graphql-server with DB_SCHEMA (TypeORM context, live DB)', () => {
+    useSchema('gql_typeorm_schema', [
+        `create table scalar (id text primary key, "bool" bool, date timestamptz, big_int numeric, big_decimal numeric, "bytes" bytea, attributes jsonb)`,
+        `insert into scalar (id, bool) values ('1', true)`,
+    ])
+
+    const client = useServer('lib/test/resolvers-extension')
+
+    it('custom resolver (EntityManager) reads entities from DB_SCHEMA', () => {
+        return client.test(`query { scalarsExtension { id bool } }`, {
+            scalarsExtension: [{id: '1', bool: true}]
+        })
+    })
+
+    it('openreader reads entities from DB_SCHEMA', () => {
+        return client.test(`query { scalars { id bool } }`, {
+            scalars: [{id: '1', bool: true}]
+        })
+    })
+})

--- a/graphql/graphql-server/src/test/util/schema.ts
+++ b/graphql/graphql-server/src/test/util/schema.ts
@@ -1,0 +1,93 @@
+/// <reference types="vitest/globals" />
+import {Client as PgClient} from 'pg'
+
+
+function isCockroach(): boolean {
+    return process.env.DB_TYPE == 'cockroach'
+}
+
+
+// Mirror util/db.ts: resolve DB_PORT from the per-engine test ports so the
+// server under test (which reads DB_PORT via @subsquid/typeorm-config) connects
+// to the docker-compose database rather than the default 5432.
+if (!process.env.DB_PORT) {
+    let port = isCockroach() ? process.env.DB_PORT_COCKROACH : process.env.DB_PORT_PG
+    if (port) {
+        process.env.DB_PORT = port
+    }
+}
+
+
+function basePort(): number {
+    if (process.env.DB_PORT) return parseInt(process.env.DB_PORT)
+    let p = isCockroach() ? process.env.DB_PORT_COCKROACH : process.env.DB_PORT_PG
+    return parseInt(p || '5432')
+}
+
+
+/**
+ * A pg client on the plain connection — no `DB_SCHEMA`/search_path — used by the
+ * tests to provision (and later drop) a dedicated data schema out-of-band. This
+ * deliberately does NOT go through @subsquid/typeorm-config, so the setup client
+ * is unaffected by the `DB_SCHEMA` we toggle to exercise the server.
+ */
+async function withBaseClient(block: (client: PgClient) => Promise<void>): Promise<void> {
+    let client = new PgClient({
+        host: process.env.DB_HOST || 'localhost',
+        port: basePort(),
+        user: process.env.DB_USER || 'postgres',
+        password: process.env.DB_PASS || 'postgres',
+        database: process.env.DB_NAME || 'postgres',
+    })
+    await client.connect()
+    try {
+        await block(client)
+    } finally {
+        await client.end()
+    }
+}
+
+
+/**
+ * Registers hooks that, for the duration of the enclosing `describe`, point
+ * `DB_SCHEMA` at a freshly created schema, provision the given tables/rows inside
+ * it, and tear it all down afterwards (restoring the previous env). The server
+ * started by `useServer` then reads/writes that schema via its search_path.
+ */
+export function useSchema(schema: string, sql: string[]): void {
+    let savedSchema: string | undefined
+    let savedIncludePublic: string | undefined
+
+    beforeAll(async () => {
+        savedSchema = process.env.DB_SCHEMA
+        savedIncludePublic = process.env.DB_SCHEMA_INCLUDE_PUBLIC
+        process.env.DB_SCHEMA = schema
+        delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
+
+        await withBaseClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+            await client.query(`CREATE SCHEMA "${schema}"`)
+            // Create the fixtures inside the schema without qualifying each name.
+            await client.query(`SET search_path TO "${schema}"`)
+            for (let stmt of sql) {
+                await client.query(stmt)
+            }
+        })
+    })
+
+    afterAll(async () => {
+        if (savedSchema === undefined) {
+            delete process.env.DB_SCHEMA
+        } else {
+            process.env.DB_SCHEMA = savedSchema
+        }
+        if (savedIncludePublic === undefined) {
+            delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
+        } else {
+            process.env.DB_SCHEMA_INCLUDE_PUBLIC = savedIncludePublic
+        }
+        await withBaseClient(async client => {
+            await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+        })
+    })
+}

--- a/graphql/graphql-server/src/test/util/schema.ts
+++ b/graphql/graphql-server/src/test/util/schema.ts
@@ -19,9 +19,15 @@ if (!process.env.DB_PORT) {
 
 
 function basePort(): number {
-    if (process.env.DB_PORT) return parseInt(process.env.DB_PORT)
+    if (process.env.DB_PORT) return Number.parseInt(process.env.DB_PORT, 10)
     let p = isCockroach() ? process.env.DB_PORT_COCKROACH : process.env.DB_PORT_PG
-    return parseInt(p || '5432')
+    return Number.parseInt(p || '5432', 10)
+}
+
+
+// Quote a schema name as a Postgres identifier, escaping embedded double quotes.
+function quoteIdent(id: string): string {
+    return `"${id.replace(/"/g, '""')}"`
 }
 
 
@@ -64,11 +70,12 @@ export function useSchema(schema: string, sql: string[]): void {
         process.env.DB_SCHEMA = schema
         delete process.env.DB_SCHEMA_INCLUDE_PUBLIC
 
+        let ident = quoteIdent(schema)
         await withBaseClient(async client => {
-            await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
-            await client.query(`CREATE SCHEMA "${schema}"`)
+            await client.query(`DROP SCHEMA IF EXISTS ${ident} CASCADE`)
+            await client.query(`CREATE SCHEMA ${ident}`)
             // Create the fixtures inside the schema without qualifying each name.
-            await client.query(`SET search_path TO "${schema}"`)
+            await client.query(`SET search_path TO ${ident}`)
             for (let stmt of sql) {
                 await client.query(stmt)
             }
@@ -87,7 +94,7 @@ export function useSchema(schema: string, sql: string[]): void {
             process.env.DB_SCHEMA_INCLUDE_PUBLIC = savedIncludePublic
         }
         await withBaseClient(async client => {
-            await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+            await client.query(`DROP SCHEMA IF EXISTS ${quoteIdent(schema)} CASCADE`)
         })
     })
 }


### PR DESCRIPTION
## What

Fifth PR in the `DB_SCHEMA` (configurable data schema) series. Makes `@subsquid/graphql-server` serve entity data from the schema named by `DB_SCHEMA`, closing the last gap on the read side.

## The bug

`Server.createTypeormConnection()` built its `DataSource` config by spreading `createOrmConfig()` and then **overwriting** `extra` with a fresh object holding only `statement_timeout`/`max`/`min`:

```ts
let cfg = {
    ...createOrmConfig({projectDir: this.dir}),
    extra: { statement_timeout, max, min }   // clobbers extra.options (search_path)
}
```

`@subsquid/typeorm-config` populates `extra.options` with `-c search_path=<DB_SCHEMA>`. Overwriting `extra` dropped it, so a graphql-server on the **TypeORM context path** (projects that define custom resolvers — `TypeormOpenreaderContext`) silently ignored `DB_SCHEMA` and read from the default schema.

The **pg `Pool` path** (`createPgPool`, used when there are no custom resolvers — `PoolOpenreaderContext`) already spread `toPgClientConfig(...)` and inherited the search_path correctly. Unchanged.

## The fix

Merge into the existing `extra` instead of replacing it:

```ts
let ormConfig = createOrmConfig({projectDir: this.dir})
let cfg = {
    ...ormConfig,
    extra: { ...ormConfig.extra, statement_timeout, max, min }
}
```

## Tests (live DB, TDD)

Adds a `useSchema()` helper (`src/test/util/schema.ts`) that provisions a dedicated schema, points `DB_SCHEMA` at it for the duration of a `describe`, and tears it down. Two files cover **both** context paths against a real Postgres:

- `schema-typeorm.test.ts` — reuses the `resolvers-extension` fixture (custom resolvers → TypeORM context). Asserts both a custom resolver (`EntityManager`) and an openreader query read from `DB_SCHEMA`. **This is the regression test** — RED before the fix (`relation "scalar" does not exist`), GREEN after.
- `schema-pool.test.ts` — new minimal resolver-less `schema-plain` fixture (→ pg `Pool` context). Guards the already-working path.

Full suite: 13 passing.

## Scope note — standalone `openreader` CLI

The standalone `@subsquid/openreader` binary is intentionally left `--db-url`-driven. It's a low-level tool with no env-var conventions and no `@subsquid/typeorm-config` dependency; a schema is selectable via the standard pg URL parameter (`?options=-c search_path=<schema>`). The `DB_SCHEMA` convention lives at the squid layer (`typeorm-store` for the processor, `graphql-server` for the API). This will be documented in the docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmEtzbcoThPGFsY59qjTai