### PR TITLE
fix(evm-rpc): tolerate per-tx null trace/stateDiff in trace_replayBlockTransactions

### DIFF
--- a/common/changes/@subsquid/evm-rpc/alert-fix-dHLYGb-gnosis-statediff-null_2026-07-22-06-42.json
+++ b/common/changes/@subsquid/evm-rpc/alert-fix-dHLYGb-gnosis-statediff-null_2026-07-22-06-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "tolerate per-tx null trace/stateDiff from trace_replayBlockTransactions and flag the block for retry instead of crashing ingestion",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-rpc/src/rpc-data.ts
+++ b/evm/evm-rpc/src/rpc-data.ts
@@ -674,8 +674,10 @@ export function getTraceTransactionReplayValidator(tracers: TraceReplayTraces): 
     return object({
         transactionHash: option(BYTES),
         ...project(tracers, {
-            trace: array(TraceFrame),
-            stateDiff: record(BYTES, TraceStateDiff)
+            // Nullable: a provider may return null for an individual tx's trace or
+            // stateDiff. Tolerated here and flagged for retry in addTraceTxReplays.
+            trace: nullable(array(TraceFrame)),
+            stateDiff: nullable(record(BYTES, TraceStateDiff))
         })
     }) as unknown as Validator<TraceTransactionReplay>
 }

--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -1177,6 +1177,14 @@ export class Rpc {
             let txs = new Set(block.block.transactions.map(getTxHash))
 
             for (let rep of replays) {
+                // A provider may return null for an individual tx's trace or
+                // stateDiff. Flag the block for retry instead of crashing ingestion.
+                if ((traces.trace && rep.trace == null) || (traces.stateDiff && rep.stateDiff == null)) {
+                    block._isInvalid = true
+                    block._errorMessage = 'missing trace or stateDiff for some transactions'
+                    break
+                }
+
                 if (!rep.transactionHash) {
                     let txHash: Bytes32 | null | undefined = undefined
                     for (let frame of rep.trace || []) {
@@ -1192,6 +1200,7 @@ export class Rpc {
                     block._errorMessage = 'trace_replayBlockTransactions returned a trace of a different block'
                 }
             }
+            if (block._isInvalid) continue
 
             block.traceReplays = replays
         }

--- a/evm/evm-rpc/test/trace-replay-null.test.ts
+++ b/evm/evm-rpc/test/trace-replay-null.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { array } from '@subsquid/util-internal-validation'
+import { getTraceTransactionReplayValidator } from '../src/rpc-data'
+
+// Regression for a dump crash-loop: some providers return `stateDiff: null`
+// (or `trace: null`) for an individual transaction inside an otherwise valid
+// `trace_replayBlockTransactions` 200 response. Before the fix the per-tx
+// validator required a non-null object and threw a fatal DataValidationError
+// ("invalid value at /0/stateDiff: null is not an object"), crashing ingestion.
+describe('trace_replayBlockTransactions per-tx null tolerance', () => {
+    it('accepts a per-tx null stateDiff when stateDiff is requested', () => {
+        const validator = array(getTraceTransactionReplayValidator({ trace: true, stateDiff: true }))
+        const response = [
+            {
+                transactionHash: '0x' + 'ab'.repeat(32),
+                trace: [],
+                stateDiff: null,
+            },
+        ]
+        expect(validator.validate(response)).toBeUndefined()
+    })
+
+    it('accepts a per-tx null trace when trace is requested', () => {
+        const validator = array(getTraceTransactionReplayValidator({ trace: true, stateDiff: true }))
+        const response = [
+            {
+                transactionHash: '0x' + 'cd'.repeat(32),
+                trace: null,
+                stateDiff: {},
+            },
+        ]
+        expect(validator.validate(response)).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Problem

The `evm-dump` for gnosis-mainnet is stuck in a fatal crash-loop:

```
DataValidationError: server returned unexpected result: invalid value at /0/stateDiff: null is not an object
  at evm/evm-rpc/lib/rpc.js  (getResultValidator for trace_replayBlockTransactions)
  rpcMethod: trace_replayBlockTransactions   params: [<hash>, ["trace","stateDiff"]]
```

The upstream provider returns a valid HTTP 200 for `trace_replayBlockTransactions`, but with `stateDiff: null` for an individual transaction (verified: the same gnosis block returns a proper `stateDiff` object from two other providers, so the `null` is a provider-side defect, not inherent to the chain). Because `getTraceTransactionReplayValidator` requires `stateDiff` (and `trace`) to be a **non-null** object when the tracer is requested, validation throws a fatal `DataValidationError` and the whole ingestion process crashes and crash-loops — a single provider hiccup takes down the dump.

`#497` already added tolerance for a **block-level** `null` (whole array). This extends the same treatment to the **per-transaction** case it missed (`/0/stateDiff`).

## Fix

- `getTraceTransactionReplayValidator`: make the per-tx `trace` and `stateDiff` fields **nullable**, so a transient `null` no longer fatally fails schema validation.
- `addTraceTxReplays`: when a requested tracer is `null` for any tx, flag the block `_isInvalid` for retry (mirroring the block-level `null` path from #497 and the `debug_*` `_isInvalid` guards) instead of letting corrupt data through.

This makes the process **survive** a genuinely-external malformed response and retry the block, rather than crash-looping. (Complementary operator action — routing gnosis trace/stateDiff traffic away from the degraded provider — is being handled separately in ops; that only removes today's trigger, whereas this stops any provider hiccup from crash-looping ingestion.)

## Test

`evm/evm-rpc/test/trace-replay-null.test.ts` — asserts the validator accepts a per-tx `null` stateDiff/trace. Fails on the pre-fix code (`"... null is not an object"`), passes after.

- `rush build -t @subsquid/evm-rpc` — green (compiles)
- `vitest --run` (evm-rpc) — 172 passed / 28 skipped, incl. the 2 new
- `tsc --noEmit -p tsconfig.test.json` — clean

Falsification: if a provider persistently returns `null` for a block, `_isInvalid` retries 5× then throws (same as every other invalid-block path) — the durable resolution to a persistently-degraded provider is the routing change, not this PR; this PR ensures a *transient* null can no longer crash ingestion.
