### PR TITLE
feat: auto-wire fallback source metrics into the processor

### DIFF
--- a/common/changes/@subsquid/batch-processor/auto-register-datasource-metrics_2026-07-17-00-00.json
+++ b/common/changes/@subsquid/batch-processor/auto-register-datasource-metrics_2026-07-17-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/batch-processor",
+      "comment": "feat(run): auto-register a data source's own Prometheus metrics. If the source exposes an optional `getMetricsSink(): MetricsSink` (duck-typed, so the minimal DataSource interface keeps no prom-client dependency), `run()` adds it to the metrics server alongside the runner metrics — so source-provided gauges (e.g. a fallback source's `sqd_fallback_*`) appear on `/metrics` with no manual `addMetricsSink` wiring.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/batch-processor"
+}

--- a/common/changes/@subsquid/squid-sdk/fallback-metrics-auto-wired_2026-07-17-00-00.json
+++ b/common/changes/@subsquid/squid-sdk/fallback-metrics-auto-wired_2026-07-17-00-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/squid-sdk",
+      "comment": "feat(fallback): FallbackDataSource now exposes `getMetricsSink()`, so a fallback source passed to the batch-processor's `run()` gets its `sqd_fallback_*` gauges registered on `/metrics` automatically — no manual `addMetricsSink(fallbackMetricsSink(src))` needed. `fallbackMetricsSink` is now idempotent per registry, so a leftover manual registration alongside the automatic one no longer throws on duplicate gauge names.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/squid-sdk"
+}

--- a/meta/squid-sdk/README.md
+++ b/meta/squid-sdk/README.md
@@ -91,6 +91,23 @@ const rpcSource = new EvmRpcDataSourceBuilder()
     .build()
 ```
 
+## Fallback metrics
+
+When a fallback source is run through the processor (`run(src, db, handler, {prometheus})` from
+`@subsquid/batch-processor`), its `sqd_fallback_*` gauges are registered on the processor's `/metrics`
+**automatically** — no manual wiring. The exported series:
+
+- `sqd_fallback_active{source}` — 1 for the active source, 0 for standbys.
+- `sqd_fallback_source_health{source,state,check,reason,code}` — trinary per-source health; the
+  `unhealthy` row carries the cause as `check`/`reason`/`code` labels.
+- `sqd_fallback_lag_blocks`, `sqd_fallback_staleness_ms`, `sqd_fallback_chain_stalled`,
+  `sqd_fallback_switches` — fallback-wide gauges.
+
+`run()` picks these up because the built source exposes `getMetricsSink()`. To export them onto a
+different registry, or under a custom prefix, the sink is also available directly:
+`fallbackMetricsSink(source, prefix?)` from `@subsquid/squid-sdk/fallback` (idempotent per registry,
+so adding it manually alongside the automatic registration is safe).
+
 ## Optional EVM peers
 
 The `fallback` supervisor is VM-agnostic and pulls no EVM code. The EVM RPC source (`evm/rpc`) and

--- a/meta/squid-sdk/src/evm/fallback/builder.test.ts
+++ b/meta/squid-sdk/src/evm/fallback/builder.test.ts
@@ -1,4 +1,5 @@
 import type {EVMDataSource} from '@subsquid/evm-stream'
+import {Registry} from 'prom-client'
 import {describe, expect, it, vi} from 'vitest'
 
 import {FallbackDataSource} from '../../fallback/fallback'
@@ -126,6 +127,18 @@ describe('EvmFallbackDataSourceBuilder', () => {
         // Not exempt: the custom source receives the same shared field selection + query as the rest.
         expect(seen?.fields).toEqual({log: {topics: true}})
         expect(seen?.requests[0].request.logs).toEqual([{where: {address: ['0xabc']}}])
+    })
+
+    it('exposes a metrics sink so the batch-processor auto-registers sqd_fallback_* gauges', async () => {
+        const fb = new EvmFallbackDataSourceBuilder()
+            .setDownstreamSources([{type: 'rpc', url: 'https://a.example', name: 'primary'}])
+            .setCapabilityProbe(false)
+            .build()
+
+        // This is the hook `run()` duck-types (`getMetricsSink()`); registering it must populate the gauges.
+        let registry = new Registry()
+        fb.getMetricsSink().register(registry)
+        expect(await registry.metrics()).toContain('sqd_fallback_active{source="primary"}')
     })
 
     it('throws an actionable error when a portal/rpc source is missing its url at runtime', () => {

--- a/meta/squid-sdk/src/fallback/fallback.ts
+++ b/meta/squid-sdk/src/fallback/fallback.ts
@@ -1,11 +1,13 @@
 import {Logger, createLogger} from '@subsquid/logger'
 import {BlockBatch, BlockRef, BlockStream, DataSource, StreamRequest, isForkException} from '@subsquid/util-internal-data-source'
+import type {MetricsSink} from '@subsquid/util-internal-processor-tools'
 import {FiniteRange} from '@subsquid/util-internal-range'
 
 import {safeReturn, withTimeout} from './async'
 import {ProbeResult} from './capability'
 import {SourceErrorInfo, capabilityFailure, classifyError, freshnessFailure} from './diagnostics'
 import {SourceHealth} from './health'
+import {fallbackMetricsSink} from './metrics'
 import {AllSourcesDownError, FallbackPolicy, Health, ResolvedPolicy, resolvePolicy} from './policy'
 import {Selector} from './selector'
 
@@ -261,6 +263,15 @@ export class FallbackDataSource<B> implements DataSource<B> {
         }
 
         return 0
+    }
+
+    /**
+     * A Prometheus sink exporting this fallback's observable state (`sqd_fallback_*` gauges). The
+     * batch-processor's `run()` calls this automatically when the source is passed to it, so the
+     * gauges appear on the processor's `/metrics` with no manual `addMetricsSink` wiring.
+     */
+    getMetricsSink(): MetricsSink {
+        return fallbackMetricsSink(this)
     }
 
     /** Snapshot of the observable state for export to a metrics surface. */

--- a/meta/squid-sdk/src/fallback/metrics.test.ts
+++ b/meta/squid-sdk/src/fallback/metrics.test.ts
@@ -43,4 +43,21 @@ describe('fallbackMetricsSink', () => {
         expect(text).toContain('sqd_fallback_chain_stalled 1')
         expect(text).toContain('sqd_fallback_switches 2')
     })
+
+    it('is idempotent on a registry — registering the same source twice does not throw or duplicate', async () => {
+        let registry = new Registry()
+        let src = {metrics: () => snapshot}
+        // The batch-processor auto-registers plus a leftover manual add would both hit the same registry.
+        fallbackMetricsSink(src).register(registry)
+        expect(() => fallbackMetricsSink(src).register(registry)).not.toThrow()
+
+        let text = await registry.metrics()
+        expect(text.match(/sqd_fallback_switches 2/g)).toHaveLength(1)
+    })
+
+    it('honours a custom prefix', async () => {
+        let registry = new Registry()
+        fallbackMetricsSink({metrics: () => snapshot}, 'myapp_fb').register(registry)
+        expect(await registry.metrics()).toContain('myapp_fb_switches 2')
+    })
 })

--- a/meta/squid-sdk/src/fallback/metrics.ts
+++ b/meta/squid-sdk/src/fallback/metrics.ts
@@ -24,9 +24,12 @@ const HEALTH_STATES = ['healthy', 'unhealthy', 'unknown'] as const
 export function fallbackMetricsSink(source: FallbackMetricsSource, prefix = 'sqd_fallback'): MetricsSink {
     return {
         register(registry: Registry) {
-            // Idempotent: the batch-processor auto-registers this sink, so a leftover manual
-            // `addMetricsSink(fallbackMetricsSink(src))` would otherwise double-register and prom-client
-            // would throw on the duplicate gauge name. Registering the same source twice is a no-op.
+            // Idempotent per (registry, prefix): if these gauges are already registered, skip, so the
+            // batch-processor's automatic registration coexists with a leftover manual
+            // `addMetricsSink(fallbackMetricsSink(src))` without prom-client throwing on a duplicate gauge
+            // name. Note this keys on the prefix, not the source: two *distinct* fallback sources sharing
+            // one registry must use different prefixes — the fallback-wide gauges (lag/staleness/switches)
+            // have no `source` label to separate them — else this would silently no-op the second.
             if (registry.getSingleMetric(`${prefix}_active`)) return
 
             new Gauge({

--- a/meta/squid-sdk/src/fallback/metrics.ts
+++ b/meta/squid-sdk/src/fallback/metrics.ts
@@ -1,7 +1,7 @@
 import type {MetricsSink} from '@subsquid/util-internal-processor-tools'
 import {Gauge, Registry} from 'prom-client'
 
-import {FallbackMetrics} from './fallback'
+import type {FallbackMetrics} from './fallback'
 
 export interface FallbackMetricsSource {
     metrics(): FallbackMetrics
@@ -24,6 +24,11 @@ const HEALTH_STATES = ['healthy', 'unhealthy', 'unknown'] as const
 export function fallbackMetricsSink(source: FallbackMetricsSource, prefix = 'sqd_fallback'): MetricsSink {
     return {
         register(registry: Registry) {
+            // Idempotent: the batch-processor auto-registers this sink, so a leftover manual
+            // `addMetricsSink(fallbackMetricsSink(src))` would otherwise double-register and prom-client
+            // would throw on the duplicate gauge name. Registering the same source twice is a no-op.
+            if (registry.getSingleMetric(`${prefix}_active`)) return
+
             new Gauge({
                 name: `${prefix}_active`,
                 help: 'Currently active fallback source (1 = active, 0 = standby)',

--- a/meta/squid-sdk/src/fallback/metrics.ts
+++ b/meta/squid-sdk/src/fallback/metrics.ts
@@ -24,13 +24,14 @@ const HEALTH_STATES = ['healthy', 'unhealthy', 'unknown'] as const
 export function fallbackMetricsSink(source: FallbackMetricsSource, prefix = 'sqd_fallback'): MetricsSink {
     return {
         register(registry: Registry) {
-            // Idempotent per (registry, prefix): if these gauges are already registered, skip, so the
+            // Idempotent per (registry, prefix): if this gauge set is already registered, skip, so the
             // batch-processor's automatic registration coexists with a leftover manual
             // `addMetricsSink(fallbackMetricsSink(src))` without prom-client throwing on a duplicate gauge
-            // name. Note this keys on the prefix, not the source: two *distinct* fallback sources sharing
-            // one registry must use different prefixes — the fallback-wide gauges (lag/staleness/switches)
-            // have no `source` label to separate them — else this would silently no-op the second.
-            if (registry.getSingleMetric(`${prefix}_active`)) return
+            // name. Keyed on the *last*-registered gauge (`_switches`) so a registration that failed partway
+            // (a name collision on a later gauge) is not mistaken for a complete one. Note it keys on the
+            // prefix, not the source: two distinct fallback sources sharing one registry need different
+            // prefixes (the fallback-wide gauges have no `source` label), else the second would no-op.
+            if (registry.getSingleMetric(`${prefix}_switches`)) return
 
             new Gauge({
                 name: `${prefix}_active`,

--- a/processor/batch-processor/src/run.ts
+++ b/processor/batch-processor/src/run.ts
@@ -35,7 +35,7 @@ interface MetricsSource {
 }
 
 function hasMetricsSink(src: unknown): src is MetricsSource {
-    return typeof (src as Partial<MetricsSource>).getMetricsSink === 'function'
+    return src != null && typeof (src as Partial<MetricsSource>).getMetricsSink === 'function'
 }
 
 /**

--- a/processor/batch-processor/src/run.ts
+++ b/processor/batch-processor/src/run.ts
@@ -3,7 +3,7 @@ import {last, maybeLast, runProgram, Throttler} from '@subsquid/util-internal'
 import {Database, DatabaseTransactResult, FinalDatabaseState, HashAndHeight, HotDatabaseState} from './database'
 import {DataSource, isForkException, BlockRef, type BlockBatch} from '@subsquid/util-internal-data-source'
 import assert from 'assert'
-import {PrometheusServer, RunnerMetrics} from '@subsquid/util-internal-processor-tools'
+import {MetricsSink, PrometheusServer, RunnerMetrics} from '@subsquid/util-internal-processor-tools'
 import {formatHead, getItemsCount} from './util'
 
 export {PrometheusServer}
@@ -22,6 +22,20 @@ export interface BlockBase {
 
 export interface RunOptions {
     prometheus?: PrometheusServer
+}
+
+/**
+ * Optional capability: a data source that exposes its own Prometheus metrics. When present, `run()`
+ * registers the returned sink on the metrics server automatically, so a source's gauges (e.g. a
+ * fallback source's `sqd_fallback_*`) appear on `/metrics` with no manual wiring. Duck-typed here
+ * rather than added to the `DataSource` interface, which must not depend on prom-client.
+ */
+interface MetricsSource {
+    getMetricsSink(): MetricsSink
+}
+
+function hasMetricsSink(src: unknown): src is MetricsSource {
+    return typeof (src as Partial<MetricsSource>).getMetricsSink === 'function'
 }
 
 /**
@@ -160,6 +174,10 @@ export class Processor<B extends BlockBase, S> {
         if (prometheusServer == null) return
 
         prometheusServer.addRunnerMetrics(this.metrics)
+        // Auto-register the data source's own metrics (e.g. a fallback source's `sqd_fallback_*`).
+        if (hasMetricsSink(this.src)) {
+            prometheusServer.addMetricsSink(this.src.getMetricsSink())
+        }
         let listening = await prometheusServer.serve()
         log.info(`prometheus metrics are served on port ${listening.port}`)
     }

--- a/processor/batch-processor/src/run.ts
+++ b/processor/batch-processor/src/run.ts
@@ -3,7 +3,7 @@ import {last, maybeLast, runProgram, Throttler} from '@subsquid/util-internal'
 import {Database, DatabaseTransactResult, FinalDatabaseState, HashAndHeight, HotDatabaseState} from './database'
 import {DataSource, isForkException, BlockRef, type BlockBatch} from '@subsquid/util-internal-data-source'
 import assert from 'assert'
-import {MetricsSink, PrometheusServer, RunnerMetrics} from '@subsquid/util-internal-processor-tools'
+import {type MetricsSink, PrometheusServer, RunnerMetrics} from '@subsquid/util-internal-processor-tools'
 import {formatHead, getItemsCount} from './util'
 
 export {PrometheusServer}


### PR DESCRIPTION
## What

A `FallbackDataSource` already exports its observable state as `sqd_fallback_*` Prometheus gauges via `fallbackMetricsSink`, but **nothing registered the sink** — users had to call `addMetricsSink(fallbackMetricsSink(src))` by hand, so the gauges never appeared on `/metrics`. This wires them up by default.

## How

- **`@subsquid/batch-processor` `run()`** — if the data source exposes an optional `getMetricsSink(): MetricsSink`, register it on the metrics server next to the runner metrics. The capability is **duck-typed** (a local interface + `typeof … === 'function'` guard) rather than added to the `DataSource` interface, so the minimal `util-internal-data-source` package keeps no `prom-client` dependency. Additive — sources without the method are unaffected.
- **`@subsquid/squid-sdk`** — `FallbackDataSource.getMetricsSink()` returns `fallbackMetricsSink(this)`, so the `sqd_fallback_*` gauges are auto-registered whenever the source is passed to `run()`. No manual wiring.
- **Idempotency** — `fallbackMetricsSink().register()` no-ops if the gauges are already on the registry, so a leftover manual `addMetricsSink` alongside the automatic registration no longer throws on a duplicate gauge name.
- **README** — documents the automatic metrics and the direct `fallbackMetricsSink(source, prefix?)` sink for a custom registry/prefix.

Static import of `./metrics` (not a lazy `require`): `prom-client` is a direct dependency the processor's `PrometheusServer` always loads anyway — lazy-loading is reserved for the *optional* peers (`evm-rpc`). `metrics.ts`'s `FallbackMetrics` import is `import type`, so the module graph stays acyclic.

## Testing

- squid-sdk 147 pass — new: idempotent double-register, custom prefix, and `FallbackDataSource.getMetricsSink()` populating `sqd_fallback_active{source}`.
- batch-processor 22 pass; `tsc --noEmit` clean in both packages; `rush change --verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
