### PR TITLE
fix(util-internal): don't wedge ingest head-polling on a hung finalized/head fetch

### DIFF
--- a/common/changes/@subsquid/util-internal/alert-fix-UJZrJ3-throttler-head-wedge_2026-07-22-18-11.json
+++ b/common/changes/@subsquid/util-internal/alert-fix-UJZrJ3-throttler-head-wedge_2026-07-22-18-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/util-internal",
+      "comment": "Throttler: with prefetch enabled, serve the cached value instead of blocking on an in-flight refresh, so a hung head/finalized fetch can no longer wedge ingest head-polling loops",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/util-internal"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -339,7 +339,7 @@ importers:
         version: file:projects/types-test.tgz
       '@rush-temp/util-internal':
         specifier: file:./projects/util-internal.tgz
-        version: file:projects/util-internal.tgz
+        version: file:projects/util-internal.tgz(esbuild@0.27.7)(tsx@4.21.0)
       '@rush-temp/util-internal-archive-client':
         specifier: file:./projects/util-internal-archive-client.tgz
         version: file:projects/util-internal-archive-client.tgz
@@ -1406,7 +1406,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/erc20-transfers@file:projects/erc20-transfers.tgz':
-    resolution: {integrity: sha512-a0NVshKVkYr7K4Y1qIl3JBdlGJBmYAk3Cu6Crp4QY9G9vVt0x/E7wqUROArvAo//6PIHge9puyrS/iD5TDLJKA==, tarball: file:projects/erc20-transfers.tgz}
+    resolution: {integrity: sha512-5agkTAoEOVDkvQ53tJQNR6/cp2Wc8jb+OrKQYtVicfiq2Qk61vsliFkcZxEOOlvgAhI9TG1wgQkC2hXM5OBQPQ==, tarball: file:projects/erc20-transfers.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-abi@file:projects/evm-abi.tgz':
@@ -1586,7 +1586,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/solana-example@file:projects/solana-example.tgz':
-    resolution: {integrity: sha512-TCMmjScRrcc98mNzZjuccEbMeAnZDGBPZWFRQdV8d7EI77Zkw7fHa/LVO+h3rhqgDwaHvRzxPCtrB/n9DHjCKw==, tarball: file:projects/solana-example.tgz}
+    resolution: {integrity: sha512-rxhzgY1yCIzDuS5th7F5naZXFCGbMzST1757ZzzOuMIMcjoIXSR/Y9BW4Yw3/yTLFofaiOrzGJSL2Vh3itAfrA==, tarball: file:projects/solana-example.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-ingest@file:projects/solana-ingest.tgz':
@@ -1622,7 +1622,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/squid-sdk@file:projects/squid-sdk.tgz':
-    resolution: {integrity: sha512-lHjSptBD+Brxc2MGsdpgD6ss+xxQMOCXC35LR7g+3w3bXHz1MMUQwdbE7MLdI4fbIm8h17bIHfJdytir4HLgCg==, tarball: file:projects/squid-sdk.tgz}
+    resolution: {integrity: sha512-fvCSmBgnZcJV3cx/XUmT9NbgYoe51e6mgvyUuGHpQYY8IKptS1GS/NaSS+UeHyRN+ts1ASvrOPb9xAFga5oXrA==, tarball: file:projects/squid-sdk.tgz}
     version: 0.0.0
 
   '@rush-temp/ss58-codec@file:projects/ss58-codec.tgz':
@@ -1842,7 +1842,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/util-internal@file:projects/util-internal.tgz':
-    resolution: {integrity: sha512-a4u6NJ4ZvTAYIzGdRKR7+IBEzY/EQsqAsHE5iabQw2uDp12WFQJ2q7ExjcOCjHTRW7mLii/uNV8CJrBOSI9dUQ==, tarball: file:projects/util-internal.tgz}
+    resolution: {integrity: sha512-8vPykKIwnW0ZGAHBWAr5jVV2AByw3jOGjQ3nqWbpGnQp+qds0Na2f3/s925myv3ujjK6Ntvn1etwd7Sb7Jk2Xg==, tarball: file:projects/util-internal.tgz}
     version: 0.0.0
 
   '@rush-temp/util-naming@file:projects/util-naming.tgz':
@@ -7425,10 +7425,34 @@ snapshots:
       '@types/node': 24.0.15
       typescript: 5.5.4
 
-  '@rush-temp/util-internal@file:projects/util-internal.tgz':
+  '@rush-temp/util-internal@file:projects/util-internal.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:
       '@types/node': 24.0.15
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@rush-temp/util-naming@file:projects/util-naming.tgz':
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6a1b46ab1f965b3e9a73a34f938651a841ba1462"
+  "pnpmShrinkwrapHash": "5401e6dfd188d2a0dde74da9996c088f4d41384f"
 }

--- a/util/util-internal/package.json
+++ b/util/util-internal/package.json
@@ -13,10 +13,12 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/util/util-internal/src/throttler.test.ts
+++ b/util/util-internal/src/throttler.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest'
+import {Throttler} from './throttler'
+
+
+function deferred<T>(): {promise: Promise<T>; resolve: (v: T) => void} {
+    let resolve!: (v: T) => void
+    let promise = new Promise<T>((res) => {
+        resolve = res
+    })
+    return {promise, resolve}
+}
+
+function timeout<T>(ms: number, value: T): Promise<T> {
+    return new Promise((res) => setTimeout(() => res(value), ms))
+}
+
+describe('Throttler', () => {
+    it('serves the cached value while a refresh is in flight (prefetch)', async () => {
+        let calls = 0
+        let hang = deferred<number>()
+        let fn = () => {
+            calls += 1
+            // first fetch succeeds, every subsequent (background) refresh hangs forever
+            return calls === 1 ? Promise.resolve(1) : hang.promise
+        }
+        let throttler = new Throttler(fn, 20).enablePrefetch()
+
+        // first read must await the initial fetch
+        expect(await throttler.get()).toBe(1)
+
+        // let the cached value go stale so a refresh is due; the prefetch refresh now hangs
+        await timeout(60, undefined)
+
+        // get() must return the last known value promptly and NOT block on the hung refresh.
+        // Pre-fix this returned the in-flight (hung) promise and never resolved.
+        let result = await Promise.race([throttler.get(), timeout(300, 'HUNG' as const)])
+        expect(result).toBe(1)
+    })
+
+    it('blocks the very first get() until the initial value is available', async () => {
+        let gate = deferred<number>()
+        let throttler = new Throttler(() => gate.promise, 20).enablePrefetch()
+
+        let race = Promise.race([throttler.get(), timeout(50, 'PENDING' as const)])
+        expect(await race).toBe('PENDING')
+
+        gate.resolve(7)
+        expect(await throttler.get()).toBe(7)
+    })
+
+    it('non-prefetch throttler awaits a fresh value when stale', async () => {
+        let values = [1, 2]
+        let i = 0
+        let throttler = new Throttler(() => Promise.resolve(values[i++]), 20)
+
+        expect(await throttler.get()).toBe(1)
+        await timeout(40, undefined)
+        expect(await throttler.get()).toBe(2)
+    })
+})

--- a/util/util-internal/src/throttler.ts
+++ b/util/util-internal/src/throttler.ts
@@ -32,9 +32,11 @@ export class Throttler<T> {
         let now = Date.now()
         if (now - this.lastAccess < this.interval) {
             return this.lastValue
-        } else {
-            return this.performCall(0)
         }
+        let pending = this.performCall(0)
+        // A prefetching throttler must not block callers on an in-flight refresh once a value
+        // exists — return the last value and let a slow/hung refresh settle in the background.
+        return this.prefetch && this.lastAccess > -Infinity ? this.lastValue : pending
     }
 
     private performCall(pause: number): Promise<T> {


### PR DESCRIPTION
## Cause (proven)

Both `zora-mainnet` EVM hotblocks pods (dwellir **and** uniblock — two independent providers) went silent at the **identical block 49023729 at 17:28:16Z**, stopped emitting head metrics (firing `Portal_Hotblocks_Head_Metrics_Absent_zora_mainnet`), and did **not** recover even though the chain kept producing blocks (verified block 49024000 exists; providers advanced past the stuck point). No crash/restart — the process was **hung**.

Root cause is in `Throttler` (`util/util-internal/src/throttler.ts`), the shared primitive behind every ingest head-/finalized-head tracker:

```ts
async get(): Promise<T> {
    let now = Date.now()
    if (now - this.lastAccess < this.interval) return this.lastValue
    return this.performCall(0)   // <-- returns the in-flight (hung) promise
}
```

`lastAccess` is updated **only on success** (`execute()`). When the underlying fetch hangs or times out for longer than `interval`, the next `get()` falls through and returns the still-pending refresh promise. In `evm-rpc/src/data-source/ingest.ts` the hot loop does `await finalizedHeadTracker.get()` **before** the head poll (`poll.next()`), so a stalled `eth_getBlockByNumber("finalized")` (the pod logged `HttpTimeoutError: request timed out after 30000 ms` on exactly that call) blocks the whole loop. Because the loop runs in a worker, the main-thread `DataService` `for await` then blocks forever with no further logging — matching the observed permanent silence. `enablePrefetch()` is used by every EVM/Solana/Tron/Bitcoin head/finalized tracker, so this can wedge any of them.

## Fix

Honor the prefetch contract: once a value exists, `get()` returns the last known value immediately and lets the (slow/hung) refresh settle in the background, instead of blocking on it. Head polling proceeds; a stale-but-conservative finalized head is safe (only affects the finalized upper bound, which self-corrects on recovery). The first read still awaits the initial fetch, and non-prefetch throttlers are unchanged.

## Tests (red → green)

`util/util-internal/src/throttler.test.ts` (vitest, newly wired into the package's `test` script):
- **the wedge**: prefetch on, first fetch succeeds, subsequent refresh hangs → `get()` must return the cached value promptly. FAILS pre-fix (returns the hung promise → `'HUNG'`), PASSES post-fix.
- first `get()` blocks until the initial value resolves.
- non-prefetch throttler awaits a fresh value when stale (unchanged behavior).

Verified locally: `rush build --to @subsquid/util-internal` ✅, `rush test --only @subsquid/util-internal` ✅. Confirmed red→green by reverting `get()` to the old body (the wedge test fails with `expected 'HUNG' to be 1`).

## Scope / relation to other PRs

This is the *transient-hang → permanent-wedge* fatality (the process should survive a slow/unresponsive finalized endpoint and keep polling head). Distinct root cause from #513 (retry a transient `invalid block height` **error** on the finalized probe) and #523 (portal-client retries transient **null** heads). Complementary, not a duplicate.

## Falsification

If a hotblocks/dumper pod still goes permanently silent (no logs, no restart) after its finalized/head RPC endpoint hangs — i.e. the head loop stops advancing while the chain keeps producing — this fix is insufficient and the block is elsewhere on the head path.