### PR TITLE
fix(evm-processor): retry on Avalanche 'cannot query unfinalized data'

### DIFF
--- a/common/changes/@subsquid/evm-processor/fix-avalanche-unfinalized-trace_2026-08-20-10-26.json
+++ b/common/changes/@subsquid/evm-processor/fix-avalanche-unfinalized-trace_2026-08-20-10-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-processor",
+      "comment": "retry on \"cannot query unfinalized data\" error from eth_getBlockByHash and debug_traceBlockByHash",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-processor"
+}

--- a/evm/evm-processor/src/ds-rpc/client.test.ts
+++ b/evm/evm-processor/src/ds-rpc/client.test.ts
@@ -128,6 +128,36 @@ describe('EvmRpcDataSource retry behavior', () => {
         assert.strictEqual(deliveredBlocks[0].header.hash, BLOCK1_HASH)
     })
 
+    it('retries and delivers block after "cannot query unfinalized data" from debug_traceBlockByHash (Avalanche)', async () => {
+        let traceCalls = 0
+
+        let ds = new EvmRpcDataSource({
+            rpc: mockRpc({
+                eth_blockNumber: () => ({result: '0x1'}),
+                eth_getBlockByNumber: () => ({result: block1()}),
+                debug_traceBlockByHash: () => {
+                    if (traceCalls++ === 0) {
+                        return {error: {code: -32000, message: 'cannot query unfinalized data'}}
+                    }
+                    return {result: []}
+                }
+            }),
+            finalityConfirmation: 0,
+            headPollInterval: 0
+        })
+
+        let deliveredBlocks: any[] = []
+        await ds.processHotBlocks(
+            [{range: {from: 1, to: 1}, request: {traces: [{}]}}],
+            {height: 0, hash: GENESIS_HASH, top: []},
+            async upd => { deliveredBlocks.push(...upd.blocks) }
+        )
+
+        assert.ok(traceCalls >= 2, `debug_traceBlockByHash should have been called at least twice, got ${traceCalls}`)
+        assert.strictEqual(deliveredBlocks.length, 1)
+        assert.strictEqual(deliveredBlocks[0].header.hash, BLOCK1_HASH)
+    })
+
     it('propagates unexpected eth_getLogs error without retrying', async () => {
         let getLogsCalls = 0
 

--- a/evm/evm-processor/src/ds-rpc/rpc.test.ts
+++ b/evm/evm-processor/src/ds-rpc/rpc.test.ts
@@ -72,6 +72,13 @@ describe('getBlockByHash', () => {
         assert.strictEqual(await rpc.getBlockByHash('0xabc', false), null)
     })
 
+    it('returns null for "cannot query unfinalized data" error (Avalanche)', async () => {
+        let rpc = new Rpc(mockClient({
+            eth_getBlockByHash: {error: {code: -32000, message: 'cannot query unfinalized data'}}
+        }))
+        assert.strictEqual(await rpc.getBlockByHash('0xabc', false), null)
+    })
+
     it('throws for other RPC errors', async () => {
         let rpc = new Rpc(mockClient({
             eth_getBlockByHash: {error: {code: -32000, message: 'internal server error'}}

--- a/evm/evm-processor/src/ds-rpc/rpc.ts
+++ b/evm/evm-processor/src/ds-rpc/rpc.ts
@@ -572,7 +572,7 @@ export class Rpc {
             let frames = results[i]
             if (frames == null) {
                 block._isInvalid = true
-                block._errorMessage = 'got "block not found" from debug_traceBlockByHash'
+                block._errorMessage = 'failed to get debug call frames for a block'
             } else if (block.block.transactions.length === frames.length) {
                 block.debugFrames = frames
             } else {
@@ -610,7 +610,7 @@ export class Rpc {
             let diffs = results[i]
             if (diffs == null) {
                 block._isInvalid = true
-                block._errorMessage = 'got "block not found" from debug_traceBlockByHash'
+                block._errorMessage = 'failed to get debug state diffs for a block'
             } else if (block.block.transactions.length === diffs.length) {
                 block.debugStateDiffs = diffs
             } else {
@@ -795,5 +795,6 @@ function toBlock(getBlock?: GetBlock | null): Block | undefined {
 function captureNotFound(info: RpcErrorInfo): null {
     if (/not found/i.test(info.message)) return null
     if (/not currently canonical/i.test(info.message)) return null
+    if (/cannot query unfinalized data/i.test(info.message)) return null // Avalanche
     throw new RpcError(info)
 }


### PR DESCRIPTION
On Avalanche, a processor that requests traces sometimes crashes with the following error.

```
RpcError: cannot query unfinalized data
  at captureNotFound (.../lib/ds-rpc/rpc.js:615)
  rpcMethod: debug_traceBlockByHash, code: -32000
```

coreth nodes only serve blocks they have accepted (ref. [api_backend.go](https://github.com/ava-labs/avalanchego/blob/e0fa58e79330fcd9005dd645df9cd22faaff28f9/graft/coreth/eth/api_backend.go#L191-L213)). With a load-balanced RPC endpoint (such as [Chainstack Global Nodes](https://docs.chainstack.com/docs/global-elastic-node)), one node can return the block hash, and a different node can receive the trace request:

```mermaid
sequenceDiagram
    participant S as evm-processor
    participant LB as load balancer
    participant A as node A (accepted=N)
    participant B as node B (accepted=N-1)

    S->>LB: eth_getBlockByNumber(N)
    LB->>A: .
    A-->>S: block N (hash H)
    S->>LB: debug_traceBlockByHash(H)
    LB->>B: .
    Note over B: has block N,<br/>but has not accepted it yet
    B-->>S: -32000 "cannot query unfinalized data"
    Note over S: captureNotFound does not recognize this message<br/>→ non-retriable RpcError
```

This error only means the node has not accepted the block yet. It is the same situation as the `not found` error, which `captureNotFound` already treats as retriable. `getBlockBatch` already handles this error since f9684106, and evm-rpc also handles it for the trace calls (76b87663).
