### PR TITLE
perf(fallback): poll liveness with eth_blockNumber instead of a block lookup

### DIFF
--- a/common/changes/@subsquid/evm-rpc/perf-cheap-head-polls_2026-09-01.json
+++ b/common/changes/@subsquid/evm-rpc/perf-cheap-head-polls_2026-09-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "EvmRpcDataSource implements the new optional getHeight() with eth_blockNumber, so freshness head polls no longer cost a full eth_getBlockByNumber lookup",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/common/changes/@subsquid/squid-sdk/perf-cheap-head-polls_2026-09-01.json
+++ b/common/changes/@subsquid/squid-sdk/perf-cheap-head-polls_2026-09-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/squid-sdk",
+      "comment": "The fallback source's freshness head polls prefer a source's number-only getHeight() (eth_blockNumber on EVM RPC sources) over the full getHead() block lookup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/squid-sdk"
+}

--- a/common/changes/@subsquid/util-internal-data-source/perf-cheap-head-polls_2026-09-01.json
+++ b/common/changes/@subsquid/util-internal-data-source/perf-cheap-head-polls_2026-09-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/util-internal-data-source",
+      "comment": "Add an optional getHeight() to DataSource — a number-only head poll for liveness/lag consumers, cheaper than getHead() where the backing protocol distinguishes the two",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/util-internal-data-source"
+}

--- a/evm/evm-rpc/src/data-source/rpc-data-source.test.ts
+++ b/evm/evm-rpc/src/data-source/rpc-data-source.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'vitest'
+
+import {EvmRpcDataSource} from './rpc-data-source'
+
+describe('EvmRpcDataSource', () => {
+    it('answers getHeight with eth_blockNumber, not a block lookup', async () => {
+        // The fallback's freshness machinery polls heads once per batch per standby at tip pace,
+        // so the poll must be the cheapest call the provider offers.
+        let calls: string[] = []
+        let rpc = {
+            getHeight: async () => {
+                calls.push('eth_blockNumber')
+                return 100
+            },
+            getConcurrency: () => 10,
+        }
+        let src = new EvmRpcDataSource({rpc: rpc as never, req: {}})
+
+        expect(await src.getHeight()).toBe(100)
+        expect(calls).toEqual(['eth_blockNumber'])
+    })
+})

--- a/evm/evm-rpc/src/data-source/rpc-data-source.ts
+++ b/evm/evm-rpc/src/data-source/rpc-data-source.ts
@@ -43,6 +43,11 @@ export class EvmRpcDataSource implements DataSource<Block> {
         }
     }
 
+    /** The cheap liveness poll: `eth_blockNumber`, no block lookup. */
+    getHeight(): Promise<number> {
+        return this.rpc.getHeight()
+    }
+
     async *getFinalizedStream(req: StreamRequest): BlockStream<Block> {
         let stream = this.ensureContinuity(
             this.ingest('finalized', req),

--- a/meta/squid-sdk/src/evm/rpc/source/data-source.test.ts
+++ b/meta/squid-sdk/src/evm/rpc/source/data-source.test.ts
@@ -129,3 +129,24 @@ describe('keptByPosition', () => {
         expect(keptByPosition(projected, pre, [])).toEqual([])
     })
 })
+
+describe('EvmRpcStreamDataSource — head polls', () => {
+    it('forwards getHeight to the inner source (eth_blockNumber, not a block lookup)', async () => {
+        // Regression: this adapter is what the fallback holds, and it enumerates the DataSource
+        // contract method by method — an optional method it omits is invisible, silently
+        // downgrading every freshness poll to the full eth_getBlockByNumber lookup.
+        const {EvmRpcStreamDataSource} = await import('./data-source')
+        let calls: string[] = []
+        let rpc = {
+            getHeight: async () => {
+                calls.push('eth_blockNumber')
+                return 100
+            },
+            getConcurrency: () => 10,
+        }
+        let src = new EvmRpcStreamDataSource({rpc: rpc as never, fields: {}, requests: []})
+
+        expect(await src.getHeight()).toBe(100)
+        expect(calls).toEqual(['eth_blockNumber'])
+    })
+})

--- a/meta/squid-sdk/src/evm/rpc/source/data-source.ts
+++ b/meta/squid-sdk/src/evm/rpc/source/data-source.ts
@@ -99,6 +99,13 @@ export class EvmRpcStreamDataSource<F extends FieldSelection> implements DataSou
         return this.inner.getHead()
     }
 
+    // Forwarded explicitly, like every method here: this adapter is what the fallback holds, so
+    // an optional contract method it omits is invisible — the fallback would silently downgrade
+    // every head poll to the full eth_getBlockByNumber lookup.
+    getHeight(): Promise<number> {
+        return this.inner.getHeight()
+    }
+
     getFinalizedHead(): Promise<BlockRef> {
         return this.inner.getFinalizedHead()
     }

--- a/meta/squid-sdk/src/fallback/fallback.test.ts
+++ b/meta/squid-sdk/src/fallback/fallback.test.ts
@@ -762,6 +762,38 @@ describe('FallbackDataSource — freshness (M1)', () => {
     })
 })
 
+describe('FallbackDataSource — freshness head polls', () => {
+    it("prefers a source's cheap getHeight over getHead for the poll", async () => {
+        // On an EVM RPC source `getHeight` is `eth_blockNumber` while `getHead` is a block
+        // lookup; the freshness machinery consumes only the number, so the cheap call must win
+        // whenever the source offers it.
+        let heights = 0
+        let heads = 0
+        let s0 = new MockSource(async function* () {
+            for (let n = 1; n <= 3; n++) yield batch([blk(n)])
+        })
+        let standby: DataSource<TestBlock> = {
+            getStream: async function* () {},
+            getFinalizedStream: async function* () {},
+            getHead: async () => {
+                heads++
+                return {number: 1000, hash: '0x1000'}
+            },
+            getHeight: async () => {
+                heights++
+                return 1000
+            },
+            getFinalizedHead: async () => ({number: 1000, hash: '0x1000'}),
+        }
+        let fb = fallback([s0, standby], {headTtlMs: 0})
+
+        await collect(fb.getStream({from: 1, to: 3}))
+
+        expect(heights).toBeGreaterThan(0)
+        expect(heads).toBe(0)
+    })
+})
+
 describe('FallbackDataSource — getHead delegation', () => {
     it('delegates to the active source and fails over on error', async () => {
         let noop: StreamFn = async function* () {}

--- a/meta/squid-sdk/src/fallback/fallback.ts
+++ b/meta/squid-sdk/src/fallback/fallback.ts
@@ -328,14 +328,14 @@ export class FallbackDataSource<B> implements DataSource<B> {
 
         try {
             let head = await this.headWithTimeout(i)
-            this.#headCache[i] = {value: head.number, at: now}
+            this.#headCache[i] = {value: head, at: now}
             // The head fetch doubles as the liveness probe: a fresh head is proof the source
             // is reachable, so it counts toward the `M` passes that promote a standby to `healthy`
             // — without which it could never be eligible for eager switch-up. A reachable source
             // is also when we (re)confirm its capability.
             this.health[i].onLivenessPass()
             this.#maybeProbeCapability(i)
-            return head.number
+            return head
         } catch (e) {
             this.#headCache[i] = {value: undefined, at: now}
             this.failSource(i, classifyError('liveness', e))
@@ -349,10 +349,15 @@ export class FallbackDataSource<B> implements DataSource<B> {
      * active source: on timeout this rejects, and `getCachedHead` records a liveness failure. `null`
      * disables the guard and defers to the underlying client's own request timeout.
      */
-    private headWithTimeout(i: number): Promise<BlockRef> {
+    private headWithTimeout(i: number): Promise<number> {
         let timeoutMs = this.policy.headPollTimeoutMs
+        // Only the head NUMBER is consumed by the freshness machinery, so a source offering the
+        // cheaper number-only poll (`eth_blockNumber` on an EVM RPC source, vs a full block
+        // lookup) is preferred.
+        let source = this.sources[i].source
+        let head = source.getHeight ? source.getHeight() : source.getHead().then(h => h.number)
         return withTimeout(
-            this.sources[i].source.getHead(),
+            head,
             timeoutMs,
             () => new Error(`head poll timed out after ${timeoutMs}ms`),
         )

--- a/util/util-internal-data-source/src/index.ts
+++ b/util/util-internal-data-source/src/index.ts
@@ -33,6 +33,14 @@ export type BlockStream<B> = AsyncIterable<BlockBatch<B>>
 export interface DataSource<B> {
     getHead(): Promise<BlockRef>
 
+    /**
+     * Head number without the hash, for callers that need liveness/lag rather than a resume
+     * anchor. Optional: consumers fall back to `getHead().number`. An EVM RPC source answers it
+     * with `eth_blockNumber`, which is far cheaper for the provider than the
+     * `eth_getBlockByNumber` lookup a full {@link BlockRef} requires.
+     */
+    getHeight?(): Promise<number>
+
     getFinalizedHead(): Promise<BlockRef>
     
     // FIXME: maybe it's better to pass it as an option to `getStream`


### PR DESCRIPTION
## Summary

The fallback source's freshness machinery (lag reference, liveness, stall recovery) polls standby heads once per batch at tip pace — the batch cadence outruns the 5s head cache — and each poll fetched a full block reference via `eth_getBlockByNumber`, of which only the **number** was ever consumed. Users watching provider dashboards see a steady stream of block lookups from an idle standby.

- `DataSource` gains an **optional** `getHeight(): Promise<number>` — a number-only head poll for liveness/lag consumers. Sources that don't implement it are unaffected (the fallback falls back to `getHead().number`).
- `EvmRpcDataSource` answers it with `eth_blockNumber` — typically the cheapest (often unmetered) call a provider offers.
- The fallback's `headWithTimeout` prefers `getHeight` when the source has one.

Solana is untouched: its `getHead` already rides `getLatestBlockhash`, which is a cheap native call.

## Test plan
- New: fallback prefers `getHeight` over `getHead` for the poll (asserts zero `getHead` calls on a source offering both); `EvmRpcDataSource.getHeight` delegates to `eth_blockNumber` only.
- Full suites green: fallback (75), evm-rpc (213), squid-sdk meta (175).

The sibling change in the Pipes SDK additionally gates its boundary poll; this repo's fallback already gates every poll path (`laggingTooFar` early-returns with lag off, `probeHigherPreference` is a no-op at index 0, the stall poll fires only past the staleness window), so only the call cost needed fixing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2HQnYVvTkKkVPJCB6pjn6