### PR TITLE
feat(evm/fallback): standalone-capable Portal/RPC source builders

### DIFF
--- a/common/changes/@subsquid/squid-sdk/feat-standalone-fallback-source-builders_2026-07-15-10-44.json
+++ b/common/changes/@subsquid/squid-sdk/feat-standalone-fallback-source-builders_2026-07-15-10-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/squid-sdk",
+      "comment": "evm/fallback: EvmPortalDataSourceBuilder and EvmRpcDataSourceBuilder are now full standalone data-source builders (fluent setFields/addLog/… + build()), sharing the query surface with EvmFallbackDataSourceBuilder. Used in a fallback they take connection config only; the fallback injects its shared query, and a source that also sets its own query throws at build() time.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/squid-sdk"
+}

--- a/meta/squid-sdk/README.md
+++ b/meta/squid-sdk/README.md
@@ -64,6 +64,25 @@ const source = new EvmFallbackDataSourceBuilder()
     .build()
 ```
 
+### Standalone sources
+
+`EvmPortalDataSourceBuilder` and `EvmRpcDataSourceBuilder` are full data-source builders in their own
+right — the same fluent `setFields`/`addLog`/… surface as `DataSourceBuilder`. Call `.build()` on one
+directly for a single Portal or RPC source, no fallback involved:
+
+```ts
+const rpcSource = new EvmRpcDataSourceBuilder()
+    .setRpc({url: RPC_URL, network: 'ethereum-mainnet'})
+    .setFields({log: {topics: true, data: true}})
+    .addLog({where: {address: [CONTRACT], topic0: [TRANSFER]}, range: {from: 10_000_000}})
+    .build() // an EVMDataSource<F>, exactly like DataSourceBuilder.build()
+```
+
+When you drop the **same** builder into a fallback, give it connection config only (`setPortal`/`setRpc`
+/`setName`) and define the shared query once on the fallback — it is injected into every source so they
+all fetch identical data. A source that carries **both** its own query and is placed in a fallback throws
+at `build()` time (the query must live in exactly one place).
+
 To drive an arbitrary pre-built `EVMDataSource` (e.g. a custom source), implement the
 `EvmDownstreamSourceBuilder` interface — its `buildSource(fields, requests)` returns your source.
 

--- a/meta/squid-sdk/src/evm/fallback/builder.test.ts
+++ b/meta/squid-sdk/src/evm/fallback/builder.test.ts
@@ -1,6 +1,6 @@
 import type {DataRequest, EVMDataSource, FieldSelection} from '@subsquid/evm-stream'
 import type {RangeRequestList} from '@subsquid/util-internal-range'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {FallbackDataSource} from '../../fallback/fallback'
 import {
@@ -9,6 +9,20 @@ import {
     EvmPortalDataSourceBuilder,
     EvmRpcDataSourceBuilder,
 } from './builder'
+
+// Stub the lazy RPC loader: `require('../rpc')` resolves a directory to lib/index.js when compiled,
+// but vitest can't resolve it to the .ts source. So RPC-build tests here verify the builder's wiring
+// (which fields/requests it hands to evmRpcStream) rather than the real RPC stack — the network-gated
+// e2e test covers the real one. `rpcCalls` records every evmRpcStream config.
+const {rpcCalls} = vi.hoisted(() => ({rpcCalls: [] as any[]}))
+vi.mock('./load-rpc-stream', () => ({
+    loadRpcStream: () => ({
+        evmRpcStream: (config: any) => {
+            rpcCalls.push(config)
+            return {getFinalizedStream() {}, getFinalizedHead() {}, getStream() {}, getHead() {}}
+        },
+    }),
+}))
 
 /** A downstream that records the shared fields + requests it is finalized with, returning a stub. */
 function capturing(
@@ -93,5 +107,81 @@ describe('EvmFallbackDataSourceBuilder', () => {
         // connects until it is streamed.
         expect(typeof src.getFinalizedStream).toBe('function')
         expect(typeof src.getFinalizedHead).toBe('function')
+    })
+
+    it('builds a real Portal downstream as part of a fallback and names the sources', () => {
+        const fb = new EvmFallbackDataSourceBuilder()
+            .setDownstreamSources([
+                new EvmPortalDataSourceBuilder().setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet'),
+                new EvmRpcDataSourceBuilder().setRpc({url: 'https://rpc.example'}),
+            ])
+            .setFields({log: {topics: true}})
+            .addLog({where: {address: ['0xabc']}})
+            .setCapabilityProbe(false)
+            .build()
+
+        expect(fb).toBeInstanceOf(FallbackDataSource)
+        expect(fb.metrics().sources.map((s) => s.name)).toEqual(['portal-0', 'rpc-1'])
+    })
+})
+
+describe('standalone source builders', () => {
+    it('builds a standalone Portal source with its own field selection + query (no connection)', () => {
+        const src = new EvmPortalDataSourceBuilder()
+            .setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet')
+            .setFields({log: {topics: true}})
+            .addLog({where: {address: ['0xabc']}, range: {from: 10}})
+            .build()
+
+        expect(typeof src.getFinalizedStream).toBe('function')
+        expect(typeof src.getFinalizedHead).toBe('function')
+    })
+
+    it('builds a standalone RPC source, passing its own field selection + query to evmRpcStream', () => {
+        rpcCalls.length = 0
+        const src = new EvmRpcDataSourceBuilder()
+            .setRpc({url: 'https://rpc.example', network: 'ethereum-mainnet'})
+            .setFields({log: {topics: true}})
+            .addLog({where: {address: ['0xabc']}, range: {from: 10}})
+            .build()
+
+        expect(typeof src.getFinalizedStream).toBe('function')
+        expect(rpcCalls).toHaveLength(1)
+        expect(rpcCalls[0]).toMatchObject({url: 'https://rpc.example', network: 'ethereum-mainnet', fields: {log: {topics: true}}})
+        expect(rpcCalls[0].requests[0].request.logs).toEqual([{where: {address: ['0xabc']}}])
+    })
+
+    it('injects the fallback shared query into an RPC downstream (not the downstream\'s own)', () => {
+        rpcCalls.length = 0
+        new EvmFallbackDataSourceBuilder()
+            .setDownstreamSources([new EvmRpcDataSourceBuilder().setRpc({url: 'https://rpc.example'})])
+            .setFields({transaction: {hash: true}})
+            .addTransaction({where: {to: ['0xdef']}, range: {from: 5}})
+            .setCapabilityProbe(false)
+            .build()
+
+        expect(rpcCalls).toHaveLength(1)
+        expect(rpcCalls[0].fields).toEqual({transaction: {hash: true}})
+        expect(rpcCalls[0].requests[0].request.transactions).toEqual([{where: {to: ['0xdef']}}])
+    })
+
+    it('rejects a downstream that also sets its own query inside a fallback', () => {
+        // Portal downstream carrying its own query.
+        expect(() =>
+            new EvmFallbackDataSourceBuilder()
+                .setDownstreamSources([
+                    new EvmPortalDataSourceBuilder().setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet').addLog({where: {address: ['0xabc']}}),
+                ])
+                .setFields({log: {topics: true}})
+                .build(),
+        ).toThrow(/inside a fallback/i)
+
+        // RPC downstream carrying its own field selection.
+        expect(() =>
+            new EvmFallbackDataSourceBuilder()
+                .setDownstreamSources([new EvmRpcDataSourceBuilder().setRpc({url: 'https://rpc.invalid'}).setFields({log: {topics: true}})])
+                .addLog({where: {address: ['0xabc']}})
+                .build(),
+        ).toThrow(/inside a fallback/i)
     })
 })

--- a/meta/squid-sdk/src/evm/fallback/builder.ts
+++ b/meta/squid-sdk/src/evm/fallback/builder.ts
@@ -28,184 +28,29 @@ interface BlockRange {
 
 const evmBlockRef = (b: Block<any>): BlockRef => ({number: b.header.number, hash: b.header.hash})
 
-/**
- * A downstream source in an EVM fallback — **connection config only**. The field selection and query
- * are defined once on the {@link EvmFallbackDataSourceBuilder} and passed to every downstream's
- * {@link buildSource}, so all sources fetch the same data and produce identical output no matter
- * which one is active. Implemented by {@link EvmPortalDataSourceBuilder} and
- * {@link EvmRpcDataSourceBuilder}.
- *
- * Implementing this interface directly is an escape hatch for wrapping an arbitrary pre-built
- * `EVMDataSource`. If you do, **`buildSource` must build from the `fields` and `requests` it is
- * given** — a source configured with a different field selection or query makes the fallback's
- * output silently depend on which source is currently active, defeating the purpose of a fallback.
- */
-export interface EvmDownstreamSourceBuilder {
-    /**
-     * Name **prefix** for this source in metrics/logs when {@link name} is unset: the source is
-     * named `` `${defaultName}-${index}` `` (e.g. `portal-0`), where `index` is its position in the
-     * fallback's source list.
-     */
-    readonly defaultName: string
-    /** Explicit source name for metrics/logs. Used verbatim (no index suffix) when set. */
-    readonly name?: string
-    /**
-     * Finalize into a full data source. Must build from the given `fields` and `requests` — the
-     * fallback's shared selection and query — so every source in the fallback returns identical data.
-     */
-    buildSource<F extends FieldSelection>(fields: F, requests: RangeRequestList<DataRequest>): EVMDataSource<F>
-}
+const OWN_QUERY_IN_FALLBACK =
+    'This source already has its own field selection or query, so it cannot be used inside a fallback. ' +
+    'Define the query once on the EvmFallbackDataSourceBuilder (setFields/addLog/…) and give each source ' +
+    'only its connection config (setPortal/setRpc/setName). Call .build() on the source to use it standalone.'
 
 /**
- * A SQD Network Portal source in an EVM fallback. Mirrors `@subsquid/evm-stream`'s
- * `DataSourceBuilder#setPortal` — pass a URL, {@link PortalClientOptions}, or a {@link PortalClient}.
+ * The shared fluent query surface — field selection + item filters + block range — common to the
+ * standalone source builders ({@link EvmPortalDataSourceBuilder}, {@link EvmRpcDataSourceBuilder})
+ * and the {@link EvmFallbackDataSourceBuilder}. Mirrors `@subsquid/evm-stream`'s `DataSourceBuilder`
+ * so all of them read identically. Not instantiated directly.
  */
-export class EvmPortalDataSourceBuilder implements EvmDownstreamSourceBuilder {
-    readonly defaultName = 'portal'
-    name?: string
-    private portal?: PortalClient | PortalClientOptions
+export abstract class EvmQueryBuilder {
+    protected fields: FieldSelection = {}
+    protected requests: RangeRequest<DataRequest>[] = []
+    protected blockRange?: Range
 
-    /** Optional explicit name for this source in metrics/logs (default `portal-<index>`). */
-    setName(name: string): this {
-        this.name = name
-        return this
-    }
-
-    /**
-     * Set the SQD Network Portal endpoint.
-     *
-     * @example
-     * new EvmPortalDataSourceBuilder().setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet')
-     */
-    setPortal(portal: string | PortalClientOptions | PortalClient): this {
-        this.portal = typeof portal === 'string' ? {url: portal} : portal
-        return this
-    }
-
-    buildSource<F extends FieldSelection>(fields: F, requests: RangeRequestList<DataRequest>): EVMDataSource<F> {
-        assert(this.portal, 'Portal endpoint not set — call setPortal(...) on the portal source')
-        // Reuse the canonical Portal builder so a fallback Portal source is byte-for-byte what a
-        // standalone one would be. Re-feeding the already-merged requests is idempotent: they are
-        // disjoint by range, so mergeRangeRequests leaves them untouched.
-        let builder = new DataSourceBuilder().setPortal(this.portal).setFields(fields)
-        for (let req of requests) builder.addQuery(req)
-        return builder.build()
-    }
-}
-
-/** Connection + per-network config for an {@link EvmRpcDataSourceBuilder} (everything `evmRpcStream` takes bar the shared `fields`/`requests`). */
-export interface EvmRpcSourceOptions {
-    /** JSON-RPC endpoint URL. */
-    url: string
-    /** Known network slug or chainId — selects the per-network preset (trace/debug method, validation). */
-    network?: string | number
-    /** Explicit validation/finality overrides, merged over the preset. */
-    rpc?: NetworkOverrides['rpc']
-    /** Explicit trace/stateDiff method overrides, merged over the preset. */
-    method?: RpcMethodOptions
-    capacity?: number
-    rateLimit?: number
-    strideSize?: number
-    strideConcurrency?: number
-}
-
-/**
- * A JSON-RPC source in an EVM fallback. Configured by endpoint (with an optional per-network preset
- * and overrides); the `@subsquid/evm-rpc` stack is loaded lazily, only when the source is built.
- */
-export class EvmRpcDataSourceBuilder implements EvmDownstreamSourceBuilder {
-    readonly defaultName = 'rpc'
-    name?: string
-    private options?: EvmRpcSourceOptions
-
-    /** Optional explicit name for this source in metrics/logs (default `rpc-<index>`). */
-    setName(name: string): this {
-        this.name = name
-        return this
-    }
-
-    /**
-     * Configure the JSON-RPC data source — a bare endpoint URL, or {@link EvmRpcSourceOptions} for a
-     * per-network preset, method/validation overrides, and connection tuning.
-     *
-     * @example
-     * new EvmRpcDataSourceBuilder().setRpc({url: 'https://rpc...', network: 'ethereum-mainnet'})
-     */
-    setRpc(options: string | EvmRpcSourceOptions): this {
-        this.options = typeof options === 'string' ? {url: options} : options
-        return this
-    }
-
-    buildSource<F extends FieldSelection>(fields: F, requests: RangeRequestList<DataRequest>): EVMDataSource<F> {
-        assert(this.options, 'RPC endpoint not set — call setRpc(...) on the rpc source')
-        // Lazy: this is the only point that touches the optional @subsquid/evm-rpc peer.
-        return loadRpcStream().evmRpcStream({...this.options, fields, requests})
-    }
-}
-
-/**
- * Fluent builder for an EVM fallback data source, shaped like `@subsquid/evm-stream`'s
- * `DataSourceBuilder`: define the field selection + query **once** here (`setFields`, `addLog`, …),
- * list the ordered downstream sources (Portal and/or RPC) via {@link setDownstreamSources}, and
- * `build()` a `FallbackDataSource<Block<F>>` — a drop-in for a single `EVMDataSource<F>`.
- *
- * @example
- * const source = new EvmFallbackDataSourceBuilder()
- *     .setDownstreamSources([
- *         new EvmPortalDataSourceBuilder().setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet'),
- *         new EvmRpcDataSourceBuilder().setRpc({url: RPC_URL, network: 'ethereum-mainnet'}),
- *     ])
- *     .setFields({log: {topics: true, data: true}})
- *     .addLog({where: {address: [CONTRACT], topic0: [TRANSFER]}, range: {from: 10_000_000}})
- *     .build()
- */
-export class EvmFallbackDataSourceBuilder<F extends FieldSelection = {}> {
-    private downstream: EvmDownstreamSourceBuilder[] = []
-    private requests: RangeRequest<DataRequest>[] = []
-    private fields?: FieldSelection
-    private blockRange?: Range
-    private policy?: FallbackPolicy
-    private capabilityProbe: boolean | CapabilityProbeOptions = true
-
-    /** Ordered downstream sources, most-preferred first. The fallback drives the first healthy one. */
-    setDownstreamSources(sources: EvmDownstreamSourceBuilder[]): this {
-        this.downstream = sources
-        return this
-    }
-
-    /** Failover/switch-up policy (lag/staleness thresholds, cooldowns, …). Defaults are sensible. */
-    setPolicy(policy: FallbackPolicy): this {
-        this.policy = policy
-        return this
-    }
-
-    /**
-     * Attach a generic capability probe to every source (default `true`): a source counts as
-     * `healthy` only once it confirms it can serve the configured data at the indexing frontier —
-     * catching a reachable-but-incapable node (trace/`debug_` disabled, pruned state) before a
-     * switch-up promotes it. Pass `false` to govern health by liveness alone, or `{timeoutMs}` to
-     * tune the probe.
-     */
-    setCapabilityProbe(probe: boolean | CapabilityProbeOptions): this {
-        this.capabilityProbe = probe
-        return this
-    }
-
-    // ---- Shared query: mirrors @subsquid/evm-stream DataSourceBuilder, so the API feels identical ----
-
-    /** Limit the range of blocks to fetch (applied across every downstream source). */
+    /** Limit the range of blocks to fetch. */
     setBlockRange(range?: Range): this {
         this.blockRange = range
         return this
     }
 
-    /** Configure the set of fetched fields — infers the block type `F` for `build()`. */
-    setFields<T extends FieldSelection>(fields: T): EvmFallbackDataSourceBuilder<T> {
-        this.fields = fields
-        return this as unknown as EvmFallbackDataSourceBuilder<T>
-    }
-
-    /** Add a portal query — a set of item filters sharing a block range (accepts a {@link QueryBuilder}). */
+    /** Add a query — a set of item filters sharing a block range (accepts a {@link QueryBuilder}). */
     addQuery(query: Query | QueryBuilder): this {
         this.requests.push(query instanceof QueryBuilder ? query.build() : query)
         return this
@@ -240,8 +85,8 @@ export class EvmFallbackDataSourceBuilder<F extends FieldSelection = {}> {
         return this.addQuery({range: range ?? {from: 0}, request: {stateDiffs: [req]}})
     }
 
-    // Merge + range-bound the accumulated queries (mirrors DataSourceBuilder#getRequests).
-    private getRequests(): RangeRequestList<DataRequest> {
+    /** Merge + range-bound the accumulated queries (mirrors DataSourceBuilder#getRequests). */
+    protected getRequests(): RangeRequestList<DataRequest> {
         function concat<T>(a?: T[], b?: T[]): T[] | undefined {
             let result = [...(a ?? []), ...(b ?? [])]
             return result.length === 0 ? undefined : result
@@ -258,11 +103,239 @@ export class EvmFallbackDataSourceBuilder<F extends FieldSelection = {}> {
         return applyRangeBound(requests, this.blockRange)
     }
 
+    /** Whether this builder carries a field selection, query, or block range of its own. */
+    protected hasOwnQuery(): boolean {
+        return Object.keys(this.fields).length > 0 || this.requests.length > 0 || this.blockRange !== undefined
+    }
+}
+
+/**
+ * The fallback's contract for a downstream source: a name and a {@link buildSource} that produces a
+ * full data source from the fallback's shared field selection + requests. Implemented by the
+ * standalone {@link EvmPortalDataSourceBuilder} and {@link EvmRpcDataSourceBuilder}, which pass those
+ * through so every source in the fallback fetches the same data (and produces identical output no
+ * matter which one is active).
+ *
+ * Implementing this interface directly is an escape hatch for wrapping an arbitrary pre-built
+ * `EVMDataSource`. If you do, **`buildSource` must build from the `fields` and `requests` it is
+ * given** — a source configured with a different field selection or query makes the fallback's
+ * output silently depend on which source is currently active, defeating the purpose of a fallback.
+ */
+export interface EvmDownstreamSourceBuilder {
+    /**
+     * Name **prefix** for this source in metrics/logs when {@link name} is unset: the source is
+     * named `` `${defaultName}-${index}` `` (e.g. `portal-0`), where `index` is its position in the
+     * fallback's source list.
+     */
+    readonly defaultName: string
+    /** Explicit source name for metrics/logs. Used verbatim (no index suffix) when set. */
+    readonly name?: string
+    /**
+     * Finalize into a full data source using the fallback's shared `fields` and `requests`, so every
+     * source in the fallback returns identical data.
+     */
+    buildSource<F extends FieldSelection>(fields: F, requests: RangeRequestList<DataRequest>): EVMDataSource<F>
+}
+
+/**
+ * A SQD Network Portal data source builder — mirrors `@subsquid/evm-stream`'s `DataSourceBuilder`
+ * (`setPortal` + the shared `setFields`/`addLog`/… query surface). Use it two ways:
+ *
+ * - **Standalone**: `new EvmPortalDataSourceBuilder().setPortal(url).setFields(…).addLog(…).build()`
+ *   returns an `EVMDataSource<F>`, exactly like `DataSourceBuilder`.
+ * - **As a fallback downstream**: pass it (with connection config only — `setPortal`/`setName`) to
+ *   {@link EvmFallbackDataSourceBuilder.setDownstreamSources}; the fallback supplies the shared
+ *   query. Setting a query here *and* using it in a fallback throws at `build()` time.
+ */
+export class EvmPortalDataSourceBuilder<F extends FieldSelection = {}>
+    extends EvmQueryBuilder
+    implements EvmDownstreamSourceBuilder
+{
+    readonly defaultName = 'portal'
+    name?: string
+    private portal?: PortalClient | PortalClientOptions
+
+    /** Optional explicit name for this source in metrics/logs (default `portal-<index>`). */
+    setName(name: string): this {
+        this.name = name
+        return this
+    }
+
+    /**
+     * Set the SQD Network Portal endpoint.
+     *
+     * @example
+     * new EvmPortalDataSourceBuilder().setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet')
+     */
+    setPortal(portal: string | PortalClientOptions | PortalClient): this {
+        this.portal = typeof portal === 'string' ? {url: portal} : portal
+        return this
+    }
+
+    /** Configure the set of fetched fields — infers the block type `F` for standalone `build()`. */
+    setFields<T extends FieldSelection>(fields: T): EvmPortalDataSourceBuilder<T> {
+        this.fields = fields
+        return this as unknown as EvmPortalDataSourceBuilder<T>
+    }
+
+    /** Build a standalone Portal data source from this builder's own field selection + query. */
+    build(): EVMDataSource<F> {
+        return this.toSource(this.fields as F, this.getRequests())
+    }
+
+    buildSource<G extends FieldSelection>(fields: G, requests: RangeRequestList<DataRequest>): EVMDataSource<G> {
+        assert(!this.hasOwnQuery(), OWN_QUERY_IN_FALLBACK)
+        return this.toSource(fields, requests)
+    }
+
+    private toSource<G extends FieldSelection>(fields: G, requests: RangeRequestList<DataRequest>): EVMDataSource<G> {
+        assert(this.portal, 'Portal endpoint not set — call setPortal(...) on the portal source')
+        // Reuse the canonical Portal builder so the source is byte-for-byte what a standalone one
+        // would be. Re-feeding the already-merged requests is idempotent: they are disjoint by range,
+        // so mergeRangeRequests leaves them untouched.
+        let builder = new DataSourceBuilder().setPortal(this.portal).setFields(fields)
+        for (let req of requests) builder.addQuery(req)
+        return builder.build()
+    }
+}
+
+/** Connection + per-network config for an {@link EvmRpcDataSourceBuilder} (everything `evmRpcStream` takes bar the shared `fields`/`requests`). */
+export interface EvmRpcSourceOptions {
+    /** JSON-RPC endpoint URL. */
+    url: string
+    /** Known network slug or chainId — selects the per-network preset (trace/debug method, validation). */
+    network?: string | number
+    /** Explicit validation/finality overrides, merged over the preset. */
+    rpc?: NetworkOverrides['rpc']
+    /** Explicit trace/stateDiff method overrides, merged over the preset. */
+    method?: RpcMethodOptions
+    capacity?: number
+    rateLimit?: number
+    strideSize?: number
+    strideConcurrency?: number
+}
+
+/**
+ * A JSON-RPC data source builder — the same fluent shape as {@link EvmPortalDataSourceBuilder}, but
+ * backed by a JSON-RPC endpoint (with an optional per-network preset and overrides). Use it two ways:
+ *
+ * - **Standalone**: `new EvmRpcDataSourceBuilder().setRpc({url, network}).setFields(…).addLog(…).build()`
+ *   returns an `EVMDataSource<F>`.
+ * - **As a fallback downstream**: pass it (with connection config only — `setRpc`/`setName`) to
+ *   {@link EvmFallbackDataSourceBuilder.setDownstreamSources}; the fallback supplies the shared
+ *   query. Setting a query here *and* using it in a fallback throws at `build()` time.
+ *
+ * The `@subsquid/evm-rpc` stack is loaded lazily, only when the source is built.
+ */
+export class EvmRpcDataSourceBuilder<F extends FieldSelection = {}>
+    extends EvmQueryBuilder
+    implements EvmDownstreamSourceBuilder
+{
+    readonly defaultName = 'rpc'
+    name?: string
+    private options?: EvmRpcSourceOptions
+
+    /** Optional explicit name for this source in metrics/logs (default `rpc-<index>`). */
+    setName(name: string): this {
+        this.name = name
+        return this
+    }
+
+    /**
+     * Configure the JSON-RPC data source — a bare endpoint URL, or {@link EvmRpcSourceOptions} for a
+     * per-network preset, method/validation overrides, and connection tuning.
+     *
+     * @example
+     * new EvmRpcDataSourceBuilder().setRpc({url: 'https://rpc...', network: 'ethereum-mainnet'})
+     */
+    setRpc(options: string | EvmRpcSourceOptions): this {
+        this.options = typeof options === 'string' ? {url: options} : options
+        return this
+    }
+
+    /** Configure the set of fetched fields — infers the block type `F` for standalone `build()`. */
+    setFields<T extends FieldSelection>(fields: T): EvmRpcDataSourceBuilder<T> {
+        this.fields = fields
+        return this as unknown as EvmRpcDataSourceBuilder<T>
+    }
+
+    /** Build a standalone RPC data source from this builder's own field selection + query. */
+    build(): EVMDataSource<F> {
+        return this.toSource(this.fields as F, this.getRequests())
+    }
+
+    buildSource<G extends FieldSelection>(fields: G, requests: RangeRequestList<DataRequest>): EVMDataSource<G> {
+        assert(!this.hasOwnQuery(), OWN_QUERY_IN_FALLBACK)
+        return this.toSource(fields, requests)
+    }
+
+    private toSource<G extends FieldSelection>(fields: G, requests: RangeRequestList<DataRequest>): EVMDataSource<G> {
+        assert(this.options, 'RPC endpoint not set — call setRpc(...) on the rpc source')
+        // Lazy: this is the only point that touches the optional @subsquid/evm-rpc peer.
+        return loadRpcStream().evmRpcStream({...this.options, fields, requests})
+    }
+}
+
+/**
+ * Fluent builder for an EVM fallback data source, shaped like `@subsquid/evm-stream`'s
+ * `DataSourceBuilder`: define the field selection + query **once** here (`setFields`, `addLog`, …),
+ * list the ordered downstream sources (Portal and/or RPC) via {@link setDownstreamSources}, and
+ * `build()` a `FallbackDataSource<Block<F>>` — a drop-in for a single `EVMDataSource<F>`.
+ *
+ * Each downstream is an {@link EvmPortalDataSourceBuilder} / {@link EvmRpcDataSourceBuilder} carrying
+ * **connection config only**; the query defined here is injected into every one, so they all fetch
+ * identical data. A downstream that sets its own query (rather than being used standalone) throws.
+ *
+ * @example
+ * const source = new EvmFallbackDataSourceBuilder()
+ *     .setDownstreamSources([
+ *         new EvmPortalDataSourceBuilder().setPortal('https://portal.sqd.dev/datasets/ethereum-mainnet'),
+ *         new EvmRpcDataSourceBuilder().setRpc({url: RPC_URL, network: 'ethereum-mainnet'}),
+ *     ])
+ *     .setFields({log: {topics: true, data: true}})
+ *     .addLog({where: {address: [CONTRACT], topic0: [TRANSFER]}, range: {from: 10_000_000}})
+ *     .build()
+ */
+export class EvmFallbackDataSourceBuilder<F extends FieldSelection = {}> extends EvmQueryBuilder {
+    private downstream: EvmDownstreamSourceBuilder[] = []
+    private policy?: FallbackPolicy
+    private capabilityProbe: boolean | CapabilityProbeOptions = true
+
+    /** Ordered downstream sources, most-preferred first. The fallback drives the first healthy one. */
+    setDownstreamSources(sources: EvmDownstreamSourceBuilder[]): this {
+        this.downstream = sources
+        return this
+    }
+
+    /** Failover/switch-up policy (lag/staleness thresholds, cooldowns, …). Defaults are sensible. */
+    setPolicy(policy: FallbackPolicy): this {
+        this.policy = policy
+        return this
+    }
+
+    /**
+     * Attach a generic capability probe to every source (default `true`): a source counts as
+     * `healthy` only once it confirms it can serve the configured data at the indexing frontier —
+     * catching a reachable-but-incapable node (trace/`debug_` disabled, pruned state) before a
+     * switch-up promotes it. Pass `false` to govern health by liveness alone, or `{timeoutMs}` to
+     * tune the probe.
+     */
+    setCapabilityProbe(probe: boolean | CapabilityProbeOptions): this {
+        this.capabilityProbe = probe
+        return this
+    }
+
+    /** Configure the set of fetched fields — infers the block type `F` for `build()`. */
+    setFields<T extends FieldSelection>(fields: T): EvmFallbackDataSourceBuilder<T> {
+        this.fields = fields
+        return this as unknown as EvmFallbackDataSourceBuilder<T>
+    }
+
     /** Build the fallback data source. Requires at least one downstream source. */
     build(): FallbackDataSource<Block<F>> {
         assert(this.downstream.length > 0, 'No downstream sources — call setDownstreamSources([...])')
 
-        let fields = (this.fields ?? {}) as F
+        let fields = this.fields as F
         let requests = this.getRequests()
 
         let ranked: RankedSource<Block<F>>[] = this.downstream.map((d, i) => {


### PR DESCRIPTION
## What

Makes `EvmPortalDataSourceBuilder` and `EvmRpcDataSourceBuilder` **full standalone data-source builders** — the familiar `DataSourceBuilder` shape (`setFields`/`addLog`/… + `.build()`) — while keeping the fallback's "define the query once" guarantee.

Previously they were minimal connection-only configs: they couldn't build a source on their own, and weren't reusable outside a fallback. Now the same builder works both ways:

```ts
// Standalone — returns an EVMDataSource<F>, exactly like DataSourceBuilder.build()
const rpcSource = new EvmRpcDataSourceBuilder()
    .setRpc({url: RPC_URL, network: 'ethereum-mainnet'})
    .setFields({log: {topics: true, data: true}})
    .addLog({where: {address: [CONTRACT], topic0: [TRANSFER]}, range: {from: 10_000_000}})
    .build()

// In a fallback — connection config only; the fallback injects the shared query
const fb = new EvmFallbackDataSourceBuilder()
    .setDownstreamSources([
        new EvmPortalDataSourceBuilder().setPortal(PORTAL_URL),
        new EvmRpcDataSourceBuilder().setRpc({url: RPC_URL, network: 'ethereum-mainnet'}),
    ])
    .setFields({log: {topics: true, data: true}})
    .addLog({where: {address: [CONTRACT], topic0: [TRANSFER]}, range: {from: 10_000_000}})
    .build()
```

## Design: "standalone builders, query injected"

The core fallback invariant is that every source fetches **identical** data. This PR keeps that but relocates the guard from compile-time to init-time (a deliberate, chosen trade-off):

- The shared query still lives once on `EvmFallbackDataSourceBuilder` and is injected into each downstream via `buildSource(fields, requests)`.
- A source used in a fallback that **also** sets its own field selection/query is rejected at `build()` time (`hasOwnQuery` guard) — the query must live in exactly one place.

## Structure

- Extract the shared query surface (`setFields`/`addLog`/`addTransaction`/`addTrace`/`addStateDiff`/`addQuery`/`includeAllBlocks`/`setBlockRange` + `getRequests`) into an exported abstract `EvmQueryBuilder` base, reused by all three builders — no duplication.
- Portal builds standalone via the canonical `DataSourceBuilder` (byte-identical output); RPC via `evmRpcStream` (lazy peer load unchanged).

## Testing

- 84 fallback tests pass (added: standalone Portal build, standalone + injected RPC build, conflict-throws).
- The RPC-build unit tests stub the lazy loader — `require('../rpc')` resolves a directory to `lib/index.js` only when compiled, not to the `.ts` source under vitest; the network-gated e2e covers the real RPC stack.
- `tsc --noEmit` + declaration emit clean; type inference verified end-to-end (`block.logs[0].topics: string[]`, `block.transactions[0].gasUsed: bigint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)