### PR TITLE
feat(squid-sdk): add Solana RPC and fallback data sources

### DIFF
--- a/common/changes/@subsquid/solana-stream/solana-rpc-fallback_2026-08-03.json
+++ b/common/changes/@subsquid/solana-stream/solana-rpc-fallback_2026-08-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/solana-stream",
+      "comment": "export the data request types (DataRequest, item request/relations interfaces) from the package barrel",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/solana-stream"
+}

--- a/common/changes/@subsquid/squid-sdk/solana-rpc-fallback_2026-08-03.json
+++ b/common/changes/@subsquid/squid-sdk/solana-rpc-fallback_2026-08-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/squid-sdk",
+      "comment": "add Solana RPC and fallback data sources: SolanaRpcDataSourceBuilder (solana/rpc) and SolanaFallbackDataSourceBuilder (solana/fallback), mirroring the EVM counterparts",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/squid-sdk"
+}

--- a/meta/squid-sdk/package.json
+++ b/meta/squid-sdk/package.json
@@ -55,6 +55,16 @@
       "import": "./lib/solana/index.js",
       "require": "./lib/solana/index.js"
     },
+    "./solana/rpc": {
+      "types": "./lib/solana/rpc/index.d.ts",
+      "import": "./lib/solana/rpc/index.js",
+      "require": "./lib/solana/rpc/index.js"
+    },
+    "./solana/fallback": {
+      "types": "./lib/solana/fallback/index.d.ts",
+      "import": "./lib/solana/fallback/index.js",
+      "require": "./lib/solana/fallback/index.js"
+    },
     "./fuel": {
       "types": "./lib/fuel/index.d.ts",
       "import": "./lib/fuel/index.js",
@@ -138,27 +148,75 @@
   },
   "typesVersions": {
     "*": {
-      "evm": ["./lib/evm/index.d.ts"],
-      "evm/rpc": ["./lib/evm/rpc/index.d.ts"],
-      "evm/fallback": ["./lib/evm/fallback/index.d.ts"],
-      "evm/objects": ["./lib/evm/objects/index.d.ts"],
-      "solana": ["./lib/solana/index.d.ts"],
-      "fuel": ["./lib/fuel/index.d.ts"],
-      "fallback": ["./lib/fallback/index.d.ts"],
-      "util": ["./lib/util/index.d.ts"],
-      "util/data-source": ["./lib/util/data-source/index.d.ts"],
-      "util/range": ["./lib/util/range/index.d.ts"],
-      "util/hex": ["./lib/util/hex/index.d.ts"],
-      "util/json": ["./lib/util/json/index.d.ts"],
-      "util/validation": ["./lib/util/validation/index.d.ts"],
-      "util/processor-tools": ["./lib/util/processor-tools/index.d.ts"],
-      "util/timeout": ["./lib/util/timeout/index.d.ts"],
-      "client/portal": ["./lib/client/portal/index.d.ts"],
-      "client/rpc": ["./lib/client/rpc/index.d.ts"],
-      "client/http": ["./lib/client/http/index.d.ts"],
-      "logger": ["./lib/logger/index.d.ts"],
-      "processor": ["./lib/processor/index.d.ts"],
-      "store/typeorm": ["./lib/store/typeorm/index.d.ts"]
+      "evm": [
+        "./lib/evm/index.d.ts"
+      ],
+      "evm/rpc": [
+        "./lib/evm/rpc/index.d.ts"
+      ],
+      "evm/fallback": [
+        "./lib/evm/fallback/index.d.ts"
+      ],
+      "evm/objects": [
+        "./lib/evm/objects/index.d.ts"
+      ],
+      "solana": [
+        "./lib/solana/index.d.ts"
+      ],
+      "solana/rpc": [
+        "./lib/solana/rpc/index.d.ts"
+      ],
+      "solana/fallback": [
+        "./lib/solana/fallback/index.d.ts"
+      ],
+      "fuel": [
+        "./lib/fuel/index.d.ts"
+      ],
+      "fallback": [
+        "./lib/fallback/index.d.ts"
+      ],
+      "util": [
+        "./lib/util/index.d.ts"
+      ],
+      "util/data-source": [
+        "./lib/util/data-source/index.d.ts"
+      ],
+      "util/range": [
+        "./lib/util/range/index.d.ts"
+      ],
+      "util/hex": [
+        "./lib/util/hex/index.d.ts"
+      ],
+      "util/json": [
+        "./lib/util/json/index.d.ts"
+      ],
+      "util/validation": [
+        "./lib/util/validation/index.d.ts"
+      ],
+      "util/processor-tools": [
+        "./lib/util/processor-tools/index.d.ts"
+      ],
+      "util/timeout": [
+        "./lib/util/timeout/index.d.ts"
+      ],
+      "client/portal": [
+        "./lib/client/portal/index.d.ts"
+      ],
+      "client/rpc": [
+        "./lib/client/rpc/index.d.ts"
+      ],
+      "client/http": [
+        "./lib/client/http/index.d.ts"
+      ],
+      "logger": [
+        "./lib/logger/index.d.ts"
+      ],
+      "processor": [
+        "./lib/processor/index.d.ts"
+      ],
+      "store/typeorm": [
+        "./lib/store/typeorm/index.d.ts"
+      ]
     }
   },
   "scripts": {
@@ -189,13 +247,21 @@
   },
   "peerDependencies": {
     "@subsquid/evm-normalization": "^0.0.6",
-    "@subsquid/evm-rpc": "^0.1.0"
+    "@subsquid/evm-rpc": "^0.1.0",
+    "@subsquid/solana-rpc": "^1.0.0",
+    "@subsquid/solana-normalization": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@subsquid/evm-normalization": {
       "optional": true
     },
     "@subsquid/evm-rpc": {
+      "optional": true
+    },
+    "@subsquid/solana-rpc": {
+      "optional": true
+    },
+    "@subsquid/solana-normalization": {
       "optional": true
     }
   },
@@ -206,6 +272,8 @@
     "@types/node": "^24.0.0",
     "typeorm": "^0.3.17",
     "typescript": "5.5.4",
-    "vitest": "4.1.5"
+    "vitest": "4.1.5",
+    "@subsquid/solana-rpc": "^1.0.0",
+    "@subsquid/solana-normalization": "^1.0.0"
   }
 }

--- a/meta/squid-sdk/src/common/bounded-stream.ts
+++ b/meta/squid-sdk/src/common/bounded-stream.ts
@@ -1,0 +1,80 @@
+import {BlockRef, BlockStream, DataSource, StreamRequest} from '@subsquid/util-internal-data-source'
+import {RangeRequestList, applyRangeBound} from '@subsquid/util-internal-range'
+
+/**
+ * Stream an inner RPC source per *request range*, intersected with the caller's `[from, to]`
+ * window — exactly like the Portal source, which issues one query per range. Blocks in a gap
+ * between non-contiguous ranges are never streamed, so they can't leak through unfiltered: that
+ * would break the Portal-compatible / drop-in guarantee and disagree with `getBlocksCountInRange`,
+ * which counts only the request ranges.
+ *
+ * `parentHash` is threaded through *contiguous* ranges so the inner source's continuity/fork
+ * detection keeps working across a seam, and is dropped across a gap (there is no parent to
+ * assert there). The caller's `parentHash` is preserved for the very first streamed block *when the
+ * stream starts within the first request range* (no leading gap) — that is what lets a fallback
+ * detect a fork when it resumes after switching sources. If the stream instead starts inside a gap
+ * (`range.from !== expectedFrom` on the first range), there is no asserted parent, so it is dropped.
+ *
+ * `toRef` extracts the chain reference of a raw block — chains whose raw blocks already carry
+ * `{number, hash}` (EVM) pass the identity; others (Solana's `{slot, block}`) supply an adapter.
+ */
+export async function* streamBoundedRanges<B>(
+    inner: Pick<DataSource<B>, 'getStream' | 'getFinalizedStream'>,
+    requests: RangeRequestList<unknown>,
+    req: StreamRequest,
+    finalized: boolean,
+    toRef: (block: B) => BlockRef,
+): BlockStream<B> {
+    let ranges = applyRangeBound(requests, {from: req.from, to: req.to})
+
+    let parentHash = req.parentHash
+    let expectedFrom = req.from
+
+    for (let {range} of ranges) {
+        // A gap precedes this range (or the stream starts inside one): don't hand the inner source
+        // a parentHash it would treat as a fork.
+        if (range.from !== expectedFrom) parentHash = undefined
+
+        let streamReq: StreamRequest = {from: range.from, to: range.to, parentHash}
+        let stream = finalized ? inner.getFinalizedStream(streamReq) : inner.getStream(streamReq)
+
+        for await (let batch of stream) {
+            yield batch
+
+            let last = batch.blocks[batch.blocks.length - 1]
+            if (last) {
+                let ref = toRef(last)
+                parentHash = ref.hash
+                expectedFrom = ref.number + 1
+            }
+        }
+
+        // The next *contiguous* range begins right after this one; a larger jump is a gap.
+        if (range.to != null) expectedFrom = Math.max(expectedFrom, range.to + 1)
+    }
+}
+
+/**
+ * Drop blocks left empty after filtering, matching the Portal — which forwards `includeAllBlocks`
+ * to the server and, when it is false, returns only blocks with matching data. A block is kept iff
+ * it carries data (`hasData`), its range opted into `includeAllBlocks`, or it is a *boundary*
+ * block.
+ *
+ * The batch's first and last blocks are always kept even when empty, mirroring the Portal: the last
+ * block lets the consumer's cursor advance to the batch end (without it, progress would stall on a
+ * dataless tail), and the first anchors chain continuity. Keeping them is also what makes a
+ * `[Portal, RPC]` fallback transparent — both sides drop the same interior empties.
+ */
+export function dropEmptyBlocks<B>(
+    blocks: B[],
+    includeAllBlocks: (blockNumber: number) => boolean,
+    blockNumber: (block: B) => number,
+    hasData: (block: B) => boolean,
+): B[] {
+    return blocks.filter((b, i) => {
+        if (i === 0 || i === blocks.length - 1) return true // boundary blocks: always present
+        if (includeAllBlocks(blockNumber(b))) return true
+
+        return hasData(b)
+    })
+}

--- a/meta/squid-sdk/src/evm/rpc/source/data-source.ts
+++ b/meta/squid-sdk/src/evm/rpc/source/data-source.ts
@@ -2,6 +2,10 @@ import {mapRpcBlock} from '@subsquid/evm-normalization'
 import {Block, DataRequest, FieldSelection} from '@subsquid/evm-stream'
 import {EvmRpcDataSource, Rpc, DataRequest as RpcDataRequest, Block as RpcBlock} from '@subsquid/evm-rpc'
 import {BlockBatch, BlockRef, BlockStream, DataSource, StreamRequest} from '@subsquid/util-internal-data-source'
+import {
+    dropEmptyBlocks as dropEmptyBlocksGeneric,
+    streamBoundedRanges as streamBoundedRangesGeneric,
+} from '../../../common/bounded-stream'
 import {FiniteRange, RangeRequest, RangeRequestList, applyRangeBound, getSize} from '@subsquid/util-internal-range'
 
 import {decodeBlock} from '../decode/decode'
@@ -189,75 +193,35 @@ export function keptByPosition<P, Q>(projected: P[], pre: Q[], kept: Q[]): P[] {
 
 
 /**
- * Stream the inner RPC source per *request range*, intersected with the caller's `[from, to]`
- * window — exactly like the Portal source, which issues one query per range. Blocks in a gap
- * between non-contiguous ranges are never streamed, so they can't leak through unfiltered: that
- * would break the Portal-compatible / drop-in guarantee and disagree with `getBlocksCountInRange`,
- * which counts only the request ranges.
- *
- * `parentHash` is threaded through *contiguous* ranges so the inner source's continuity/fork
- * detection keeps working across a seam, and is dropped across a gap (there is no parent to
- * assert there). The caller's `parentHash` is preserved for the very first streamed block *when the
- * stream starts within the first request range* (no leading gap) — that is what lets a fallback
- * detect a fork when it resumes after switching sources. If the stream instead starts inside a gap
- * (`range.from !== expectedFrom` on the first range), there is no asserted parent, so it is dropped.
+ * Stream the inner RPC source per *request range* — see the shared
+ * {@link streamBoundedRangesGeneric} for the range/parentHash semantics. EVM raw blocks already
+ * carry `{number, hash}`, so the identity serves as the block reference.
  */
-export async function* streamBoundedRanges(
+export function streamBoundedRanges(
     inner: Pick<DataSource<RpcBlock>, 'getStream' | 'getFinalizedStream'>,
     requests: RangeRequestList<unknown>,
     req: StreamRequest,
     finalized: boolean,
 ): BlockStream<RpcBlock> {
-    let ranges = applyRangeBound(requests, {from: req.from, to: req.to})
-
-    let parentHash = req.parentHash
-    let expectedFrom = req.from
-
-    for (let {range} of ranges) {
-        // A gap precedes this range (or the stream starts inside one): don't hand the inner source
-        // a parentHash it would treat as a fork.
-        if (range.from !== expectedFrom) parentHash = undefined
-
-        let streamReq: StreamRequest = {from: range.from, to: range.to, parentHash}
-        let stream = finalized ? inner.getFinalizedStream(streamReq) : inner.getStream(streamReq)
-
-        for await (let batch of stream) {
-            yield batch
-
-            let last = batch.blocks[batch.blocks.length - 1]
-            if (last) {
-                parentHash = last.hash
-                expectedFrom = last.number + 1
-            }
-        }
-
-        // The next *contiguous* range begins right after this one; a larger jump is a gap.
-        if (range.to != null) expectedFrom = Math.max(expectedFrom, range.to + 1)
-    }
+    return streamBoundedRangesGeneric(inner, requests, req, finalized, (b) => b)
 }
 
 type AnyDecodedBlock = {header: {number: number}; logs: unknown[]; transactions: unknown[]; traces: unknown[]; stateDiffs: unknown[]}
 
 /**
- * Drop blocks left empty after filtering, matching the Portal — which forwards `includeAllBlocks`
- * to the server and, when it is false, returns only blocks with matching data. A block is kept iff
- * it carries data, its range opted into `includeAllBlocks`, or it is a *boundary* block.
- *
- * The batch's first and last blocks are always kept even when empty, mirroring the Portal: the last
- * block lets the consumer's cursor advance to the batch end (without it, progress would stall on a
- * dataless tail), and the first anchors chain continuity. Keeping them is also what makes a
- * `[Portal, RPC]` fallback transparent — both sides drop the same interior empties.
+ * Drop blocks left empty after filtering — see the shared {@link dropEmptyBlocksGeneric} for the
+ * boundary-block semantics. A decoded EVM block is empty when all four item arrays are.
  */
 export function dropEmptyBlocks<B extends AnyDecodedBlock>(
     blocks: B[],
     includeAllBlocks: (blockNumber: number) => boolean,
 ): B[] {
-    return blocks.filter((b, i) => {
-        if (i === 0 || i === blocks.length - 1) return true // boundary blocks: always present
-        if (includeAllBlocks(b.header.number)) return true
-
-        return b.logs.length > 0 || b.transactions.length > 0 || b.traces.length > 0 || b.stateDiffs.length > 0
-    })
+    return dropEmptyBlocksGeneric(
+        blocks,
+        includeAllBlocks,
+        (b) => b.header.number,
+        (b) => b.logs.length > 0 || b.transactions.length > 0 || b.traces.length > 0 || b.stateDiffs.length > 0,
+    )
 }
 
 // Re-export so the bounded-stream consumer can apply request range bounds the same way.

--- a/meta/squid-sdk/src/solana/fallback/builder.test.ts
+++ b/meta/squid-sdk/src/solana/fallback/builder.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {FallbackDataSource} from '../../fallback/fallback'
+import {SolanaFallbackDataSourceBuilder} from './builder'
+
+// Stub the lazy RPC loader: `require('../rpc/builder')` resolves a directory to lib/index.js when
+// compiled, but vitest can't resolve it to the .ts source. So `rpc` sources here verify the builder's
+// wiring (which fields/requests it hands to solanaRpcStream); the network-gated e2e covers the real
+// stack.
+const {rpcCalls} = vi.hoisted(() => ({rpcCalls: [] as any[]}))
+vi.mock('./load-rpc-stream', () => ({
+    loadRpcStream: () => ({
+        solanaRpcStream: (config: any) => {
+            rpcCalls.push(config)
+            return {getFinalizedStream() {}, getFinalizedHead() {}, getStream() {}, getHead() {}}
+        },
+    }),
+}))
+
+const PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+
+describe('SolanaFallbackDataSourceBuilder', () => {
+    it('defines the query once and applies identical fields + merged requests to every source', () => {
+        rpcCalls.length = 0
+
+        const fb = new SolanaFallbackDataSourceBuilder()
+            .setDownstreamSources([
+                {type: 'rpc', url: 'https://a.example'},
+                {type: 'rpc', url: 'https://b.example'},
+            ])
+            .setFields({instruction: {programId: true, data: true}, transaction: {signatures: true}})
+            .addInstruction({where: {programId: [PROGRAM]}, range: {from: 100}})
+            .addTransaction({where: {feePayer: ['abc']}, range: {from: 100}})
+            .setCapabilityProbe(false)
+            .build()
+
+        expect(fb).toBeInstanceOf(FallbackDataSource)
+        expect(rpcCalls).toHaveLength(2)
+
+        // Same shared field selection handed to both sources.
+        expect(rpcCalls[0].fields).toEqual({instruction: {programId: true, data: true}, transaction: {signatures: true}})
+        expect(rpcCalls[1].fields).toEqual(rpcCalls[0].fields)
+
+        // Same merged requests handed to both sources: the two same-range adds coalesce into one
+        // range-request carrying both the instruction and the transaction filter.
+        expect(rpcCalls[1].requests).toEqual(rpcCalls[0].requests)
+        expect(rpcCalls[0].requests).toHaveLength(1)
+        expect(rpcCalls[0].requests[0].range).toEqual({from: 100})
+        expect(rpcCalls[0].requests[0].request.instructions).toEqual([{where: {programId: [PROGRAM]}}])
+        expect(rpcCalls[0].requests[0].request.transactions).toEqual([{where: {feePayer: ['abc']}}])
+    })
+
+    it('passes per-source connection options through, stripping the type/name tags', () => {
+        rpcCalls.length = 0
+
+        new SolanaFallbackDataSourceBuilder()
+            .setDownstreamSources([{type: 'rpc', name: 'my-node', url: 'https://a.example', capacity: 5}])
+            .setCapabilityProbe(false)
+            .build()
+
+        expect(rpcCalls[0]).toMatchObject({url: 'https://a.example', capacity: 5})
+        expect(rpcCalls[0].type).toBeUndefined()
+        expect(rpcCalls[0].name).toBeUndefined()
+    })
+
+    it('requires at least one downstream source', () => {
+        expect(() => new SolanaFallbackDataSourceBuilder().build()).toThrow(/No downstream sources/)
+    })
+
+    it('names sources by type and index when no name is given', () => {
+        rpcCalls.length = 0
+
+        const fb = new SolanaFallbackDataSourceBuilder()
+            .setDownstreamSources([
+                {type: 'rpc', url: 'https://a.example'},
+                {type: 'rpc', name: 'standby', url: 'https://b.example'},
+            ])
+            .setCapabilityProbe(false)
+            .build()
+
+        expect(fb.metrics().sources.map((s) => s.name)).toEqual(['rpc-0', 'standby'])
+    })
+
+    it('builds a custom source with the shared fields and requests', () => {
+        let seen: any = null
+
+        new SolanaFallbackDataSourceBuilder()
+            .setDownstreamSources([
+                {
+                    type: 'custom',
+                    buildSource(fields, requests) {
+                        seen = {fields, requests}
+                        return {getFinalizedStream() {}, getFinalizedHead() {}, getStream() {}, getHead() {}} as any
+                    },
+                },
+            ])
+            .setFields({log: {message: true}})
+            .addLog({where: {programId: [PROGRAM]}, range: {from: 7}})
+            .setCapabilityProbe(false)
+            .build()
+
+        expect(seen.fields).toEqual({log: {message: true}})
+        expect(seen.requests).toHaveLength(1)
+        expect(seen.requests[0].request.logs).toEqual([{where: {programId: [PROGRAM]}}])
+    })
+})

--- a/meta/squid-sdk/src/solana/fallback/builder.ts
+++ b/meta/squid-sdk/src/solana/fallback/builder.ts
@@ -1,0 +1,164 @@
+import type {PortalClientOptions} from '@subsquid/portal-client'
+import {
+    type Block,
+    type DataRequest,
+    DataSourceBuilder,
+    type FieldSelection,
+    type SolanaDataSource,
+} from '@subsquid/solana-stream'
+import type {BlockRef} from '@subsquid/util-internal-data-source'
+import type {RangeRequestList} from '@subsquid/util-internal-range'
+import assert from 'assert'
+
+import {SolanaQueryBuilder} from '../query-builder'
+import type {SolanaRpcOptions} from '../rpc'
+import {type CapabilityProbeOptions, makeCapabilityProbe} from '../../fallback/capability'
+import {FallbackDataSource, type RankedSource} from '../../fallback/fallback'
+import type {FallbackPolicy} from '../../fallback/policy'
+import {loadRpcStream} from './load-rpc-stream'
+
+const solanaBlockRef = (b: Block<any>): BlockRef => ({number: b.header.number, hash: b.header.hash})
+
+/** A SQD Network Portal source — the same options as `DataSourceBuilder#setPortal` (`url`, …). */
+export type SolanaPortalSourceConfig = {type: 'portal'; name?: string} & PortalClientOptions
+
+/** A JSON-RPC source. */
+export type SolanaRpcSourceConfig = {type: 'rpc'; name?: string} & SolanaRpcOptions
+
+/**
+ * A custom source — the escape hatch. Its {@link buildSource} is handed the fallback's shared field
+ * selection + requests, exactly like `portal`/`rpc` sources, so it can build a matching source. A
+ * source that doesn't use them (e.g. wrapping an already-built one) may ignore its arguments — but
+ * then it is on you to keep it consistent with the others, or output depends on which is active.
+ */
+export interface SolanaCustomSourceConfig {
+    type: 'custom'
+    name?: string
+    buildSource(fields: FieldSelection, requests: RangeRequestList<DataRequest>): SolanaDataSource<any>
+}
+
+/**
+ * A downstream source in a Solana fallback, given as a plain tagged config object. The field
+ * selection and query are defined **once** on the {@link SolanaFallbackDataSourceBuilder} and
+ * applied to every source, so they all fetch the same data (and produce identical output no matter
+ * which one is active). `name` is optional — sources default to `` `${type}-${index}` `` in
+ * metrics/logs.
+ */
+export type SolanaFallbackSourceConfig = SolanaPortalSourceConfig | SolanaRpcSourceConfig | SolanaCustomSourceConfig
+
+/**
+ * Fluent builder for a Solana fallback data source, shaped like `@subsquid/solana-stream`'s
+ * `DataSourceBuilder`: define the field selection + query **once** here (`setFields`,
+ * `addInstruction`, …), list the ordered downstream sources via {@link setDownstreamSources}, and
+ * `build()` a `FallbackDataSource<Block<F>>` — a drop-in for a single `SolanaDataSource<F>`.
+ * `setFields` infers the block type `F`, so field access is fully typed.
+ *
+ * @example
+ * const source = new SolanaFallbackDataSourceBuilder()
+ *     .setDownstreamSources([
+ *         {type: 'portal', url: 'https://portal.sqd.dev/datasets/solana-mainnet'},
+ *         {type: 'rpc', url: RPC_URL},
+ *     ])
+ *     .setFields({instruction: {programId: true, data: true}})
+ *     .addInstruction({where: {programId: [PROGRAM_ID]}, range: {from: 250_000_000}})
+ *     .build()
+ */
+export class SolanaFallbackDataSourceBuilder<F extends FieldSelection = {}> extends SolanaQueryBuilder {
+    private downstream: SolanaFallbackSourceConfig[] = []
+    private policy?: FallbackPolicy
+    private capabilityProbe: boolean | CapabilityProbeOptions = true
+
+    /**
+     * The ordered list of downstream sources, most-preferred first — the fallback drives the first
+     * healthy one and fails over (and back up) as health changes. Each entry is a plain tagged config
+     * object; the shared field selection + query (`setFields`/`addInstruction`/…) is applied to every
+     * source, so they all fetch identical data.
+     *
+     * - `{type: 'portal', url}` — a SQD Network Portal dataset (same options as `DataSourceBuilder#setPortal`).
+     * - `{type: 'rpc', url}` — a JSON-RPC endpoint ({@link SolanaRpcSourceConfig}).
+     * - `{type: 'custom', buildSource}` — the escape hatch ({@link SolanaCustomSourceConfig}).
+     *
+     * `name` is optional on each entry and defaults to `` `${type}-${index}` `` in metrics/logs.
+     *
+     * @example
+     * .setDownstreamSources([
+     *     {type: 'portal', url: 'https://portal.sqd.dev/datasets/solana-mainnet'},
+     *     {type: 'rpc', url: process.env.SOLANA_RPC_URL!},
+     * ])
+     */
+    setDownstreamSources(sources: SolanaFallbackSourceConfig[]): this {
+        this.downstream = sources
+        return this
+    }
+
+    /** Failover/switch-up policy (lag/staleness thresholds, cooldowns, …). Defaults are sensible. */
+    setPolicy(policy: FallbackPolicy): this {
+        this.policy = policy
+        return this
+    }
+
+    /**
+     * Attach a generic capability probe to every source (default `true`): a source counts as
+     * `healthy` only once it confirms it can serve the configured data at the indexing frontier —
+     * catching a reachable-but-incapable node (e.g. one without historical blocks) before a
+     * switch-up promotes it. Pass `false` to govern health by liveness alone, or `{timeoutMs}` to
+     * tune the probe.
+     */
+    setCapabilityProbe(probe: boolean | CapabilityProbeOptions): this {
+        this.capabilityProbe = probe
+        return this
+    }
+
+    /** Configure the set of fetched fields — infers the block type `F` for `build()`. */
+    setFields<T extends FieldSelection>(fields: T): SolanaFallbackDataSourceBuilder<T> {
+        this.fields = fields
+        return this as unknown as SolanaFallbackDataSourceBuilder<T>
+    }
+
+    /** Build one downstream source from its config, applying the shared field selection + query. */
+    private buildDownstream(
+        cfg: SolanaFallbackSourceConfig,
+        fields: F,
+        requests: RangeRequestList<DataRequest>,
+    ): SolanaDataSource<F> {
+        switch (cfg.type) {
+            case 'portal': {
+                let {type, name, ...portal} = cfg
+                assert(portal.url, "portal fallback source requires a 'url' (the portal dataset endpoint)")
+                // Drive a fresh canonical Portal builder — never wrap it. The requests are already merged
+                // (by getRequests()); re-adding them via addQuery is safe because DataSourceBuilder merges
+                // again internally and the ranges are disjoint, so that re-merge is a no-op.
+                let builder = new DataSourceBuilder().setPortal(portal).setFields(fields)
+                for (let req of requests) builder.addQuery(req)
+                return builder.build()
+            }
+            case 'rpc': {
+                let {type, name, ...options} = cfg
+                assert(options.url, "rpc fallback source requires a 'url' (the JSON-RPC endpoint)")
+                // Lazy: this is the only point that touches the optional @subsquid/solana-rpc peer.
+                return loadRpcStream().solanaRpcStream({...options, fields, requests})
+            }
+            case 'custom':
+                return cfg.buildSource(fields, requests)
+        }
+    }
+
+    /** Build the fallback data source. Requires at least one downstream source. */
+    build(): FallbackDataSource<Block<F>> {
+        assert(this.downstream.length > 0, 'No downstream sources — call setDownstreamSources([...])')
+
+        let fields = this.fields as F
+        let requests = this.getRequests()
+
+        let ranked: RankedSource<Block<F>>[] = this.downstream.map((cfg, i) => {
+            let source = this.buildDownstream(cfg, fields, requests)
+            let probeCapability =
+                this.capabilityProbe === false
+                    ? undefined
+                    : makeCapabilityProbe(source, this.capabilityProbe === true ? undefined : this.capabilityProbe)
+            return {name: cfg.name ?? `${cfg.type}-${i}`, source, probeCapability}
+        })
+
+        return new FallbackDataSource<Block<F>>({sources: ranked, getBlockRef: solanaBlockRef, policy: this.policy})
+    }
+}

--- a/meta/squid-sdk/src/solana/fallback/index.ts
+++ b/meta/squid-sdk/src/solana/fallback/index.ts
@@ -1,0 +1,4 @@
+export * from './builder'
+// Re-exported for convenience so a squid using this subpath can `catch (AllSourcesDownError)` and
+// type a `FallbackPolicy` without also importing from `@subsquid/squid-sdk/fallback`.
+export {AllSourcesDownError, type FallbackPolicy} from '../../fallback/policy'

--- a/meta/squid-sdk/src/solana/fallback/load-rpc-stream.test.ts
+++ b/meta/squid-sdk/src/solana/fallback/load-rpc-stream.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from 'vitest'
+
+import {translateMissingRpcPeer} from './load-rpc-stream'
+
+function moduleNotFound(message: string): NodeJS.ErrnoException {
+    let e = new Error(message) as NodeJS.ErrnoException
+    e.code = 'MODULE_NOT_FOUND'
+    return e
+}
+
+describe('translateMissingRpcPeer', () => {
+    it('translates a missing @subsquid/solana-rpc peer into an actionable error', () => {
+        let out = translateMissingRpcPeer(moduleNotFound("Cannot find module '@subsquid/solana-rpc'")) as Error
+        expect(out).toBeInstanceOf(Error)
+        expect(out.message).toContain('optional peer dependencies')
+        expect(out.message).toContain('@subsquid/solana-rpc')
+        expect(out.message).toContain('@subsquid/solana-normalization')
+    })
+
+    it('translates a missing @subsquid/solana-normalization peer too', () => {
+        let out = translateMissingRpcPeer(moduleNotFound("Cannot find module '@subsquid/solana-normalization'")) as Error
+        expect(out.message).toContain('optional peer dependencies')
+    })
+
+    it('passes a MODULE_NOT_FOUND for an unrelated module through unchanged', () => {
+        let orig = moduleNotFound("Cannot find module 'some-transitive-dep'")
+        expect(translateMissingRpcPeer(orig)).toBe(orig)
+    })
+
+    it('passes a non-MODULE_NOT_FOUND fault through unchanged', () => {
+        let orig = new Error('boom')
+        expect(translateMissingRpcPeer(orig)).toBe(orig)
+    })
+})

--- a/meta/squid-sdk/src/solana/fallback/load-rpc-stream.ts
+++ b/meta/squid-sdk/src/solana/fallback/load-rpc-stream.ts
@@ -1,0 +1,37 @@
+const RPC_PEERS = ['@subsquid/solana-rpc', '@subsquid/solana-normalization']
+
+/**
+ * Load the sibling `solana/rpc` subpath lazily, only when an `rpc` source is actually built.
+ *
+ * `@subsquid/solana-rpc` and `@subsquid/solana-normalization` are *optional peer dependencies* of
+ * `@subsquid/squid-sdk` — a Portal-only or non-Solana squid installs neither. The `solana/rpc`
+ * code imports them at module scope, so deferring the `require` keeps the RPC stack out of the
+ * module graph until an `rpc` source is configured, and lets us translate a missing peer into an
+ * actionable message instead of a raw `MODULE_NOT_FOUND` thrown from deep inside the stack.
+ */
+export function loadRpcStream(): typeof import('../rpc/builder') {
+    try {
+        // Require the builder module directly (not the barrel) so we can reach the internal
+        // `solanaRpcStream` construction primitive, which the barrel intentionally does not re-export.
+        return require('../rpc/builder')
+    } catch (e) {
+        throw translateMissingRpcPeer(e)
+    }
+}
+
+/**
+ * If `e` is a `MODULE_NOT_FOUND` for one of the optional RPC peers, return an actionable error
+ * naming both peers. Matches the missing module by its exact quoted name, so a `MODULE_NOT_FOUND`
+ * for a *different* module (a broken install of a transitive dep) — and any non-`MODULE_NOT_FOUND`
+ * fault thrown on load — passes through unchanged rather than being masked as "peers missing".
+ */
+export function translateMissingRpcPeer(e: unknown): unknown {
+    let err = e as NodeJS.ErrnoException
+    if (err?.code === 'MODULE_NOT_FOUND' && RPC_PEERS.some((p) => err.message.includes(`'${p}'`))) {
+        return new Error(
+            "An 'rpc' fallback source requires the optional peer dependencies '@subsquid/solana-rpc' " +
+                "and '@subsquid/solana-normalization'. Install them, or use only 'portal' sources.",
+        )
+    }
+    return err
+}

--- a/meta/squid-sdk/src/solana/query-builder.ts
+++ b/meta/squid-sdk/src/solana/query-builder.ts
@@ -1,0 +1,103 @@
+import {
+    type BalanceRequest,
+    type DataRequest,
+    type FieldSelection,
+    type InstructionRequest,
+    type LogRequest,
+    type Query,
+    QueryBuilder,
+    type RewardRequest,
+    type TokenBalanceRequest,
+    type TransactionRequest,
+} from '@subsquid/solana-stream'
+import {type Range, type RangeRequest, type RangeRequestList, applyRangeBound, mergeRangeRequests} from '@subsquid/util-internal-range'
+
+interface BlockRange {
+    range?: Range
+}
+
+/**
+ * The shared fluent query surface — field selection + item filters + block range — mirroring
+ * `@subsquid/solana-stream`'s `DataSourceBuilder`. Base of {@link SolanaRpcDataSourceBuilder} and
+ * `SolanaFallbackDataSourceBuilder` so both read identically. `setFields` lives on each subclass
+ * (it re-types the builder to infer the block type); everything else is shared here. Not
+ * instantiated directly.
+ */
+export abstract class SolanaQueryBuilder {
+    protected fields: FieldSelection = {}
+    protected requests: RangeRequest<DataRequest>[] = []
+    protected blockRange?: Range
+
+    /** Limit the range of blocks (slots) to fetch. */
+    setBlockRange(range?: Range): this {
+        this.blockRange = range
+        return this
+    }
+
+    /** Add a query — a set of item filters sharing a block range (accepts a {@link QueryBuilder}). */
+    addQuery(query: Query | QueryBuilder): this {
+        this.requests.push(query instanceof QueryBuilder ? query.build() : query)
+        return this
+    }
+
+    /** Shorthand for {@link addQuery} that only sets `includeAllBlocks` (and optionally a range). */
+    includeAllBlocks(range?: Range): this {
+        return this.addQuery({range: range ?? {from: 0}, request: {includeAllBlocks: true}})
+    }
+
+    /** Shorthand for {@link addQuery} with a single transaction filter. */
+    addTransaction(options: TransactionRequest & BlockRange): this {
+        let {range, ...req} = options
+        return this.addQuery({range: range ?? {from: 0}, request: {transactions: [req]}})
+    }
+
+    /** Shorthand for {@link addQuery} with a single instruction filter. */
+    addInstruction(options: InstructionRequest & BlockRange): this {
+        let {range, ...req} = options
+        return this.addQuery({range: range ?? {from: 0}, request: {instructions: [req]}})
+    }
+
+    /** Shorthand for {@link addQuery} with a single log filter. */
+    addLog(options: LogRequest & BlockRange): this {
+        let {range, ...req} = options
+        return this.addQuery({range: range ?? {from: 0}, request: {logs: [req]}})
+    }
+
+    /** Shorthand for {@link addQuery} with a single native-balance filter. */
+    addBalance(options: BalanceRequest & BlockRange): this {
+        let {range, ...req} = options
+        return this.addQuery({range: range ?? {from: 0}, request: {balances: [req]}})
+    }
+
+    /** Shorthand for {@link addQuery} with a single token-balance filter. */
+    addTokenBalance(options: TokenBalanceRequest & BlockRange): this {
+        let {range, ...req} = options
+        return this.addQuery({range: range ?? {from: 0}, request: {tokenBalances: [req]}})
+    }
+
+    /** Shorthand for {@link addQuery} with a single reward filter. */
+    addReward(options: RewardRequest & BlockRange): this {
+        let {range, ...req} = options
+        return this.addQuery({range: range ?? {from: 0}, request: {rewards: [req]}})
+    }
+
+    /** Merge + range-bound the accumulated queries (mirrors DataSourceBuilder#getRequests). */
+    protected getRequests(): RangeRequestList<DataRequest> {
+        function concat<T>(a?: T[], b?: T[]): T[] | undefined {
+            let result = [...(a ?? []), ...(b ?? [])]
+            return result.length === 0 ? undefined : result
+        }
+
+        let requests = mergeRangeRequests(this.requests, (a, b) => ({
+            includeAllBlocks: a.includeAllBlocks || b.includeAllBlocks,
+            transactions: concat(a.transactions, b.transactions),
+            instructions: concat(a.instructions, b.instructions),
+            logs: concat(a.logs, b.logs),
+            balances: concat(a.balances, b.balances),
+            tokenBalances: concat(a.tokenBalances, b.tokenBalances),
+            rewards: concat(a.rewards, b.rewards),
+        }))
+
+        return applyRangeBound(requests, this.blockRange)
+    }
+}

--- a/meta/squid-sdk/src/solana/rpc/builder.test.ts
+++ b/meta/squid-sdk/src/solana/rpc/builder.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from 'vitest'
+
+import {SolanaRpcDataSourceBuilder} from './builder'
+import {coarseRequest} from './source/data-source'
+
+const PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+
+describe('SolanaRpcDataSourceBuilder', () => {
+    it('builds a standalone RPC data source from a fluent query (no connection)', () => {
+        const src = new SolanaRpcDataSourceBuilder()
+            .setRpc({url: 'https://rpc.example'})
+            .setFields({instruction: {programId: true, data: true}})
+            .addInstruction({where: {programId: [PROGRAM]}, range: {from: 250_000_000}})
+            .build()
+
+        // A real SolanaDataSource — construction succeeds and it exposes the DataSource surface.
+        // Nothing connects until it is streamed.
+        expect(typeof src.getFinalizedStream).toBe('function')
+        expect(typeof src.getFinalizedHead).toBe('function')
+    })
+
+    it('accepts a bare URL string', () => {
+        const src = new SolanaRpcDataSourceBuilder().setRpc('https://rpc.example').build()
+        expect(typeof src.getFinalizedStream).toBe('function')
+    })
+
+    it('throws when the endpoint is not set', () => {
+        expect(() => new SolanaRpcDataSourceBuilder().build()).toThrow(/rpc/i)
+    })
+})
+
+describe('coarseRequest', () => {
+    it('needs transaction details for any transaction-derived item filter', () => {
+        for (let request of [
+            {transactions: [{}]},
+            {instructions: [{}]},
+            {logs: [{}]},
+            {balances: [{}]},
+            {tokenBalances: [{}]},
+        ]) {
+            expect(coarseRequest([{range: {from: 0}, request}])).toEqual({transactions: true, rewards: false})
+        }
+    })
+
+    it('fetches rewards only for a reward filter', () => {
+        expect(coarseRequest([{range: {from: 0}, request: {rewards: [{}]}}])).toEqual({
+            transactions: false,
+            rewards: true,
+        })
+    })
+
+    it('fetches neither for a header-only query', () => {
+        expect(coarseRequest([{range: {from: 0}, request: {includeAllBlocks: true}}])).toEqual({
+            transactions: false,
+            rewards: false,
+        })
+    })
+
+    it('unions across ranges', () => {
+        expect(
+            coarseRequest([
+                {range: {from: 0, to: 10}, request: {rewards: [{}]}},
+                {range: {from: 11}, request: {instructions: [{}]}},
+            ]),
+        ).toEqual({transactions: true, rewards: true})
+    })
+})

--- a/meta/squid-sdk/src/solana/rpc/builder.ts
+++ b/meta/squid-sdk/src/solana/rpc/builder.ts
@@ -1,0 +1,90 @@
+import {Rpc} from '@subsquid/solana-rpc'
+import {DataRequest, FieldSelection} from '@subsquid/solana-stream'
+import {RpcClient} from '@subsquid/rpc-client'
+import {RangeRequestList} from '@subsquid/util-internal-range'
+import assert from 'assert'
+
+import {SolanaQueryBuilder} from '../query-builder'
+import {SolanaRpcStreamDataSource} from './source/data-source'
+
+/** JSON-RPC connection config, shared by {@link solanaRpcStream}, {@link SolanaRpcDataSourceBuilder}, and the `rpc` fallback source. */
+export interface SolanaRpcOptions {
+    /** JSON-RPC endpoint URL. */
+    url: string
+    /** Max concurrent requests. */
+    capacity?: number
+    /** Requests per second cap. */
+    rateLimit?: number
+    /** Blocks per ingestion stride. */
+    strideSize?: number
+    /** Concurrent strides. */
+    strideConcurrency?: number
+}
+
+export interface SolanaRpcStreamConfig<F extends FieldSelection> extends SolanaRpcOptions {
+    fields: F
+    requests: RangeRequestList<DataRequest>
+}
+
+/**
+ * Build an RPC `DataSource<Block<F>>` from a simple config. Unlike EVM there is no per-network
+ * deploy-config layer to resolve: the Solana RPC surface is uniform across networks, and
+ * `@subsquid/solana-normalization` produces the same block model the Portal datasets are built
+ * from — so dataset parity needs no per-network preset.
+ */
+export function solanaRpcStream<F extends FieldSelection>(config: SolanaRpcStreamConfig<F>): SolanaRpcStreamDataSource<F> {
+    const client = new RpcClient({
+        url: config.url,
+        capacity: config.capacity,
+        rateLimit: config.rateLimit,
+        // Solana RPC responses routinely carry u64 values (lamports, slots) that overflow
+        // double precision — parse them exactly, as the legacy SolanaRpcClient always did.
+        fixUnsafeIntegers: true,
+    })
+
+    return new SolanaRpcStreamDataSource<F>({
+        rpc: new Rpc(client),
+        fields: config.fields,
+        requests: config.requests,
+        strideSize: config.strideSize,
+        strideConcurrency: config.strideConcurrency,
+    })
+}
+
+/**
+ * Fluent builder for a standalone JSON-RPC Solana data source — the RPC counterpart of
+ * `@subsquid/solana-stream`'s `DataSourceBuilder`, with an identical query surface
+ * (`setFields`/`addInstruction`/…). The only difference is `setRpc(...)` in place of
+ * `setPortal(...)`. Block ranges are expressed in **slots**, matching the Portal numbering.
+ *
+ * @example
+ * const source = new SolanaRpcDataSourceBuilder()
+ *     .setRpc({url: RPC_URL})
+ *     .setFields({instruction: {programId: true, data: true}})
+ *     .addInstruction({where: {programId: [PROGRAM_ID]}, range: {from: 250_000_000}})
+ *     .build()
+ */
+export class SolanaRpcDataSourceBuilder<F extends FieldSelection = {}> extends SolanaQueryBuilder {
+    private options?: SolanaRpcOptions
+
+    /**
+     * Configure the JSON-RPC endpoint — a bare URL, or {@link SolanaRpcOptions} for connection
+     * tuning.
+     */
+    setRpc(options: string | SolanaRpcOptions): this {
+        this.options = typeof options === 'string' ? {url: options} : options
+        return this
+    }
+
+    /** Configure the set of fetched fields — infers the block type `F` for `build()`. */
+    setFields<T extends FieldSelection>(fields: T): SolanaRpcDataSourceBuilder<T> {
+        this.fields = fields
+        return this as unknown as SolanaRpcDataSourceBuilder<T>
+    }
+
+    /** Build the RPC data source from this builder's field selection + query. */
+    build(): SolanaRpcStreamDataSource<F> {
+        assert(this.options, 'RPC endpoint not set — call setRpc(...)')
+        return solanaRpcStream({...this.options, fields: this.fields as F, requests: this.getRequests()})
+    }
+}

--- a/meta/squid-sdk/src/solana/rpc/decode/decode.ts
+++ b/meta/squid-sdk/src/solana/rpc/decode/decode.ts
@@ -1,0 +1,46 @@
+import {Block as NormalizedBlock} from '@subsquid/solana-normalization'
+import {Block, FieldSelection, mapBlock} from '@subsquid/solana-stream'
+import {solana} from '@subsquid/portal-client'
+import {toJSON} from '@subsquid/util-internal-json'
+import {cast} from '@subsquid/util-internal-validation'
+
+/**
+ * The Portal source's field-selection augmentation: every item's *required* fields are forced on
+ * regardless of the user selection, so the decoded items always carry their identity/navigation
+ * keys. Mirrors the (private) `mapFieldSelection` of `@subsquid/solana-stream`'s Portal source —
+ * kept in sync by the parity e2e test.
+ */
+export function mapFieldSelection(fields: FieldSelection) {
+    return {
+        block: fields.block,
+        transaction: {...fields.transaction, transactionIndex: true},
+        instruction: {...fields.instruction, transactionIndex: true, instructionAddress: true},
+        log: {...fields.log, logIndex: true, transactionIndex: true, instructionAddress: true},
+        balance: {...fields.balance, transactionIndex: true, account: true},
+        tokenBalance: {...fields.tokenBalance, transactionIndex: true, account: true},
+        reward: {...fields.reward, pubkey: true},
+    } satisfies solana.FieldSelection
+}
+
+export type MapFieldSelection = ReturnType<typeof mapFieldSelection>
+
+/**
+ * Decode an already-serialized wire block (the `toJSON` of a normalized block) into the
+ * Portal `Block<F>` model by reusing the **exact** Portal decoder: the shared
+ * `getBlockSchema`/`patchQueryFields` + `cast`, then the Portal source's exported `mapBlock`.
+ * Reusing the producer's decoder is what makes the RPC source's output byte-identical to the
+ * Portal source's (including its `timestamp` seconds→ms conversion).
+ */
+export function decodeWireBlock<F extends FieldSelection>(wire: unknown, fields: F): Block<F> {
+    let schema = solana.getBlockSchema(solana.patchQueryFields(mapFieldSelection(fields)))
+    let decoded = cast(schema, wire) as solana.Block<MapFieldSelection>
+
+    return mapBlock<F>(decoded)
+}
+
+/**
+ * Decode a normalized RPC block (`mapRpcBlock` output) into the Portal `Block<F>` model.
+ */
+export function decodeBlock<F extends FieldSelection>(block: NormalizedBlock, fields: F): Block<F> {
+    return decodeWireBlock(toJSON(block), fields)
+}

--- a/meta/squid-sdk/src/solana/rpc/filter/filter.test.ts
+++ b/meta/squid-sdk/src/solana/rpc/filter/filter.test.ts
@@ -25,6 +25,7 @@ function mkBlock(): Block {
         ],
         logs: [
             {transactionIndex: 0, logIndex: 0, instructionAddress: [0], programId: TOKEN_PROGRAM, kind: 'log'},
+            {transactionIndex: 0, logIndex: 1, instructionAddress: [0, 0], programId: OTHER_PROGRAM, kind: 'log'},
             {transactionIndex: 1, logIndex: 0, instructionAddress: [0], programId: OTHER_PROGRAM, kind: 'log'},
         ],
         balances: [
@@ -78,7 +79,8 @@ describe('filterBlockItems', () => {
         expect(block.transactions.map((tx) => tx.transactionIndex)).toEqual([0])
         // the matched instruction plus its inner instruction, in address order
         expect(block.instructions.map((i) => i.instructionAddress)).toEqual([[0], [0, 0]])
-        expect(block.logs.map((l) => l.transactionIndex)).toEqual([0])
+        // logs of the instruction itself AND of its inner instructions
+        expect(block.logs.map((l) => l.instructionAddress)).toEqual([[0], [0, 0]])
     })
 
     it('filters transactions by fee payer and pulls their items via include', () => {

--- a/meta/squid-sdk/src/solana/rpc/filter/filter.test.ts
+++ b/meta/squid-sdk/src/solana/rpc/filter/filter.test.ts
@@ -1,0 +1,135 @@
+import type {Block} from '@subsquid/solana-normalization'
+import {getInstructionDescriptor} from '@subsquid/solana-stream'
+import {describe, expect, it} from 'vitest'
+
+import {filterBlockItems} from './filter'
+
+const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+const OTHER_PROGRAM = 'ComputeBudget111111111111111111111111111111'
+const FEE_PAYER = 'FeePayer1111111111111111111111111111111111'
+
+// Minimal normalized block stub: only the fields the filter engine touches are populated.
+function mkBlock(): Block {
+    return {
+        header: {} as Block['header'],
+        transactions: [
+            {transactionIndex: 0, accountKeys: [FEE_PAYER, 'x']},
+            {transactionIndex: 1, accountKeys: ['someone-else', 'y']},
+        ],
+        instructions: [
+            // tx 0: a token instruction with one inner instruction
+            {transactionIndex: 0, instructionAddress: [0], programId: TOKEN_PROGRAM, accounts: ['acc0', 'acc1'], data: '3Bxs4h24hBtQy9rw', isCommitted: true},
+            {transactionIndex: 0, instructionAddress: [0, 0], programId: OTHER_PROGRAM, accounts: ['acc2'], data: '11', isCommitted: true},
+            // tx 1: an unrelated top-level instruction
+            {transactionIndex: 1, instructionAddress: [0], programId: OTHER_PROGRAM, accounts: [], data: '11', isCommitted: true},
+        ],
+        logs: [
+            {transactionIndex: 0, logIndex: 0, instructionAddress: [0], programId: TOKEN_PROGRAM, kind: 'log'},
+            {transactionIndex: 1, logIndex: 0, instructionAddress: [0], programId: OTHER_PROGRAM, kind: 'log'},
+        ],
+        balances: [
+            {transactionIndex: 0, account: 'acc0'},
+            {transactionIndex: 1, account: 'acc9'},
+        ],
+        tokenBalances: [
+            {transactionIndex: 0, account: 'acc1', postMint: 'mint-a'},
+            {transactionIndex: 1, account: 'acc9', postMint: 'mint-b'},
+        ],
+        rewards: [{pubkey: 'validator-1'}, {pubkey: 'validator-2'}],
+    } as unknown as Block
+}
+
+describe('filterBlockItems', () => {
+    it('keeps only matching instructions and drops everything unrequested', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {instructions: [{where: {programId: [TOKEN_PROGRAM]}}]})
+
+        expect(block.instructions.map((i) => i.programId)).toEqual([TOKEN_PROGRAM])
+        expect(block.transactions).toEqual([])
+        expect(block.logs).toEqual([])
+        expect(block.balances).toEqual([])
+        expect(block.tokenBalances).toEqual([])
+        expect(block.rewards).toEqual([])
+    })
+
+    it('matches instructions by discriminator prefix', () => {
+        let block = mkBlock()
+        let d = getInstructionDescriptor(block.instructions[0] as any)
+
+        filterBlockItems(block, {instructions: [{where: {d1: [d.slice(0, 4)]}}]})
+        expect(block.instructions.map((i) => i.programId)).toEqual([TOKEN_PROGRAM])
+
+        let block2 = mkBlock()
+        filterBlockItems(block2, {instructions: [{where: {discriminator: ['0xffff']}}]})
+        expect(block2.instructions).toEqual([])
+    })
+
+    it('includes instruction relations: parent transaction, inner instructions, and own logs', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {
+            instructions: [
+                {
+                    where: {programId: [TOKEN_PROGRAM]},
+                    include: {transaction: true, innerInstructions: true, logs: true},
+                },
+            ],
+        })
+
+        expect(block.transactions.map((tx) => tx.transactionIndex)).toEqual([0])
+        // the matched instruction plus its inner instruction, in address order
+        expect(block.instructions.map((i) => i.instructionAddress)).toEqual([[0], [0, 0]])
+        expect(block.logs.map((l) => l.transactionIndex)).toEqual([0])
+    })
+
+    it('filters transactions by fee payer and pulls their items via include', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {
+            transactions: [{where: {feePayer: [FEE_PAYER]}, include: {instructions: true, balances: true}}],
+        })
+
+        expect(block.transactions.map((tx) => tx.transactionIndex)).toEqual([0])
+        expect(block.instructions.map((i) => i.transactionIndex)).toEqual([0, 0])
+        expect(block.balances.map((b) => b.account)).toEqual(['acc0'])
+        expect(block.tokenBalances).toEqual([])
+    })
+
+    it('filters logs and navigates to their instruction', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {
+            logs: [{where: {programId: [TOKEN_PROGRAM]}, include: {instruction: true, transaction: true}}],
+        })
+
+        expect(block.logs.map((l) => l.transactionIndex)).toEqual([0])
+        expect(block.instructions.map((i) => i.instructionAddress)).toEqual([[0]])
+        expect(block.transactions.map((tx) => tx.transactionIndex)).toEqual([0])
+    })
+
+    it('filters token balances and rewards by their own keys', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {
+            tokenBalances: [{where: {postMint: ['mint-a']}}],
+            rewards: [{where: {pubkey: ['validator-2']}}],
+        })
+
+        expect(block.tokenBalances.map((b) => b.account)).toEqual(['acc1'])
+        expect(block.rewards.map((r) => r.pubkey)).toEqual(['validator-2'])
+    })
+
+    it('a match-all filter for an item type keeps every item of that type', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {balances: [{}]})
+
+        expect(block.balances).toHaveLength(2)
+        expect(block.transactions).toEqual([])
+    })
+
+    it('an empty request drops all items', () => {
+        let block = mkBlock()
+        filterBlockItems(block, {})
+
+        expect(block.transactions).toEqual([])
+        expect(block.instructions).toEqual([])
+        expect(block.logs).toEqual([])
+        expect(block.rewards).toEqual([])
+    })
+})

--- a/meta/squid-sdk/src/solana/rpc/filter/filter.ts
+++ b/meta/squid-sdk/src/solana/rpc/filter/filter.ts
@@ -1,0 +1,360 @@
+import {Balance, Block, Instruction, LogMessage, Reward, TokenBalance, Transaction} from '@subsquid/solana-normalization'
+import {
+    BalanceRequestRelations,
+    DataRequest,
+    InstructionRequestRelations,
+    LogRequestRelations,
+    TokenBalanceRequestRelations,
+    TransactionRequestRelations,
+    getInstructionDescriptor,
+} from '@subsquid/solana-stream'
+import {bisect, groupBy, weakMemo} from '@subsquid/util-internal'
+import {EntityFilter, FilterBuilder} from '@subsquid/util-internal-processor-tools'
+import assert from 'assert'
+
+/**
+ * Client-side filter engine for RPC-ingested Solana blocks, ported from the legacy
+ * `@subsquid/solana-stream` `ds-rpc` module and extended to the full modern `where` surface
+ * (`d3`, variable-length `discriminator`). It consumes the *stream* `DataRequest` directly —
+ * `where`/`include` need no flattening — and runs on the **full normalized block** before
+ * field projection, so `where` clauses never reference a missing field and no post-filter
+ * projection pass is needed (unlike the EVM engine, which filters decoded blocks).
+ */
+
+function buildTransactionFilter(dataRequest: DataRequest): EntityFilter<Transaction, TransactionRequestRelations> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.transactions ?? []) {
+        let filter = new FilterBuilder<Transaction>()
+        let where = req.where || {}
+        filter.getIn((tx) => tx.accountKeys[0], where.feePayer)
+        items.add(filter, req.include || {})
+    }
+    return items
+}
+
+function buildInstructionFilter(dataRequest: DataRequest): EntityFilter<Instruction, InstructionRequestRelations> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.instructions ?? []) {
+        let filter = new FilterBuilder<Instruction>()
+        let where = req.where || {}
+        filter.propIn('programId', where.programId)
+        // d1–d4 and the generic `discriminator` are data prefixes of varying length; d8 spans the
+        // full 8-byte descriptor, so exact matching suffices there.
+        filter.matchAny((i, d) => getInstructionDescriptor(i).startsWith(d), where.d1)
+        filter.matchAny((i, d) => getInstructionDescriptor(i).startsWith(d), where.d2)
+        filter.matchAny((i, d) => getInstructionDescriptor(i).startsWith(d), where.d3)
+        filter.matchAny((i, d) => getInstructionDescriptor(i).startsWith(d), where.d4)
+        filter.getIn(getInstructionDescriptor, where.d8)
+        filter.matchAny((i, d) => getInstructionDescriptor(i).startsWith(d), where.discriminator)
+        filter.getIn((i) => i.accounts[0], where.a0)
+        filter.getIn((i) => i.accounts[1], where.a1)
+        filter.getIn((i) => i.accounts[2], where.a2)
+        filter.getIn((i) => i.accounts[3], where.a3)
+        filter.getIn((i) => i.accounts[4], where.a4)
+        filter.getIn((i) => i.accounts[5], where.a5)
+        filter.getIn((i) => i.accounts[6], where.a6)
+        filter.getIn((i) => i.accounts[7], where.a7)
+        filter.getIn((i) => i.accounts[8], where.a8)
+        filter.getIn((i) => i.accounts[9], where.a9)
+        if (where.isCommitted != null) {
+            filter.propIn('isCommitted', [where.isCommitted])
+        }
+        items.add(filter, req.include ?? {})
+    }
+    return items
+}
+
+function buildLogFilter(dataRequest: DataRequest): EntityFilter<LogMessage, LogRequestRelations> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.logs ?? []) {
+        let filter = new FilterBuilder<LogMessage>()
+        let where = req.where ?? {}
+        filter.propIn('programId', where.programId)
+        filter.propIn('kind', where.kind)
+        items.add(filter, req.include ?? {})
+    }
+    return items
+}
+
+function buildBalanceFilter(dataRequest: DataRequest): EntityFilter<Balance, BalanceRequestRelations> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.balances ?? []) {
+        let filter = new FilterBuilder<Balance>()
+        let where = req.where || {}
+        filter.propIn('account', where.account)
+        items.add(filter, req.include || {})
+    }
+    return items
+}
+
+function buildTokenBalanceFilter(dataRequest: DataRequest): EntityFilter<TokenBalance, TokenBalanceRequestRelations> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.tokenBalances ?? []) {
+        let filter = new FilterBuilder<TokenBalance>()
+        let where = req.where || {}
+        filter.propIn('account', where.account)
+        filter.propIn('preProgramId', where.preProgramId)
+        filter.propIn('postProgramId', where.postProgramId)
+        filter.propIn('preMint', where.preMint)
+        filter.propIn('postMint', where.postMint)
+        filter.propIn('preOwner', where.preOwner)
+        filter.propIn('postOwner', where.postOwner)
+        items.add(filter, req.include || {})
+    }
+    return items
+}
+
+function buildRewardsFilter(dataRequest: DataRequest): EntityFilter<Reward, {}> {
+    let items = new EntityFilter()
+    for (let req of dataRequest.rewards ?? []) {
+        let filter = new FilterBuilder<Reward>()
+        let where = req.where || {}
+        filter.propIn('pubkey', where.pubkey)
+        items.add(filter, {})
+    }
+    return items
+}
+
+const getItemFilters = weakMemo((req: DataRequest) => {
+    return {
+        transactions: buildTransactionFilter(req),
+        instructions: buildInstructionFilter(req),
+        logs: buildLogFilter(req),
+        balances: buildBalanceFilter(req),
+        tokenBalances: buildTokenBalanceFilter(req),
+        rewards: buildRewardsFilter(req),
+    }
+})
+
+class IncludeSet {
+    transactions = new Set<Transaction>()
+    instructions = new Set<Instruction>()
+    logs = new Set<LogMessage>()
+    balances = new Set<Balance>()
+    tokenBalances = new Set<TokenBalance>()
+    rewards = new Set<Reward>()
+}
+
+/** Filter the block's item arrays in place, applying the request's `where`/`include` clauses. */
+export function filterBlockItems(block: Block, req: DataRequest): void {
+    new BlockFilter(block, req).apply()
+}
+
+class BlockFilter {
+    private include = new IncludeSet()
+    private items: ReturnType<typeof getItemFilters>
+
+    // Lazily-built per-block indexes.
+    private _transactions?: Map<number, Transaction>
+    private _logsByTx?: Map<number, LogMessage[]>
+    private _instructionsByTx?: Map<number, Instruction[]>
+    private _balancesByTx?: Map<number, Balance[]>
+    private _tokenBalancesByTx?: Map<number, TokenBalance[]>
+
+    constructor(
+        private block: Block,
+        req: DataRequest,
+    ) {
+        this.items = getItemFilters(req)
+    }
+
+    private transactions(): Map<number, Transaction> {
+        return (this._transactions ??= new Map(this.block.transactions.map((tx) => [tx.transactionIndex, tx])))
+    }
+
+    private getTransaction(idx: number): Transaction {
+        let tx = this.transactions().get(idx)
+        assert(tx)
+        return tx
+    }
+
+    private logsByTx(): Map<number, LogMessage[]> {
+        return (this._logsByTx ??= groupBy(this.block.logs, (log) => log.transactionIndex))
+    }
+
+    private instructionsByTx(): Map<number, Instruction[]> {
+        return (this._instructionsByTx ??= groupBy(this.block.instructions, (i) => i.transactionIndex))
+    }
+
+    private balancesByTx(): Map<number, Balance[]> {
+        return (this._balancesByTx ??= groupBy(this.block.balances, (b) => b.transactionIndex))
+    }
+
+    private tokenBalancesByTx(): Map<number, TokenBalance[]> {
+        return (this._tokenBalancesByTx ??= groupBy(this.block.tokenBalances, (b) => b.transactionIndex))
+    }
+
+    private filterTransactions(): void {
+        if (!this.items.transactions.present()) return
+        for (let tx of this.block.transactions) {
+            let rel = this.items.transactions.match(tx)
+            if (rel == null) continue
+            this.include.transactions.add(tx)
+            if (rel.logs) {
+                include(this.include.logs, this.logsByTx().get(tx.transactionIndex))
+            }
+            if (rel.instructions) {
+                include(this.include.instructions, this.instructionsByTx().get(tx.transactionIndex))
+            }
+            if (rel.balances) {
+                include(this.include.balances, this.balancesByTx().get(tx.transactionIndex))
+            }
+            if (rel.tokenBalances) {
+                include(this.include.tokenBalances, this.tokenBalancesByTx().get(tx.transactionIndex))
+            }
+        }
+    }
+
+    private filterInstructions(): void {
+        if (!this.items.instructions.present()) return
+        for (let i = 0; i < this.block.instructions.length; i++) {
+            let ins = this.block.instructions[i]
+            let rel = this.items.instructions.match(ins)
+            if (rel == null) continue
+            this.include.instructions.add(ins)
+            if (rel.innerInstructions) {
+                // Instructions are ordered by (transactionIndex, instructionAddress); a child run
+                // directly follows its parent, so scan forward until the prefix stops matching.
+                for (let j = i + 1; j < this.block.instructions.length; j++) {
+                    let child = this.block.instructions[j]
+                    if (
+                        ins.transactionIndex == child.transactionIndex &&
+                        isChildAddress(ins.instructionAddress, child.instructionAddress)
+                    ) {
+                        this.include.instructions.add(child)
+                    } else {
+                        break
+                    }
+                }
+            }
+            if (rel.logs) {
+                let logs = this.logsByTx().get(ins.transactionIndex) ?? []
+                include(this.include.logs, findInstructionChildren(logs, ins.instructionAddress))
+            }
+            if (rel.transaction) {
+                this.include.transactions.add(this.getTransaction(ins.transactionIndex))
+            }
+            if (rel.transactionBalances) {
+                include(this.include.balances, this.balancesByTx().get(ins.transactionIndex))
+            }
+            if (rel.transactionTokenBalances) {
+                include(this.include.tokenBalances, this.tokenBalancesByTx().get(ins.transactionIndex))
+            }
+            if (rel.transactionInstructions) {
+                include(this.include.instructions, this.instructionsByTx().get(ins.transactionIndex))
+            }
+        }
+    }
+
+    private filterLogs(): void {
+        if (!this.items.logs.present()) return
+        for (let log of this.block.logs) {
+            let rel = this.items.logs.match(log)
+            if (rel == null) continue
+            this.include.logs.add(log)
+            if (rel.transaction) {
+                this.include.transactions.add(this.getTransaction(log.transactionIndex))
+            }
+            if (rel.instruction) {
+                this.include.instructions.add(this.getInstruction(log.transactionIndex, log.instructionAddress))
+            }
+        }
+    }
+
+    private getInstruction(transactionIdx: number, address: number[]): Instruction {
+        let pos = bisect(
+            this.block.instructions,
+            null,
+            (ins) => ins.transactionIndex - transactionIdx || addressCompare(ins.instructionAddress, address),
+        )
+        let ins = this.block.instructions[pos]
+        assert(ins && ins.transactionIndex == transactionIdx && addressCompare(ins.instructionAddress, address) == 0)
+        return ins
+    }
+
+    private filterTokenBalances(): void {
+        if (!this.items.tokenBalances.present()) return
+        for (let balance of this.block.tokenBalances) {
+            let rel = this.items.tokenBalances.match(balance)
+            if (rel == null) continue
+            this.include.tokenBalances.add(balance)
+            if (rel.transaction) {
+                this.include.transactions.add(this.getTransaction(balance.transactionIndex))
+            }
+            if (rel.transactionInstructions) {
+                include(this.include.instructions, this.instructionsByTx().get(balance.transactionIndex))
+            }
+        }
+    }
+
+    private filterBalances(): void {
+        if (!this.items.balances.present()) return
+        for (let balance of this.block.balances) {
+            let rel = this.items.balances.match(balance)
+            if (rel == null) continue
+            this.include.balances.add(balance)
+            if (rel.transaction) {
+                this.include.transactions.add(this.getTransaction(balance.transactionIndex))
+            }
+            if (rel.transactionInstructions) {
+                include(this.include.instructions, this.instructionsByTx().get(balance.transactionIndex))
+            }
+        }
+    }
+
+    private filterRewards(): void {
+        if (!this.items.rewards.present() || this.block.rewards == null) return
+        for (let reward of this.block.rewards) {
+            if (this.items.rewards.match(reward)) {
+                this.include.rewards.add(reward)
+            }
+        }
+    }
+
+    apply(): void {
+        this.filterTransactions()
+        this.filterInstructions()
+        this.filterLogs()
+        this.filterBalances()
+        this.filterTokenBalances()
+        this.filterRewards()
+        this.block.transactions = this.block.transactions.filter((i) => this.include.transactions.has(i))
+        this.block.instructions = this.block.instructions.filter((i) => this.include.instructions.has(i))
+        this.block.logs = this.block.logs.filter((i) => this.include.logs.has(i))
+        this.block.balances = this.block.balances.filter((i) => this.include.balances.has(i))
+        this.block.tokenBalances = this.block.tokenBalances.filter((i) => this.include.tokenBalances.has(i))
+        this.block.rewards = this.block.rewards.filter((i) => this.include.rewards.has(i))
+    }
+}
+
+function include<T>(set: Set<T>, items?: Iterable<T>): void {
+    if (items == null) return
+    for (let it of items) {
+        set.add(it)
+    }
+}
+
+function* findInstructionChildren<I extends {instructionAddress: number[]}>(items: I[], addr: number[]): Iterable<I> {
+    if (items.length == 0) return
+    let beg = bisect(items, addr, (ins, a) => addressCompare(ins.instructionAddress, a))
+    while (beg < items.length && isChildAddress(items[beg].instructionAddress, addr)) {
+        yield items[beg]
+        beg += 1
+    }
+}
+
+function isChildAddress(parent: number[], addr: number[]): boolean {
+    if (parent.length > addr.length) return false
+    for (let i = 0; i < parent.length; i++) {
+        if (parent[i] !== addr[i]) return false
+    }
+    return true
+}
+
+function addressCompare(a: number[], b: number[]): number {
+    for (let i = 0; i < Math.min(a.length, b.length); i++) {
+        let order = a[i] - b[i]
+        if (order) return order
+    }
+    return a.length - b.length
+}

--- a/meta/squid-sdk/src/solana/rpc/filter/filter.ts
+++ b/meta/squid-sdk/src/solana/rpc/filter/filter.ts
@@ -337,7 +337,9 @@ function include<T>(set: Set<T>, items?: Iterable<T>): void {
 function* findInstructionChildren<I extends {instructionAddress: number[]}>(items: I[], addr: number[]): Iterable<I> {
     if (items.length == 0) return
     let beg = bisect(items, addr, (ins, a) => addressCompare(ins.instructionAddress, a))
-    while (beg < items.length && isChildAddress(items[beg].instructionAddress, addr)) {
+    // `addr` is the parent: keep every item whose address it prefixes (the instruction itself and
+    // its inner instructions' items — a contiguous run in (transaction, address) order).
+    while (beg < items.length && isChildAddress(addr, items[beg].instructionAddress)) {
         yield items[beg]
         beg += 1
     }

--- a/meta/squid-sdk/src/solana/rpc/index.ts
+++ b/meta/squid-sdk/src/solana/rpc/index.ts
@@ -1,0 +1,7 @@
+export * from './filter/filter'
+export * from './decode/decode'
+export * from './source/data-source'
+// `solanaRpcStream` / `SolanaRpcStreamConfig` are internal construction primitives — the public
+// surface is the fluent `SolanaRpcDataSourceBuilder` (used standalone, or via a `{type: 'rpc'}`
+// fallback source).
+export {SolanaRpcDataSourceBuilder, type SolanaRpcOptions} from './builder'

--- a/meta/squid-sdk/src/solana/rpc/source/data-source.ts
+++ b/meta/squid-sdk/src/solana/rpc/source/data-source.ts
@@ -1,0 +1,144 @@
+import {mapRpcBlock} from '@subsquid/solana-normalization'
+import {Block as RpcBlock, RpcApi, SolanaRpcDataSource} from '@subsquid/solana-rpc'
+import {Block, DataRequest, FieldSelection} from '@subsquid/solana-stream'
+import {createLogger} from '@subsquid/logger'
+import {BlockBatch, BlockRef, BlockStream, DataSource, StreamRequest} from '@subsquid/util-internal-data-source'
+import {FiniteRange, RangeRequestList, getSize} from '@subsquid/util-internal-range'
+
+import {dropEmptyBlocks, streamBoundedRanges} from '../../../common/bounded-stream'
+import {decodeBlock} from '../decode/decode'
+import {filterBlockItems} from '../filter/filter'
+
+const log = createLogger('sqd:solana-rpc')
+
+export interface SolanaRpcStreamOptions<F extends FieldSelection> {
+    rpc: RpcApi
+    fields: F
+    requests: RangeRequestList<DataRequest>
+    strideSize?: number
+    strideConcurrency?: number
+}
+
+const rpcBlockRef = (b: RpcBlock): BlockRef => ({number: b.slot, hash: b.block.blockhash})
+
+/**
+ * An RPC-backed `DataSource<Block<F>>` whose output matches the Portal source's. It delegates
+ * streaming, finality tracking, continuity and fork detection to `@subsquid/solana-rpc`'s
+ * `SolanaRpcDataSource` (which throws the same `ForkException` the processor handles), then maps
+ * every raw block through `@subsquid/solana-normalization` and the ported client-side filter
+ * engine, and finally decodes through the reused Portal decoder (`decodeBlock`) so the result is
+ * shaped exactly as the Portal source produces.
+ *
+ * Unlike the EVM adapter, filtering happens on the **full normalized block**, before field
+ * projection — so `where` clauses never reference a missing field and no augmentation/projection
+ * machinery is needed. `includeAllBlocks` is honored like the Portal: when it is false for a
+ * block's range, a block left empty by filtering is dropped (interior blocks only — batch
+ * boundaries always survive).
+ *
+ * Blocks are keyed by **slot** throughout, matching the Portal dataset numbering.
+ */
+export class SolanaRpcStreamDataSource<F extends FieldSelection> implements DataSource<Block<F>> {
+    private inner: SolanaRpcDataSource
+    private fields: F
+    private requests: RangeRequestList<DataRequest>
+
+    constructor(options: SolanaRpcStreamOptions<F>) {
+        this.fields = options.fields
+        this.requests = options.requests
+
+        this.inner = new SolanaRpcDataSource({
+            rpc: options.rpc,
+            req: coarseRequest(options.requests),
+            strideSize: options.strideSize ?? 5,
+            strideConcurrency: options.strideConcurrency ?? 5,
+        })
+    }
+
+    getHead(): Promise<BlockRef> {
+        return this.inner.getHead()
+    }
+
+    getFinalizedHead(): Promise<BlockRef> {
+        return this.inner.getFinalizedHead()
+    }
+
+    async *getFinalizedStream(req: StreamRequest): BlockStream<Block<F>> {
+        for await (let batch of streamBoundedRanges(this.inner, this.requests, req, true, rpcBlockRef)) {
+            yield this.mapBatch(batch)
+        }
+    }
+
+    async *getStream(req: StreamRequest): BlockStream<Block<F>> {
+        for await (let batch of streamBoundedRanges(this.inner, this.requests, req, false, rpcBlockRef)) {
+            yield this.mapBatch(batch)
+        }
+    }
+
+    getBlocksCountInRange(range: FiniteRange): number {
+        return getSize(
+            this.requests.map((r) => r.range),
+            range,
+        )
+    }
+
+    private mapBatch(batch: BlockBatch<RpcBlock>): BlockBatch<Block<F>> {
+        let blocks = batch.blocks.map((raw) => this.mapBlock(raw))
+
+        return {
+            blocks: dropEmptyBlocks(
+                blocks,
+                (slot) => this.requestFor(slot)?.includeAllBlocks ?? false,
+                (b) => b.header.number,
+                (b) =>
+                    b.transactions.length > 0 ||
+                    b.instructions.length > 0 ||
+                    b.logs.length > 0 ||
+                    b.balances.length > 0 ||
+                    b.tokenBalances.length > 0 ||
+                    b.rewards.length > 0,
+            ),
+            finalizedHead: batch.finalizedHead,
+        }
+    }
+
+    private mapBlock(raw: RpcBlock): Block<F> {
+        let normalized = mapRpcBlock(raw.slot, raw.block, log)
+        let request = this.requestFor(raw.slot)
+        if (request) {
+            filterBlockItems(normalized, request)
+        }
+        return decodeBlock(normalized, this.fields)
+    }
+
+    private requestFor(slot: number): DataRequest | undefined {
+        for (let {range, request} of this.requests) {
+            if (range.from <= slot && (range.to == null || slot <= range.to)) {
+                return request
+            }
+        }
+
+        return undefined
+    }
+}
+
+/**
+ * Union the per-range stream requests into the coarse `@subsquid/solana-rpc` data request: any
+ * transaction-derived item filter (transactions, instructions, logs, balances, token balances)
+ * needs full transaction details; rewards fetch only when a reward filter is present. A block's
+ * unrequested sections are never fetched — mirroring what the Portal serves for the same query.
+ */
+export function coarseRequest(requests: RangeRequestList<DataRequest>): {transactions: boolean; rewards: boolean} {
+    let transactions = false
+    let rewards = false
+    for (let {request} of requests) {
+        transactions ||= !!(
+            request.transactions?.length ||
+            request.instructions?.length ||
+            request.logs?.length ||
+            request.balances?.length ||
+            request.tokenBalances?.length
+        )
+        rewards ||= !!request.rewards?.length
+    }
+    return {transactions, rewards}
+}

--- a/solana/solana-stream/src/index.ts
+++ b/solana/solana-stream/src/index.ts
@@ -1,4 +1,5 @@
 export * from './data/model'
+export type * from './data/request'
 export * from './instruction'
 export * from './builder'
 export * from './query'


### PR DESCRIPTION
## What

Ports the EVM RPC + fallback streams to Solana, packaged identically under the megapackage:

- **`@subsquid/squid-sdk/solana/rpc`** — `SolanaRpcDataSourceBuilder`, the RPC counterpart of `@subsquid/solana-stream`'s `DataSourceBuilder` with an identical query surface (`setFields`/`addInstruction`/`addLog`/…, slot-keyed ranges). Only `setRpc(...)` replaces `setPortal(...)`.
- **`@subsquid/squid-sdk/solana/fallback`** — `SolanaFallbackDataSourceBuilder` over the shared chain-agnostic fallback core: ordered `portal`/`rpc`/`custom` tagged sources, one shared query applied to every source, capability probe, automatic `sqd_fallback_*` gauges, same `FallbackPolicy`.

## Design (mirrors the EVM port)

- The RPC source wraps `@subsquid/solana-rpc`'s `SolanaRpcDataSource` (continuity, finality, forks), normalizes via `@subsquid/solana-normalization`, filters client-side, and decodes through the **reused Portal decoder** (`solana.getBlockSchema` + the Portal source's exported `mapBlock`) so output is shaped exactly as the Portal source produces.
- The filter engine is ported from the legacy `solana-stream` `ds-rpc` module (extracted from git history at `8ce76093^`), extended to the modern `where` surface (`d3`, variable-length `discriminator`). Two simplifications vs EVM: filtering runs on the **full normalized block before projection** (no field-augmentation/projection machinery), and there is **no per-network preset layer** (the Solana RPC surface is uniform; normalization produces the exact model the Portal datasets are built from).
- `@subsquid/solana-rpc` + `@subsquid/solana-normalization` are **optional peers**, loaded lazily only when an `rpc` source is built, with an actionable missing-peer error.
- The bounded-range streaming + Portal-compatible empty-block dropping is extracted from `evm/rpc` into `src/common/bounded-stream.ts` and shared by both adapters.
- `@subsquid/solana-stream` now exports its data request types from the barrel (`DataRequest`, item request/relations interfaces) — `evm-stream` already exported its equivalents.

## Testing

- `tsc --noEmit` clean; full vitest suite: 100 passed / 5 skipped (includes new tests for the fallback builder wiring, missing-peer translation, RPC builder, coarse request derivation, and the filter engine's where/include semantics).
- `rush build --to @subsquid/squid-sdk` green; `solana-stream` suite still green after the barrel change.
- Rush change files included for both touched packages (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2n1VHrhUa2szzVMW3mrkY