### PR TITLE
fix(evm-rpc): retry eRPC upstreams-exhausted errors instead of crashing the dumper

### DIFF
--- a/common/changes/@subsquid/evm-rpc/alert-fix-Y4PDnh-linea-erpc-crashloop_2026-07-23-09-05.json
+++ b/common/changes/@subsquid/evm-rpc/alert-fix-Y4PDnh-linea-erpc-crashloop_2026-07-23-09-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "Retry eRPC ErrUpstreamsExhausted / ErrFailsafeRetryExceeded responses instead of crashing on the misnormalized JSON-RPC error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-rpc/src/rpc-client.ts
+++ b/evm/evm-rpc/src/rpc-client.ts
@@ -29,6 +29,9 @@ export class EvmRpcClient extends RpcClient {
             if (this.isRpcRateLimitError(err)) {
                 return true
             }
+            if (this.isErpcUpstreamsExhaustedError(err)) {
+                return true
+            }
             if (this.isRpcInternalError(err)) {
                 return this.retryInternalServerErrors
             }
@@ -39,6 +42,17 @@ export class EvmRpcClient extends RpcClient {
             }
         }
         return false
+    }
+
+    /**
+     * eRPC replies with HTTP 200 + a JSON-RPC error when its whole upstream set
+     * is temporarily unavailable (all providers rate-limited / 5xx). It attaches
+     * a stable `data.code` and can normalize the code to a misleading value
+     * (e.g. -32601), so key off `data.code` and retry like a direct provider 5xx.
+     */
+    isErpcUpstreamsExhaustedError(err: RpcError): boolean {
+        let code = (err.data as any)?.code
+        return code === 'ErrUpstreamsExhausted' || code === 'ErrFailsafeRetryExceeded'
     }
 
     isRpcInternalError(err: RpcError): boolean {

--- a/evm/evm-rpc/test/rpc-client.test.ts
+++ b/evm/evm-rpc/test/rpc-client.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { RpcError } from '@subsquid/rpc-client'
+import { EvmRpcClient } from '../src/rpc-client'
+
+function makeClient() {
+    // HTTP connections are lazy, so no network I/O happens on construction.
+    return new EvmRpcClient({ url: 'http://localhost:8082', log: null })
+}
+
+describe('EvmRpcClient.isConnectionError', () => {
+    it('retries eRPC ErrFailsafeRetryExceeded / ErrUpstreamsExhausted (misnormalized to -32601)', () => {
+        // Shape observed in production: eRPC normalized a transient upstream 503
+        // into a fatal-looking "method not found" while all upstreams were
+        // temporarily exhausted. It must be retried, not crash the dumper.
+        let err = new RpcError({
+            code: -32601,
+            message: 'The method eth_getBlockByNumber does not exist/is not available',
+            data: {
+                code: 'ErrFailsafeRetryExceeded',
+                cause: { code: 'ErrUpstreamsExhausted' },
+            },
+        })
+        expect(makeClient().isConnectionError(err)).toBe(true)
+    })
+
+    it('retries a top-level ErrUpstreamsExhausted (code not otherwise retryable)', () => {
+        // code -32099 is not matched by any other classifier, so retry here is
+        // driven solely by the eRPC data.code — a clean regression discriminator.
+        let err = new RpcError({
+            code: -32099,
+            message: 'all upstream attempts failed',
+            data: { code: 'ErrUpstreamsExhausted' },
+        })
+        expect(makeClient().isConnectionError(err)).toBe(true)
+    })
+
+    it('still treats a genuine method-not-found (no eRPC data) as fatal', () => {
+        let err = new RpcError({
+            code: -32601,
+            message: 'The method eth_getBlockByNumber does not exist/is not available',
+        })
+        expect(makeClient().isConnectionError(err)).toBe(false)
+    })
+})


### PR DESCRIPTION
## Symptom
Alert **linea-mainnet_No_Dumper_Data** (evm-archive, kind=dump). `dump-linea-mainnet-0` is in **CrashLoopBackOff** (140 restarts / 27h); no raw data written.

## Root cause (proven from pod logs)
The linea-mainnet dumper was routed through eRPC on 2026-07-22 (infra commit `248d45930` "Roll out eRPC to almost every archive ingester"; the dump pod's 27h age matches). eRPC's only *primary* upstream for linea is Alchemy, which is currently degraded — live probes return HTTP 503 `-32001 "Unable to complete request at this time"` and 429 "compute units per second exceeded" for linea.

eRPC does not fail over to the healthy dwellir/uniblock fallbacks, and returns the request as an HTTP 200 body carrying a JSON-RPC error whose code is **normalized to `-32601` ("method eth_getBlockByNumber does not exist/is not available")** with `data.code: ErrFailsafeRetryExceeded` → `cause.code: ErrUpstreamsExhausted`.

`EvmRpcClient.isConnectionError` did not recognize this shape, so the error was fatal (dump log level 5) and the process exited:
```
RpcError: The method eth_getBlockByNumber does not exist/is not available
  at EvmRpcClient.receiveResult (/squid/util/rpc-client/lib/client.js:376)
```
Before the eRPC switch the *same* underlying Alchemy 503 arrived as a raw HTTP 503, which the client already retries — so eRPC repackaging it as a fatal JSON-RPC error is what turned a recoverable degradation into a crash-loop.

## Fix
Recognize eRPC's stable `data.code` (`ErrUpstreamsExhausted` / `ErrFailsafeRetryExceeded`) as a **retryable connection error** in `EvmRpcClient.isConnectionError`. This restores parity with a direct provider 5xx: the dumper backs off and retries (retryAttempts=MAX) instead of crash-looping, so a single provider hiccup can no longer take the dump down. A genuine `-32601` with no eRPC `data` stays fatal.

## Test
`evm/evm-rpc/test/rpc-client.test.ts` — asserts the production error shape is retryable and a real method-not-found is not. Red on pre-fix (2 fail), green after.

## Falsification
If the dump still crash-loops after deploying an evm-dump built from this change with the same `-32601`/`ErrUpstreamsExhausted` fatal line, the classifier isn't matching the real payload shape.

## Note (operator action, not in this PR)
This stops the crash-loop but does not by itself restore linea data flow: Alchemy is down for linea while eRPC isn't failing over. An operator should route linea to a healthy provider (dwellir + uniblock both return 200 for linea now) or fix the eRPC failover, and raise the Alchemy linea 503/429 with the provider (https://status.alchemy.com). Provider swaps are an operator mitigation, so they're intentionally not included here.