### PR TITLE
fix(evm-normalization): tolerate SELFDESTRUCT trace frames without `to`

### DIFF
--- a/common/changes/@subsquid/evm-normalization/alert-fix-4mtxPN-selfdestruct-to_2026-07-23-13-16.json
+++ b/common/changes/@subsquid/evm-normalization/alert-fix-4mtxPN-selfdestruct-to_2026-07-23-13-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-normalization",
+      "comment": "Tolerate SELFDESTRUCT debug frames that omit `to` by falling back to the self-destructing account",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-normalization"
+}

--- a/evm/evm-normalization/src/mapping.test.ts
+++ b/evm/evm-normalization/src/mapping.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from 'vitest'
+import {mapRawBlock} from './mapping'
+
+
+// Minimal raw block carrying a single SELFDESTRUCT debug frame. The header/tx
+// fields are only what `mapRawBlock` touches on the trace path.
+function selfdestructBlock(frame: Record<string, unknown>): any {
+    return {
+        number: '0x1',
+        hash: '0xblock',
+        parentHash: '0x0',
+        timestamp: '0x0',
+        transactionsRoot: '0x',
+        receiptsRoot: '0x',
+        stateRoot: '0x',
+        logsBloom: '0x',
+        sha3Uncles: '0x',
+        extraData: '0x',
+        miner: '0x',
+        size: '0x0',
+        gasLimit: '0x0',
+        gasUsed: '0x0',
+        transactions: [
+            {
+                transactionIndex: '0x0',
+                hash: '0xtx',
+                nonce: '0x0',
+                from: '0xe22a1e72591acb61ec32a9a1d2a1d0818c2f53e0',
+                gas: '0x0',
+                debugFrame_: {result: frame},
+            },
+        ],
+    }
+}
+
+
+describe('mapDebugFrame SELFDESTRUCT', () => {
+    // Regression: a self-referential SELFDESTRUCT where callTracer omits `to`
+    // used to crash the ingest with `assertNotNull(frame.to)`.
+    it('tolerates a missing `to` by falling back to the account itself', () => {
+        let block = mapRawBlock(
+            selfdestructBlock({
+                type: 'SELFDESTRUCT',
+                from: '0xe22a1e72591acb61ec32a9a1d2a1d0818c2f53e0',
+                gas: '0x0',
+                gasUsed: '0x0',
+                input: '0x',
+                value: '0x0',
+            }),
+            {withTraces: true}
+        )
+
+        expect(block.traces).toHaveLength(1)
+        let trace = block.traces![0]
+        expect(trace.type).toBe('selfdestruct')
+        expect((trace.action as any).refundAddress).toBe(
+            '0xe22a1e72591acb61ec32a9a1d2a1d0818c2f53e0'
+        )
+    })
+
+    it('keeps an explicit `to` as the refund address', () => {
+        let block = mapRawBlock(
+            selfdestructBlock({
+                type: 'SELFDESTRUCT',
+                from: '0xe22a1e72591acb61ec32a9a1d2a1d0818c2f53e0',
+                to: '0x1111111111111111111111111111111111111111',
+                gas: '0x0',
+                gasUsed: '0x0',
+                input: '0x',
+                value: '0x0',
+            }),
+            {withTraces: true}
+        )
+
+        expect((block.traces![0].action as any).refundAddress).toBe(
+            '0x1111111111111111111111111111111111111111'
+        )
+    })
+})

--- a/evm/evm-normalization/src/mapping.ts
+++ b/evm/evm-normalization/src/mapping.ts
@@ -139,7 +139,9 @@ function* mapDebugFrame(
                     type: 'selfdestruct',
                     action: {
                         address: frame.from.toLowerCase(),
-                        refundAddress: assertNotNull(frame.to).toLowerCase(),
+                        // callTracer omits `to` on a self-referential SELFDESTRUCT;
+                        // the beneficiary is then the account itself.
+                        refundAddress: (frame.to ?? frame.from).toLowerCase(),
                         balance: frame.value ?? undefined
                     }
                 }


### PR DESCRIPTION
## Cause (proven)
The `ethereum-sepolia` EVM archive ingest crash-loops deterministically (every ~8s) on block **11319411 (`0xacb873`)**, freezing the block writer → `ethereum-sepolia_Writer_Short_Stall`. The `ingest` container throws:

```
AssertionError: (val != null, msg)
  at assertNotNull (util-internal/lib/misc.js)
  at mapDebugFrame (evm-normalization/lib/mapping.js:103:74)   // src/mapping.ts:142
  at mapRawBlock (.../mapping.js)
blockNumber: "0xacb873", blockHash: "0xb3cd8c88…"
```

The offending record is the single **`SELFDESTRUCT`** frame in tx index 17 (`0xf6c6e39b…`): a **self-referential, zero-value** self-destruct of `0xe22a1e72…5​3e0`. geth's `callTracer` omits the `to` (beneficiary) field for this case, but `mapDebugFrame` guarded it with `assertNotNull(frame.to)`, turning an expected-optional field into a fatal crash.

This is a code contradiction: the RPC-level `DebugFrame` validator declares `to` as `option(BYTES)` (optional), yet normalization asserted it non-null.

## Not a chain / provider-data problem to "accept"
Cross-checked block 11319411's trace against **two independent debug-capable archival providers** (drpc, Tatum): both return `to == from` on this frame and no null fields anywhere. So the canonical value is well-defined — the fix reconstructs it rather than fabricating data. (The configured ingest provider returns the malformed frame; swapping it is a separate operator mitigation and is **not** part of this PR — the durable fix is to stop the crash, per the "fix the fatality" convention.)

## Fix
`refundAddress: (frame.to ?? frame.from).toLowerCase()` — when `to` is omitted, the beneficiary of a self-referential SELFDESTRUCT is the account itself (`frame.from`). Keeps the process alive on the field the validator already allows to be absent, without changing the public data model.

## Test (red→green)
`evm/evm-normalization/src/mapping.test.ts` builds a raw block with a SELFDESTRUCT frame missing `to` and drives it through the production `mapRawBlock` path.
- Pre-fix: `vitest --run` **fails** — throws at `mapping.ts:142 assertNotNull(frame.to)`.
- Post-fix: **passes** (`refundAddress === frame.from`); the explicit-`to` case is also asserted.
- `rush build --to @subsquid/evm-normalization` compiles green.

## Falsification
If a provider ever omits `to` on a SELFDESTRUCT whose beneficiary is **not** the destroyed account, `?? frame.from` would record the wrong refund address — but no such frame has been observed, the value moved is zero, and the alternative (assert) crash-loops the whole dataset. Independent-provider disagreement on `refundAddress` for such a block would falsify the self-referential assumption.