### PR TITLE
fix(typeorm-codegen): avoid unused Column imports

### DIFF
--- a/common/changes/@subsquid/typeorm-codegen/master_2026-08-11-18-53.json
+++ b/common/changes/@subsquid/typeorm-codegen/master_2026-08-11-18-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Avoid unused Column imports in generated models",
+      "type": "patch",
+      "packageName": "@subsquid/typeorm-codegen"
+    }
+  ],
+  "packageName": "@subsquid/typeorm-codegen",
+  "email": "zln1905391059@163.com"
+}

--- a/typeorm/typeorm-codegen/src/codegen.test.ts
+++ b/typeorm/typeorm-codegen/src/codegen.test.ts
@@ -71,6 +71,67 @@ describe('generateOrmModels — entity table name pruning (PR #514)', () => {
 
 // docs-beta/en/sdk/squid-sdk/reference/schema-file/entities.mdx (+ intro.mdx)
 describe('scalars, id and nullability', () => {
+    it('only imports Column when generated fields use it', () => {
+        const generated = generate(`
+            type ScalarOnly @entity {
+                id: ID!
+                name: String!
+            }
+
+            type WithEnum @entity {
+                id: ID!
+                status: Status!
+            }
+
+            type WithEnumArray @entity {
+                id: ID!
+                statuses: [Status!]!
+            }
+
+            type WithObject @entity {
+                id: ID!
+                metadata: Metadata!
+            }
+
+            type WithUnion @entity {
+                id: ID!
+                owner: Owner!
+            }
+
+            type WithLists @entity {
+                id: ID!
+                metadata: [Metadata!]!
+                owners: [Owner!]!
+                matrix: [[Int!]!]!
+            }
+
+            enum Status { ACTIVE }
+            type Metadata { name: String! }
+            type User { id: String! }
+            type Team { id: String! }
+            union Owner = User | Team
+        `)
+
+        const scalarOnly = generated.read('scalarOnly.model.ts')
+        expect(scalarOnly).not.toMatch(/\bColumn as Column_\b/)
+        expect(scalarOnly).toContain(
+            'import {Entity as Entity_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_} from "@subsquid/typeorm-store"',
+        )
+
+        for (const model of [
+            generated.read('withEnum.model.ts'),
+            generated.read('withEnumArray.model.ts'),
+            generated.read('withObject.model.ts'),
+            generated.read('withUnion.model.ts'),
+            generated.read('withLists.model.ts'),
+        ]) {
+            expect(model).toMatch(/\bColumn as Column_\b/)
+        }
+
+        const lists = generated.read('withLists.model.ts')
+        expect(lists.match(/@Column_\("jsonb"/g)).toHaveLength(3)
+    })
+
     const schema = `
         type Scalar @entity {
             id: ID!

--- a/typeorm/typeorm-codegen/src/codegen.ts
+++ b/typeorm/typeorm-codegen/src/codegen.ts
@@ -106,7 +106,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
         index.line(`export * from "./${toCamelCase(name)}.model"`)
         const out = dir.file(`${toCamelCase(name)}.model.ts`)
         const imports = new ImportRegistry(name)
-        imports.useTypeormStore('Entity', 'Column', 'PrimaryColumn')
+        imports.useTypeormStore('Entity', 'PrimaryColumn')
         out.lazy(() => imports.render(model, out))
         out.line()
         printComment(entity, out)
@@ -148,6 +148,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                         }
                         break
                     case 'enum':
+                        imports.useTypeormStore('Column')
                         addIndexAnnotation(entity, key, imports, out, nameIndex)
                         out.line(
                             `@Column_("varchar", {length: ${getEnumMaxLength(
@@ -193,6 +194,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                         break
                     case 'object':
                     case 'union':
+                        imports.useTypeormStore('Column')
                         imports.useMarshal()
                         out.line(
                             `@Column_("jsonb", {transformer: {to: obj => ${marshalToJson(
@@ -220,6 +222,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                                 break
                             }
                             case 'enum':
+                                imports.useTypeormStore('Column')
                                 out.line(
                                     `@Column_("varchar", {length: ${getEnumMaxLength(
                                         model,
@@ -230,6 +233,7 @@ export function generateOrmModels(model: Model, dir: OutDir): void {
                             case 'object':
                             case 'union':
                             case 'list':
+                                imports.useTypeormStore('Column')
                                 imports.useMarshal()
                                 out.line(
                                     `@Column_("jsonb", {transformer: {to: obj => ${marshalToJson(


### PR DESCRIPTION
Relates to #547.

## Summary

- Avoid importing `Column` into scalar-only generated TypeORM models.
- Preserve `Column` imports for enum and JSONB-backed generated fields.

## Validation

- `node ../../common/scripts/install-run-rushx.js test -- codegen.test.ts` — 49 passed.
- `node ../../common/scripts/install-run-rushx.js test` — 49 passed.
- `node common/scripts/install-run-rush.js build --to @subsquid/typeorm-codegen` — passed.
- `node common/scripts/install-run-rush.js check` — passed.
- `node common/scripts/install-run-rush.js change --verify --target-branch origin/release/arrowsquid` — passed.

## Known limitations

- Repository-wide and scoped Biome checks report existing diagnostics in the touched legacy files; no unrelated formatting changes were made.
- `rush test:lfs` was not run; the local partial clone initially omitted 113 LFS fixtures.
- The full monorepo unit-test suite was not run.