### PR TITLE
fix(evm-rpc): retry transient eRPC ErrEndpointMissingData instead of crashing the dump

### DIFF
--- a/common/changes/@subsquid/evm-rpc/alert-fix-q6M8eq-erpc-missing-data-retry_2026-08-18-20-52.json
+++ b/common/changes/@subsquid/evm-rpc/alert-fix-q6M8eq-erpc-missing-data-retry_2026-08-18-20-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "Retry transient eRPC ErrEndpointMissingData instead of crash-looping the dump",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-rpc/src/rpc.ts
+++ b/evm/evm-rpc/src/rpc.ts
@@ -204,6 +204,9 @@ export class Rpc {
             validateError: info => {
                 if (info.message.includes('cannot query unfinalized data')) return null // Avalanche
                 if (info.message.includes('invalid block height')) throw new RetryError() // Hyperliquid
+                // eRPC routed the block to an upstream that lacks it; a sibling
+                // upstream may have it, so retry instead of crashing the dump.
+                if (info.data?.code === 'ErrEndpointMissingData') throw new RetryError()
                 throw new RpcError(info)
             }
         })

--- a/evm/evm-rpc/test/rpc.missing-data-retry.test.ts
+++ b/evm/evm-rpc/test/rpc.missing-data-retry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { RetryError } from '@subsquid/rpc-client'
+import { Rpc } from '../src/rpc'
+
+// Real error captured from a binance-mainnet dump crash-loop: the eRPC proxy
+// routed eth_getBlockByNumber to an upstream that lacked an already-finalized
+// block (116705561 << finalizedBlock) and returned -32014 / ErrEndpointMissingData.
+const ERPC_MISSING_DATA = {
+    code: -32014,
+    message: 'block not found with number 0x6f4c919',
+    data: {
+        code: 'ErrEndpointMissingData',
+        message: 'remote endpoint does not have this data',
+        details: {
+            upstreamId: 'binance-mainnet-uniblock',
+            latestBlock: 116721620,
+            finalizedBlock: 116721619,
+            maxAvailableRecentBlocks: 0,
+        },
+    },
+}
+
+// Minimal client that routes an error response through validateError, exactly
+// like RpcClient.receiveResult, so the real classification path is exercised.
+class ErrorRpcClient {
+    url = 'mock://erpc'
+    getConcurrency() {
+        return 1
+    }
+    isConnectionError(err: any) {
+        return err instanceof RetryError
+    }
+    async call(): Promise<any> {
+        throw new Error('not used in this test')
+    }
+    async batchCall(batch: { method: string; params?: any[] }[], options?: any): Promise<any[]> {
+        // The server responded with an error for every call in the batch.
+        return batch.map(() => options.validateError(ERPC_MISSING_DATA))
+    }
+}
+
+describe('evm-rpc: transient eRPC "endpoint missing data" is retryable', () => {
+    it('getBlockBatch retries instead of crashing on ErrEndpointMissingData', async () => {
+        const rpc = new Rpc({ client: new ErrorRpcClient() as any })
+        // A finalized block that momentarily missing on one upstream must be
+        // retried (RetryError), not surfaced as a fatal RpcError that crash-loops the dump.
+        await expect(rpc.getBlockBatch([116705561], { transactions: true })).rejects.toBeInstanceOf(
+            RetryError
+        )
+    })
+})


### PR DESCRIPTION
## Cause (proven)

`dump-binance-mainnet-0` (namespace `evm-archive`, image `evm-dump:b1bb0b3`) was in a crash-restart loop, which cascaded into `Writer_Short_Stall`, `Dumper_Pod_Restarts` (×2) and `Ingest_Behind_Head` alerts on binance-mainnet.

Fatal error from the pod logs (identical across restarts — advances ~2 blocks, then dies at the same block):

```
RpcError: block not found with number 0x6f4c919      // block 116705561
  code: -32014
  data: { code: "ErrEndpointMissingData",
          details: { upstreamId: "binance-mainnet-uniblock",
                     latestBlock: 116721620, finalizedBlock: 116721619,
                     maxAvailableRecentBlocks: 0 } }
  at validateError (evm/evm-rpc/lib/rpc.js) ... eth_getBlockByNumber
```

Block `116705561` is **already finalized** (`finalizedBlock` 116721619, ~16k blocks ahead) and **exists on-chain** — verified independently on public BSC: `eth_getBlockByNumber(116705561)` → hash `0xeda50376e351996f951bdee9c1318bfbf614c60d6f9a2b01c34b0a20a6415b4b`. The dump reaches the archive via the eRPC proxy, which momentarily routed the request to an upstream (uniblock) that did not have that block and returned `-32014 / ErrEndpointMissingData`.

In `Rpc.getBlocks()`, `validateError` fell through to `throw new RpcError(info)`, which is **not** a connection/retryable error, so the process crashed instead of retrying — a transient per-upstream data gap became a crash-loop that loses progress and pages.

## Fix

Classify eRPC's `ErrEndpointMissingData` as a `RetryError` in the `eth_getBlockByNumber` error path, mirroring the existing Hyperliquid `invalid block height` handling. The built-in retry machinery then re-issues the request (eRPC can re-route to a healthy upstream, e.g. alchemy), so a single upstream gap degrades to a short, self-healing stall instead of a crash-loop.

```ts
if (info.data?.code === 'ErrEndpointMissingData') throw new RetryError()
```

## Test

`evm/evm-rpc/test/rpc.missing-data-retry.test.ts` drives `getBlockBatch` through the real `validateError` path with the exact prod error object and asserts a retryable error, not a fatal `RpcError`.

- **red** on master: `AssertionError: expected RpcError ... to be an instance of RetryError`
- **green** after this change; full `@subsquid/evm-rpc` suite passes (207 passed, 28 skipped).

Verified locally: `rush build -t @subsquid/evm-rpc` (compiles) and `vitest --run` (red→green).

## Falsification

If the dump still crash-loops on a `-32014 / ErrEndpointMissingData` for an existing finalized block after this deploys, the classification is not catching the error shape (e.g. eRPC nests the code differently) — re-check `info.data?.code`.

## Related (different root cause)

- #551 retries a *malformed result* (deposit tx missing `nonce`, `validateResult` path). This PR handles an *error response* (`validateError` path) — same crash-loop symptom, distinct trigger.

## Operator follow-up (out of scope for this PR)

The trigger was uniblock's BSC endpoint degrading (`maxAvailableRecentBlocks: 0` — not archival for chain 56). In `infra` `erpc/values.yaml`, `binance-mainnet`'s `uniblock` upstream has no `tier: fallback` (unlike `binance-testnet`), so eRPC treats it as a co-primary. An operator should demote/remove uniblock for BSC and/or verify its archival status — a provider mitigation, tracked separately from this durable code fix.
