### PR TITLE
fix(squid-sdk): strip vote transactions in the Solana RPC source, matching Portal numbering

### DIFF
--- a/common/changes/@subsquid/squid-sdk/fix-solana-rpc-vote-parity_2026-08-21.json
+++ b/common/changes/@subsquid/squid-sdk/fix-solana-rpc-vote-parity_2026-08-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/squid-sdk",
+      "comment": "solana/rpc: strip vote transactions before normalization, matching the Portal dataset producers - transactionIndex (and derived item ids) now agree with Portal-sourced data",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/squid-sdk"
+}

--- a/meta/squid-sdk/package.json
+++ b/meta/squid-sdk/package.json
@@ -249,6 +249,7 @@
     "@subsquid/evm-normalization": "^0.0.6",
     "@subsquid/evm-rpc": "^0.1.0",
     "@subsquid/solana-rpc": "^1.0.0",
+    "@subsquid/solana-rpc-data": "^1.0.0",
     "@subsquid/solana-normalization": "^1.0.0"
   },
   "peerDependenciesMeta": {
@@ -259,6 +260,9 @@
       "optional": true
     },
     "@subsquid/solana-rpc": {
+      "optional": true
+    },
+    "@subsquid/solana-rpc-data": {
       "optional": true
     },
     "@subsquid/solana-normalization": {
@@ -274,6 +278,7 @@
     "typescript": "5.5.4",
     "vitest": "4.1.5",
     "@subsquid/solana-rpc": "^1.0.0",
+    "@subsquid/solana-rpc-data": "^1.0.0",
     "@subsquid/solana-normalization": "^1.0.0"
   }
 }

--- a/meta/squid-sdk/src/solana/fallback/load-rpc-stream.ts
+++ b/meta/squid-sdk/src/solana/fallback/load-rpc-stream.ts
@@ -1,4 +1,4 @@
-const RPC_PEERS = ['@subsquid/solana-rpc', '@subsquid/solana-normalization']
+const RPC_PEERS = ['@subsquid/solana-rpc', '@subsquid/solana-rpc-data', '@subsquid/solana-normalization']
 
 /**
  * Load the sibling `solana/rpc` subpath lazily, only when an `rpc` source is actually built.

--- a/meta/squid-sdk/src/solana/rpc/source/data-source.test.ts
+++ b/meta/squid-sdk/src/solana/rpc/source/data-source.test.ts
@@ -1,0 +1,78 @@
+import type {Block as RpcBlock} from '@subsquid/solana-rpc'
+import {describe, expect, it} from 'vitest'
+
+import {mapRawBlock} from './data-source'
+
+const VOTE_PROGRAM = 'Vote111111111111111111111111111111111111111'
+const TOKEN_PROGRAM = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+const HASH = 'Cmq7nXTbRpWkAQjwrh7hbZsSEdYUYtN86uZoDiD1BJH3'
+const SIG_VOTE = '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW'
+const SIG_SWAP = '4VvparxhgReCNHE7kRxHh9Kcxs1AwB1pN1ynT1fbyutVzpw1VYohTycdezfxAnVHHqh7sFRrSZSnio6KvtzDDeL3'
+
+function tx(signature: string, program: string, feePayer: string) {
+    return {
+        version: 'legacy' as const,
+        transaction: {
+            signatures: [signature],
+            message: {
+                accountKeys: [feePayer, program],
+                addressTableLookups: [],
+                header: {
+                    numReadonlySignedAccounts: 0,
+                    numReadonlyUnsignedAccounts: 1,
+                    numRequiredSignatures: 1,
+                },
+                instructions: [{accounts: [0], data: '1', programIdIndex: 1, stackHeight: null}],
+                recentBlockhash: HASH,
+            },
+        },
+        meta: {
+            computeUnitsConsumed: 150n,
+            costUnits: undefined,
+            err: null,
+            fee: 5000n,
+            preBalances: [1000000n, 0n],
+            postBalances: [995000n, 0n],
+            preTokenBalances: [],
+            postTokenBalances: [],
+            innerInstructions: [],
+            loadedAddresses: {readonly: [], writable: []},
+            logMessages: [`Program ${program} invoke [1]`, `Program ${program} success`],
+            returnData: undefined,
+        },
+    }
+}
+
+function rawBlock(): RpcBlock {
+    return {
+        slot: 100,
+        block: {
+            blockhash: HASH,
+            blockHeight: 90,
+            blockTime: 1787239776,
+            parentSlot: 99,
+            previousBlockhash: HASH,
+            transactions: [
+                // A vote precedes the payload transaction in the raw getBlock order.
+                tx(SIG_VOTE, VOTE_PROGRAM, 'Fd7btgySsrjuo25CJCj7oE7VPMyezDhnx7pZkj2v69Nk'),
+                tx(SIG_SWAP, TOKEN_PROGRAM, '3ASmhghwKKZjN9VEGfM6KiEogYaxtjfsSHqidEAYagSi'),
+            ],
+        },
+    } as unknown as RpcBlock
+}
+
+describe('mapRawBlock', () => {
+    it('strips vote transactions but preserves original transaction numbering, like the Portal', () => {
+        let block = mapRawBlock(
+            rawBlock(),
+            {transaction: {signatures: true}, instruction: {programId: true}},
+            {transactions: [{}], instructions: [{}]},
+        )
+
+        expect(block.transactions.map((t) => t.signatures[0])).toEqual([SIG_SWAP])
+        // The Portal datasets number transactions by their position in the raw block,
+        // votes included — index 1, not a post-filter 0.
+        expect(block.transactions.map((t) => t.transactionIndex)).toEqual([1])
+        expect(block.instructions.map((i) => i.transactionIndex)).toEqual([1])
+    })
+})

--- a/meta/squid-sdk/src/solana/rpc/source/data-source.ts
+++ b/meta/squid-sdk/src/solana/rpc/source/data-source.ts
@@ -1,5 +1,6 @@
 import {mapRpcBlock} from '@subsquid/solana-normalization'
 import {Block as RpcBlock, RpcApi, SolanaRpcDataSource} from '@subsquid/solana-rpc'
+import {removeVoteTransactions} from '@subsquid/solana-rpc-data'
 import {Block, DataRequest, FieldSelection} from '@subsquid/solana-stream'
 import {createLogger} from '@subsquid/logger'
 import {BlockBatch, BlockRef, BlockStream, DataSource, StreamRequest} from '@subsquid/util-internal-data-source'
@@ -102,12 +103,7 @@ export class SolanaRpcStreamDataSource<F extends FieldSelection> implements Data
     }
 
     private mapBlock(raw: RpcBlock): Block<F> {
-        let normalized = mapRpcBlock(raw.slot, raw.block, log)
-        let request = this.requestFor(raw.slot)
-        if (request) {
-            filterBlockItems(normalized, request)
-        }
-        return decodeBlock(normalized, this.fields)
+        return mapRawBlock(raw, this.fields, this.requestFor(raw.slot))
     }
 
     private requestFor(slot: number): DataRequest | undefined {
@@ -119,6 +115,29 @@ export class SolanaRpcStreamDataSource<F extends FieldSelection> implements Data
 
         return undefined
     }
+}
+
+/**
+ * Map one raw RPC block to the Portal-shaped block model: strip votes, normalize, filter, decode.
+ *
+ * Vote transactions are removed BEFORE normalization because that is how the Portal datasets are
+ * produced (both `solana-ingest --no-votes` and the hot-blocks `solana-data-service` call
+ * `removeVoteTransactions` first) — `removeVoteTransactions` stamps each kept transaction with its
+ * original position (`_index`), which `mapRpcBlock` adopts as `transactionIndex`. Skipping this
+ * step would number transactions differently from the Portal whenever a vote precedes them in the
+ * raw `getBlock` order, changing every item id derived from the index.
+ */
+export function mapRawBlock<F extends FieldSelection>(
+    raw: RpcBlock,
+    fields: F,
+    request: DataRequest | undefined,
+): Block<F> {
+    removeVoteTransactions(raw.block)
+    let normalized = mapRpcBlock(raw.slot, raw.block, log)
+    if (request) {
+        filterBlockItems(normalized, request)
+    }
+    return decodeBlock(normalized, fields)
 }
 
 /**


### PR DESCRIPTION
## Problem

The Portal Solana dataset producers (`solana-ingest --no-votes`, `solana-data-service`) call `removeVoteTransactions()` **before** `mapRpcBlock()`: vote transactions are dropped, and the surviving transactions keep their original `getBlock` positions via the stamped `_index`, which normalization adopts as `transactionIndex`. This is also the contract encoded in `solana-normalization`'s LFS conformance fixtures.

The `solana/rpc` adapter fed raw blocks straight into normalization, so its `transactionIndex` counted vote transactions — and every item id embedding the index disagreed with Portal-sourced data whenever a vote preceded the transaction in the raw block order. A fallback switching between `portal` and `rpc` sources would emit different ids for the same on-chain event.

## Fix

- Apply `removeVoteTransactions()` before normalization in the adapter's block mapping (extracted as `mapRawBlock` for testability, mirroring the exported `coarseRequest`).
- Declare `@subsquid/solana-rpc-data ^1.0.0` as an optional peer + devDep. It is a hard dependency of `@subsquid/solana-rpc`, so it is always installed whenever the RPC path is usable; the missing-peer translation covers it.

## Testing

- New regression test: a vote transaction preceding a payload transaction must not shift the payload's `transactionIndex` (asserts index 1, not a post-filter 0) — fails without the fix.
- Full megapackage suite: 175 passed.
- E2E: the standard Whirlpool USDC-SOL example squid run twice over the same slot range — once on the Portal source, once on the fixed RPC source against a mainnet archive node — produces **byte-identical rows including ids**. Before the fix, ids diverged in the `transactionIndex` component on every block where votes precede the matched transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2n1VHrhUa2szzVMW3mrkY