### PR TITLE
fix(portal-client): honor a configured retryAttempts, and retry for ~5 minutes by default

### DIFF
--- a/common/changes/@subsquid/http-client/expose-retry-attempts_2026-08-27.json
+++ b/common/changes/@subsquid/http-client/expose-retry-attempts_2026-08-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@subsquid/http-client",
-      "comment": "expose the configured `retryAttempts` as a readonly property, so wrappers can defer to a caller's retry configuration instead of overriding it",
+      "comment": "expose the configured `retryAttempts` and `retrySchedule` as readonly properties, so wrappers can defer to a caller's retry configuration instead of overriding it, and can work out how long a retry budget spans",
       "type": "minor"
     }
   ],

--- a/common/changes/@subsquid/http-client/expose-retry-attempts_2026-08-27.json
+++ b/common/changes/@subsquid/http-client/expose-retry-attempts_2026-08-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/http-client",
+      "comment": "expose the configured `retryAttempts` as a readonly property, so wrappers can defer to a caller's retry configuration instead of overriding it",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/http-client"
+}

--- a/common/changes/@subsquid/portal-client/fix-retry-attempts-precedence_2026-08-27.json
+++ b/common/changes/@subsquid/portal-client/fix-retry-attempts-precedence_2026-08-27.json
@@ -2,12 +2,7 @@
   "changes": [
     {
       "packageName": "@subsquid/portal-client",
-      "comment": "a configured `retryAttempts` (including `Infinity`) is no longer overridden by the client's own default",
-      "type": "patch"
-    },
-    {
-      "packageName": "@subsquid/portal-client",
-      "comment": "the default retry budget goes from 6 attempts to 20, so portal requests now keep retrying for about five minutes (was about 33 seconds) before failing",
+      "comment": "a configured `retryAttempts` (including `Infinity`) is no longer overridden by the client's own default, and that default goes from 6 retries to 20, so portal requests now keep retrying for about five minutes (was about 33 seconds) before failing",
       "type": "minor"
     }
   ],

--- a/common/changes/@subsquid/portal-client/fix-retry-attempts-precedence_2026-08-27.json
+++ b/common/changes/@subsquid/portal-client/fix-retry-attempts-precedence_2026-08-27.json
@@ -2,8 +2,13 @@
   "changes": [
     {
       "packageName": "@subsquid/portal-client",
-      "comment": "a configured `retryAttempts` (including `Infinity`) is no longer overridden by the client's own default of 6",
+      "comment": "a configured `retryAttempts` (including `Infinity`) is no longer overridden by the client's own default",
       "type": "patch"
+    },
+    {
+      "packageName": "@subsquid/portal-client",
+      "comment": "the default retry budget goes from 6 attempts to 20, so portal requests now keep retrying for about five minutes (was about 33 seconds) before failing",
+      "type": "minor"
     }
   ],
   "packageName": "@subsquid/portal-client"

--- a/common/changes/@subsquid/portal-client/fix-retry-attempts-precedence_2026-08-27.json
+++ b/common/changes/@subsquid/portal-client/fix-retry-attempts-precedence_2026-08-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/portal-client",
+      "comment": "a configured `retryAttempts` (including `Infinity`) is no longer overridden by the client's own default of 6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/portal-client"
+}

--- a/util/http-client/src/client.test.ts
+++ b/util/http-client/src/client.test.ts
@@ -1,0 +1,35 @@
+import assert from 'assert'
+import {describe, it} from 'vitest'
+import {HttpClient} from './client'
+
+const DEFAULT_SCHEDULE = [10, 100, 500, 2000, 10000, 20000]
+
+describe('HttpClient retry configuration', () => {
+    it('exposes the default schedule when none was given', () => {
+        assert.deepStrictEqual([...new HttpClient({log: null}).retrySchedule], DEFAULT_SCHEDULE)
+    })
+
+    it('exposes a configured schedule', () => {
+        let client = new HttpClient({log: null, retrySchedule: [1, 2, 3]})
+        assert.deepStrictEqual([...client.retrySchedule], [1, 2, 3])
+    })
+
+    it('copies the configured schedule instead of aliasing it', () => {
+        // The property is exposed readonly, so mutating the array the caller passed in
+        // must not retune a live client.
+        let schedule = [1, 2, 3]
+        let client = new HttpClient({log: null, retrySchedule: schedule})
+        schedule.push(999)
+        assert.deepStrictEqual([...client.retrySchedule], [1, 2, 3])
+    })
+
+    it('keeps an empty schedule rather than falling back to the default', () => {
+        assert.deepStrictEqual([...new HttpClient({log: null, retrySchedule: []}).retrySchedule], [])
+    })
+
+    it('exposes the configured retryAttempts, and 0 when unset', () => {
+        assert.strictEqual(new HttpClient({log: null, retryAttempts: 4}).retryAttempts, 4)
+        assert.strictEqual(new HttpClient({log: null, retryAttempts: Infinity}).retryAttempts, Infinity)
+        assert.strictEqual(new HttpClient({log: null}).retryAttempts, 0)
+    })
+})

--- a/util/http-client/src/client.ts
+++ b/util/http-client/src/client.ts
@@ -89,7 +89,9 @@ export class HttpClient {
         this.headers = options.headers
         this.setBaseUrl(options.baseUrl)
         this.agent = options.agent || defaultAgentProvider
-        this.retrySchedule = options.retrySchedule || [10, 100, 500, 2000, 10000, 20000]
+        // Copied, not aliased: the property is exposed readonly, so the caller must not
+        // be able to retune a live client by mutating the array it passed in.
+        this.retrySchedule = options.retrySchedule ? [...options.retrySchedule] : [10, 100, 500, 2000, 10000, 20000]
         this.retryAttempts = options.retryAttempts || 0
         this.httpTimeout = options.httpTimeout ?? 20000
     }

--- a/util/http-client/src/client.ts
+++ b/util/http-client/src/client.ts
@@ -65,7 +65,14 @@ export class HttpClient {
     private baseUrl?: string
     private agent: AgentProvider
     private retrySchedule: number[]
-    private retryAttempts: number
+    /**
+     * Retry budget configured for this client, `0` when none was configured.
+     *
+     * Readable so that wrappers can defer to a caller's configuration instead of
+     * overriding it. Note that the constructor maps an unset option and an explicit
+     * `0` onto the same value, so this cannot distinguish the two.
+     */
+    readonly retryAttempts: number
     private httpTimeout: number
     private requestCounter = 0
 

--- a/util/http-client/src/client.ts
+++ b/util/http-client/src/client.ts
@@ -64,7 +64,14 @@ export class HttpClient {
     protected headers?: Record<string, string | number | bigint>
     private baseUrl?: string
     private agent: AgentProvider
-    private retrySchedule: number[]
+    /**
+     * Backoff pauses (in milliseconds) between retries. The final entry repeats for
+     * every attempt beyond its length.
+     *
+     * Readable together with {@link retryAttempts} so that wrappers can work out how
+     * long a retry budget actually spans.
+     */
+    readonly retrySchedule: number[]
     /**
      * Retry budget configured for this client, `0` when none was configured.
      *

--- a/util/http-client/src/client.ts
+++ b/util/http-client/src/client.ts
@@ -69,9 +69,10 @@ export class HttpClient {
      * every attempt beyond its length.
      *
      * Readable together with {@link retryAttempts} so that wrappers can work out how
-     * long a retry budget actually spans.
+     * long a retry budget actually spans. Exposed for observation only, hence the
+     * readonly element type: mutating it would silently change retry behaviour.
      */
-    readonly retrySchedule: number[]
+    readonly retrySchedule: readonly number[]
     /**
      * Retry budget configured for this client, `0` when none was configured.
      *

--- a/util/portal-client/src/client.test.ts
+++ b/util/portal-client/src/client.test.ts
@@ -74,8 +74,9 @@ describe('PortalClient head null-retries', () => {
  * `DEFAULT_RETRY_ATTEMPTS` is module-private; read the value the client resolved for an
  * unconfigured transport rather than restating the constant here.
  */
-const DEFAULT_ATTEMPTS: number = (new PortalClient({url: 'http://localhost/datasets/test'}) as any)
-    .defaultRetryAttempts
+const DEFAULT_ATTEMPTS: number = (
+    new PortalClient({url: 'http://localhost/datasets/test', http: {log: null}}) as any
+).defaultRetryAttempts
 
 /**
  * Build a PortalClient over a transport that answers `statuses` in order (the last

--- a/util/portal-client/src/client.test.ts
+++ b/util/portal-client/src/client.test.ts
@@ -80,12 +80,14 @@ const DEFAULT_ATTEMPTS: number = (
 
 /**
  * Build a PortalClient over a transport that answers `statuses` in order (the last
- * entry repeats), counting every attempt the retry loop makes. Retry pauses are
- * zeroed so the real loop in `HttpClient.request` runs at full speed.
+ * entry repeats), counting every request the retry loop makes. The real loop in
+ * `HttpClient.request` runs, so pauses are forced to zero to keep it fast — these
+ * tests count requests and never depend on the backoff. Options given here cannot
+ * reinstate a schedule; a caller passing a whole `HttpClient` must zero it itself.
  */
 function retryProbe(statuses: number[], http?: HttpClientOptions | HttpClient) {
     let attempts = 0
-    let client = http instanceof HttpClient ? http : new HttpClient({log: null, retrySchedule: [0], ...http})
+    let client = http instanceof HttpClient ? http : new HttpClient({log: null, ...http, retrySchedule: [0]})
     // Stands in for node-fetch `Headers`; the retry path only ever looks up `retry-after`.
     let headers = new Headers() as any
     ;(client as any).performRequestWithTimeout = async () => {

--- a/util/portal-client/src/client.test.ts
+++ b/util/portal-client/src/client.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import {describe, it} from 'vitest'
-import {HttpClient} from '@subsquid/http-client'
+import {HttpClient, HttpClientOptions, HttpResponse} from '@subsquid/http-client'
 import {PortalClient, type BlockRef} from './client'
 
 const HEAD: BlockRef = {number: 100, hash: '0xabc'}
@@ -67,5 +67,70 @@ describe('PortalClient head null-retries', () => {
         setTimeout(() => ac.abort(), 5)
         await assert.rejects(p)
         assert.strictEqual(urls.length, 1)
+    })
+})
+
+/**
+ * Build a PortalClient over a transport that answers `statuses` in order (the last
+ * entry repeats), counting every attempt the retry loop makes. Retry pauses are
+ * zeroed so the real loop in `HttpClient.request` runs at full speed.
+ */
+function retryProbe(statuses: number[], http?: HttpClientOptions | HttpClient) {
+    let attempts = 0
+    let client = http instanceof HttpClient ? http : new HttpClient({log: null, retrySchedule: [0], ...http})
+    // Stands in for node-fetch `Headers`; the retry path only ever looks up `retry-after`.
+    let headers = new Headers() as any
+    ;(client as any).performRequestWithTimeout = async () => {
+        let status = statuses[Math.min(attempts, statuses.length - 1)]
+        attempts++
+        return new HttpResponse(0, 'http://localhost/datasets/test/head', status, headers, status == 200 ? HEAD : {}, false)
+    }
+    let portal = new PortalClient({url: 'http://localhost/datasets/test', http: client})
+    return {portal, attempts: () => attempts}
+}
+
+describe('PortalClient retry budget', () => {
+    it('applies its own default when the caller configured none', async () => {
+        let {portal, attempts} = retryProbe([503])
+        await assert.rejects(portal.getHead())
+        // 1 initial attempt + 6 retries
+        assert.strictEqual(attempts(), 7)
+    })
+
+    it('honors retryAttempts: Infinity instead of capping it at the default', async () => {
+        // Eight failures is more than the default budget would survive: under the
+        // regression this rejected on the 7th attempt.
+        let {portal, attempts} = retryProbe([503, 503, 503, 503, 503, 503, 503, 503, 200], {
+            retryAttempts: Infinity,
+        })
+        assert.deepStrictEqual(await portal.getHead(), HEAD)
+        assert.strictEqual(attempts(), 9)
+    })
+
+    it('honors a budget lower than the default', async () => {
+        let {portal, attempts} = retryProbe([503], {retryAttempts: 1})
+        await assert.rejects(portal.getHead())
+        assert.strictEqual(attempts(), 2)
+    })
+
+    it('honors the budget of a caller-supplied HttpClient', async () => {
+        let {portal, attempts} = retryProbe(
+            [503],
+            new HttpClient({log: null, retrySchedule: [0], retryAttempts: 2})
+        )
+        await assert.rejects(portal.getHead())
+        assert.strictEqual(attempts(), 3)
+    })
+
+    it('falls back to the default when a supplied HttpClient configured no retries', async () => {
+        let {portal, attempts} = retryProbe([503], new HttpClient({log: null, retrySchedule: [0]}))
+        await assert.rejects(portal.getHead())
+        assert.strictEqual(attempts(), 7)
+    })
+
+    it('lets a per-request budget override the configured one', async () => {
+        let {portal, attempts} = retryProbe([503], {retryAttempts: Infinity})
+        await assert.rejects(portal.getHead({retryAttempts: 0}))
+        assert.strictEqual(attempts(), 1)
     })
 })

--- a/util/portal-client/src/client.test.ts
+++ b/util/portal-client/src/client.test.ts
@@ -71,6 +71,13 @@ describe('PortalClient head null-retries', () => {
 })
 
 /**
+ * `DEFAULT_RETRY_ATTEMPTS` is module-private; read the value the client resolved for an
+ * unconfigured transport rather than restating the constant here.
+ */
+const DEFAULT_ATTEMPTS: number = (new PortalClient({url: 'http://localhost/datasets/test'}) as any)
+    .defaultRetryAttempts
+
+/**
  * Build a PortalClient over a transport that answers `statuses` in order (the last
  * entry repeats), counting every attempt the retry loop makes. Retry pauses are
  * zeroed so the real loop in `HttpClient.request` runs at full speed.
@@ -93,18 +100,31 @@ describe('PortalClient retry budget', () => {
     it('applies its own default when the caller configured none', async () => {
         let {portal, attempts} = retryProbe([503])
         await assert.rejects(portal.getHead())
-        // 1 initial attempt + 6 retries
-        assert.strictEqual(attempts(), 7)
+        // 1 initial attempt + 20 retries
+        assert.strictEqual(attempts(), 21)
     })
 
     it('honors retryAttempts: Infinity instead of capping it at the default', async () => {
-        // Eight failures is more than the default budget would survive: under the
-        // regression this rejected on the 7th attempt.
-        let {portal, attempts} = retryProbe([503, 503, 503, 503, 503, 503, 503, 503, 200], {
-            retryAttempts: Infinity,
-        })
+        // More failures than the default budget would survive, so this cannot pass by
+        // falling back to the default.
+        let statuses = new Array(DEFAULT_ATTEMPTS + 5).fill(503).concat(200)
+        let {portal, attempts} = retryProbe(statuses, {retryAttempts: Infinity})
         assert.deepStrictEqual(await portal.getHead(), HEAD)
-        assert.strictEqual(attempts(), 9)
+        assert.strictEqual(attempts(), statuses.length)
+    })
+
+    it('default_retry_budget_is_about_five_minutes', () => {
+        // DEFAULT_RETRY_ATTEMPTS is tuned against HttpClient's default retrySchedule;
+        // a change to either that breaks the ~5 minute target should fail here.
+        let {retrySchedule} = new HttpClient({log: null})
+        let backoff = 0
+        for (let i = 0; i < DEFAULT_ATTEMPTS; i++) {
+            backoff += retrySchedule[Math.min(i, retrySchedule.length - 1)]
+        }
+        assert.ok(
+            backoff > 4.5 * 60_000 && backoff < 5.5 * 60_000,
+            `${DEFAULT_ATTEMPTS} attempts over [${retrySchedule}] spend ${backoff} ms, which is not about five minutes`
+        )
     })
 
     it('honors a budget lower than the default', async () => {
@@ -125,7 +145,7 @@ describe('PortalClient retry budget', () => {
     it('falls back to the default when a supplied HttpClient configured no retries', async () => {
         let {portal, attempts} = retryProbe([503], new HttpClient({log: null, retrySchedule: [0]}))
         await assert.rejects(portal.getHead())
-        assert.strictEqual(attempts(), 7)
+        assert.strictEqual(attempts(), DEFAULT_ATTEMPTS + 1)
     })
 
     it('lets a per-request budget override the configured one', async () => {

--- a/util/portal-client/src/client.ts
+++ b/util/portal-client/src/client.ts
@@ -12,9 +12,14 @@ const USER_AGENT = `@subsquid/portal-client (https://sqd.ai)`
  * Retry budget applied to portal requests when the caller configured none.
  *
  * `HttpClient` performs no retries at all by default, which is a poor fit for portal
- * traffic, so portal requests opt into a budget. This is only a *default*: an explicit
- * `retryAttempts` — per request, in {@link PortalClientOptions.http}, or on a
- * caller-supplied `HttpClient` — takes precedence over it.
+ * traffic, so portal requests opt into a budget.
+ *
+ * Precedence is per-request `retryAttempts` > the budget configured on the client
+ * (through {@link PortalClientOptions.http}, or already set on a supplied `HttpClient`)
+ * > this default. With one exception: `HttpClient` stores an unset option and an
+ * explicit `0` as the same value, so a client configured with `retryAttempts: 0` cannot
+ * be told apart from an unconfigured one and falls back here too. Turning retries off
+ * therefore takes a per-request `retryAttempts: 0`.
  */
 const DEFAULT_RETRY_ATTEMPTS = 6
 
@@ -28,9 +33,11 @@ export interface PortalClientOptions {
      * Optional custom HTTP client to use.
      *
      * Its `retryAttempts` — whether given as options or already set on a supplied
-     * `HttpClient` — is the retry budget for every portal request. Leaving it unset
-     * (or `0`) falls back to 6 attempts, since `HttpClient` itself would otherwise
-     * perform no retries.
+     * `HttpClient` — becomes the *default* retry budget for portal requests; a
+     * per-request `retryAttempts` still overrides it. Leaving it unset falls back to 6
+     * attempts, since `HttpClient` itself would otherwise perform none. Note that `0`
+     * is indistinguishable from unset once `HttpClient` has stored it, so it falls back
+     * as well — to turn retries off, pass `retryAttempts: 0` per request.
      */
     http?: HttpClient | HttpClientOptions
 

--- a/util/portal-client/src/client.ts
+++ b/util/portal-client/src/client.ts
@@ -15,13 +15,15 @@ const USER_AGENT = `@subsquid/portal-client (https://sqd.ai)`
  * traffic, so portal requests opt into a budget.
  *
  * Sized to keep retrying for roughly five minutes, so that a stream rides out a portal
- * restart or a brief upstream outage instead of failing the processor. Against
- * `HttpClient`'s default `retrySchedule` — `[10, 100, 500, 2000, 10000, 20000]` ms, whose
- * last entry repeats — the first six attempts spend 32.6 s and each further attempt adds
- * 20 s, so 20 attempts span 5 min 13 s of backoff. Time spent on the attempts themselves
- * is on top of that, and is bounded by `httpTimeout` per attempt. A different
- * `retrySchedule` changes the span; `default_retry_budget_is_about_five_minutes` in the
- * tests guards the pairing.
+ * restart or a brief upstream outage instead of failing the processor.
+ *
+ * Note that the option counts *retries*, not total requests: `n` means one initial
+ * request plus up to `n` more. Against `HttpClient`'s default `retrySchedule` —
+ * `[10, 100, 500, 2000, 10000, 20000]` ms, whose last entry repeats — the first six
+ * retries pause for 32.6 s in total and every further retry adds 20 s, so 20 retries
+ * span 5 min 13 s of backoff across 21 requests. Time spent on the requests themselves
+ * is on top of that, bounded by `httpTimeout` each. A different `retrySchedule` changes
+ * the span; `default_retry_budget_is_about_five_minutes` in the tests guards the pairing.
  *
  * Precedence is per-request `retryAttempts` > the budget configured on the client
  * (through {@link PortalClientOptions.http}, or already set on a supplied `HttpClient`)
@@ -44,10 +46,10 @@ export interface PortalClientOptions {
      * Its `retryAttempts` — whether given as options or already set on a supplied
      * `HttpClient` — becomes the *default* retry budget for portal requests; a
      * per-request `retryAttempts` still overrides it. Leaving it unset falls back to 20
-     * attempts — roughly five minutes of backoff — since `HttpClient` itself would
-     * otherwise perform none. Note that `0` is indistinguishable from unset once
-     * `HttpClient` has stored it, so it falls back as well — to turn retries off, pass
-     * `retryAttempts: 0` per request.
+     * retries — one request plus 20 more, roughly five minutes of backoff — since
+     * `HttpClient` itself would otherwise perform none. Note that `0` is
+     * indistinguishable from unset once `HttpClient` has stored it, so it falls back as
+     * well — to turn retries off, pass `retryAttempts: 0` per request.
      */
     http?: HttpClient | HttpClientOptions
 

--- a/util/portal-client/src/client.ts
+++ b/util/portal-client/src/client.ts
@@ -8,6 +8,16 @@ export * from './query'
 
 const USER_AGENT = `@subsquid/portal-client (https://sqd.ai)`
 
+/**
+ * Retry budget applied to portal requests when the caller configured none.
+ *
+ * `HttpClient` performs no retries at all by default, which is a poor fit for portal
+ * traffic, so portal requests opt into a budget. This is only a *default*: an explicit
+ * `retryAttempts` — per request, in {@link PortalClientOptions.http}, or on a
+ * caller-supplied `HttpClient` — takes precedence over it.
+ */
+const DEFAULT_RETRY_ATTEMPTS = 6
+
 export interface PortalClientOptions {
     /**
      * The URL of the portal dataset.
@@ -16,6 +26,11 @@ export interface PortalClientOptions {
 
     /**
      * Optional custom HTTP client to use.
+     *
+     * Its `retryAttempts` — whether given as options or already set on a supplied
+     * `HttpClient` — is the retry budget for every portal request. Leaving it unset
+     * (or `0`) falls back to 6 attempts, since `HttpClient` itself would otherwise
+     * perform no retries.
      */
     http?: HttpClient | HttpClientOptions
 
@@ -135,10 +150,15 @@ export class PortalClient {
     private maxIdleTime: number
     private maxWaitTime: number
     private headRetrySchedule: number[]
+    private defaultRetryAttempts: number
 
     constructor(options: PortalClientOptions) {
         this.url = new URL(options.url)
         this.client = options.http instanceof HttpClient ? options.http : new HttpClient(options.http)
+        // `HttpClient` collapses "unset" and an explicit `0` into `0`, so both fall back
+        // to our default. A caller wanting no retries at all passes `retryAttempts: 0`
+        // per request, which outranks this.
+        this.defaultRetryAttempts = this.client.retryAttempts || DEFAULT_RETRY_ATTEMPTS
         this.headPollInterval = options.headPollInterval ?? 0
         this.maxBytes = options.maxBytes ?? 50 * 1024 * 1024
         this.maxIdleTime = options.maxIdleTime ?? 500
@@ -285,7 +305,7 @@ export class PortalClient {
     private request<T = any>(method: string, url: string, options: RequestOptions & HttpBody = {}) {
         return this.client.request<T>(method, url, {
             ...options,
-            retryAttempts: options.retryAttempts ?? 6,
+            retryAttempts: options.retryAttempts ?? this.defaultRetryAttempts,
             headers: {
                 'User-Agent': USER_AGENT,
                 ...options?.headers,

--- a/util/portal-client/src/client.ts
+++ b/util/portal-client/src/client.ts
@@ -14,6 +14,15 @@ const USER_AGENT = `@subsquid/portal-client (https://sqd.ai)`
  * `HttpClient` performs no retries at all by default, which is a poor fit for portal
  * traffic, so portal requests opt into a budget.
  *
+ * Sized to keep retrying for roughly five minutes, so that a stream rides out a portal
+ * restart or a brief upstream outage instead of failing the processor. Against
+ * `HttpClient`'s default `retrySchedule` — `[10, 100, 500, 2000, 10000, 20000]` ms, whose
+ * last entry repeats — the first six attempts spend 32.6 s and each further attempt adds
+ * 20 s, so 20 attempts span 5 min 13 s of backoff. Time spent on the attempts themselves
+ * is on top of that, and is bounded by `httpTimeout` per attempt. A different
+ * `retrySchedule` changes the span; `default_retry_budget_is_about_five_minutes` in the
+ * tests guards the pairing.
+ *
  * Precedence is per-request `retryAttempts` > the budget configured on the client
  * (through {@link PortalClientOptions.http}, or already set on a supplied `HttpClient`)
  * > this default. With one exception: `HttpClient` stores an unset option and an
@@ -21,7 +30,7 @@ const USER_AGENT = `@subsquid/portal-client (https://sqd.ai)`
  * be told apart from an unconfigured one and falls back here too. Turning retries off
  * therefore takes a per-request `retryAttempts: 0`.
  */
-const DEFAULT_RETRY_ATTEMPTS = 6
+const DEFAULT_RETRY_ATTEMPTS = 20
 
 export interface PortalClientOptions {
     /**
@@ -34,10 +43,11 @@ export interface PortalClientOptions {
      *
      * Its `retryAttempts` — whether given as options or already set on a supplied
      * `HttpClient` — becomes the *default* retry budget for portal requests; a
-     * per-request `retryAttempts` still overrides it. Leaving it unset falls back to 6
-     * attempts, since `HttpClient` itself would otherwise perform none. Note that `0`
-     * is indistinguishable from unset once `HttpClient` has stored it, so it falls back
-     * as well — to turn retries off, pass `retryAttempts: 0` per request.
+     * per-request `retryAttempts` still overrides it. Leaving it unset falls back to 20
+     * attempts — roughly five minutes of backoff — since `HttpClient` itself would
+     * otherwise perform none. Note that `0` is indistinguishable from unset once
+     * `HttpClient` has stored it, so it falls back as well — to turn retries off, pass
+     * `retryAttempts: 0` per request.
      */
     http?: HttpClient | HttpClientOptions
 


### PR DESCRIPTION
Two related changes to the portal retry budget. The first is a bug fix; the second
changes a default and depends on the first to be settable at all.

---

# 1. A configured `retryAttempts` was silently discarded

`PortalClient.request` set `retryAttempts` on every outgoing request:

```ts
// util/portal-client/src/client.ts
return this.client.request<T>(method, url, {
    ...options,
    retryAttempts: options.retryAttempts ?? 6,
    ...
```

`HttpClient.request` resolves the per-request value *before* its own default:

```ts
// util/http-client/src/client.ts
let retryAttempts = options.retryAttempts ?? this.retryAttempts
//                  ^^^^^^ always 6         ^^^^^^ never reached
```

Because the left-hand side is always defined, the `6` won unconditionally. Any
`retryAttempts` a user configured — through `PortalClientOptions.http`, or already set
on an `HttpClient` instance they passed in — was dropped.

This matters most for `retryAttempts: Infinity`, which is the documented way to keep a
stream alive across a transient upstream failure and is what the quickstart and the
portal migration guides tell users to write:

```ts
.setPortal({
  url: '...',
  http: {retryAttempts: Infinity},   // had no effect
})
```

Instead of retrying until the upstream recovered, such a stream spent the default
schedule and then threw a fatal `HttpError`. A user following the docs got behaviour
they had explicitly opted out of, with nothing in the logs to say their setting had been
dropped.

Introduced in `@subsquid/portal-client` 0.5.2, which added the six-attempt default —
sensible in itself, since `HttpClient` performs no retries at all otherwise, but
implemented as a per-request override rather than a default.

## Fix

Resolve the default once, at construction, and pass it only as a fallback:

```ts
this.defaultRetryAttempts = this.client.retryAttempts || DEFAULT_RETRY_ATTEMPTS
...
retryAttempts: options.retryAttempts ?? this.defaultRetryAttempts,
```

Precedence becomes **per-request > configured client > default**.

`HttpClient` maps an unset option and an explicit `0` onto the same stored value, so it
cannot tell them apart; both therefore keep falling back to the default, as before. A
caller who genuinely wants no retries passes `retryAttempts: 0` per request, which
outranks the default.

---

# 2. The default now spans about five minutes

`retryAttempts` counts *retries*, not requests: `n` means one initial request plus up to
`n` more.

Six retries against `HttpClient`'s default `retrySchedule` —
`[10, 100, 500, 2000, 10000, 20000]` ms — pause for **32.6 s** in total before the
request fails. That is short next to how long an upstream is realistically unavailable: a
portal restart or a brief outage outlives it, and the processor dies rather than waiting
it out.

The default is now **20 retries**. The schedule's last entry repeats, so retries 7..20 add
20 s each:

```
32.6 s  +  14 x 20 s  =  5 min 13 s of backoff, across 21 requests
```

Time spent on the requests themselves is on top of that, bounded by `httpTimeout` each.

That figure only holds for `HttpClient`'s default schedule, and the two constants live in
different packages — so `default_retry_budget_is_about_five_minutes` recomputes the span
from the client's own `retrySchedule` and fails if the pairing drifts outside 4.5–5.5
minutes, rather than letting the budget change silently.

**This changes failure latency**: a persistently failing portal request now surfaces its
error after about five minutes instead of about 33 seconds. Callers who want the old
behaviour set `retryAttempts` explicitly — which, thanks to change 1, now works.

---

## `HttpClient` API

`retryAttempts` and `retrySchedule` change from `private` to `readonly` properties: the
first so the wrapper can defer to a caller's configuration instead of overriding it, the
second so it can work out how long a budget spans. Nothing could reach either before, and
neither in-repo subclass (`RpcHttpClient`, `TronHttpClient`) touches them — both only
override `handleResponseBody`.

`retrySchedule` is typed `readonly number[]` and the constructor now copies the array
rather than aliasing the caller's, so the exposed value is genuinely immutable instead of
merely looking it. An empty schedule is still preserved rather than replaced by the
default, since `request()` reads that as "no backoff, pause 1000 ms".

## Behaviour

Retry counts; total requests are one more than each figure.

| configuration | before | after |
|---|---|---|
| none | 6 (~33 s) | 20 (~5 min) |
| `http: {retryAttempts: Infinity}` | 6 ❌ | `Infinity` ✅ |
| `http: {retryAttempts: 20}` | 6 ❌ | 20 ✅ |
| `http: {retryAttempts: 0}` | 6 | 20 |
| `http: new HttpClient({retryAttempts: 20})` | 6 ❌ | 20 ✅ |
| `http: new HttpClient()` | 6 | 20 |
| per-request `{retryAttempts: 3}` | 3 | 3 |
| per-request `{retryAttempts: 0}` | 0 | 0 |

## Tests

13 cases in `util/portal-client/src/client.test.ts` and 5 in
`util/http-client/src/client.test.ts` (new file). The precedence ones drive the real
retry loop in `HttpClient.request` against a stubbed transport and count requests, rather
than asserting on forwarded options; the budget one is arithmetic over the live schedule;
the http-client ones cover the newly public surface.

Each guard was checked by reverting the thing it guards. Reverting the precedence fix
fails exactly the three that pin it (`Infinity`, a lower budget, a caller-supplied
client). Reverting the default to 6 fails the budget guard with `6 attempts over
[10,100,500,2000,10000,20000] spend 32610 ms, which is not about five minutes`. Reverting
the schedule copy fails `copies the configured schedule instead of aliasing it`.

## Note, not addressed here

`PortalRequestOptions.bodyTimeout` is declared but never read anywhere in the repo —
another knob that silently does nothing. Left alone to keep this change focused; worth
either wiring up or marking `@deprecated not used` as `minBytes` already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsbeDWeFPvBKW7Bm4r5qXS
