### PR TITLE
fix(evm): accept PascalCase debug call-frame types (zkSync-era nodes)

### DIFF
--- a/common/changes/@subsquid/evm-normalization/alert-fix-eUZPoL-zklink-pascalcase-frames_2026-09-05-21-30.json
+++ b/common/changes/@subsquid/evm-normalization/alert-fix-eUZPoL-zklink-pascalcase-frames_2026-09-05-21-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-normalization",
+      "comment": "Map PascalCase debug call-frame types (zkSync-era nodes) instead of throwing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-normalization"
+}

--- a/common/changes/@subsquid/evm-rpc/alert-fix-eUZPoL-zklink-pascalcase-frames_2026-09-05-21-30.json
+++ b/common/changes/@subsquid/evm-rpc/alert-fix-eUZPoL-zklink-pascalcase-frames_2026-09-05-21-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "Accept PascalCase debug call-frame types (zkSync-era nodes) in frame verification",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-normalization/src/mapping.debug-frame.test.ts
+++ b/evm/evm-normalization/src/mapping.debug-frame.test.ts
@@ -90,6 +90,44 @@ function blockWithFrame(frame: rpc.DebugFrame): rpc.Block {
 }
 
 
+describe('PascalCase debug frame', () => {
+    // zkSync-era nodes (e.g. zklink-nova) serialize call kinds in PascalCase.
+    it('maps a `Call` frame', () => {
+        let block = blockWithFrame({
+            type: 'Call',
+            from: '0xb31fb3fd1b61e571a9709bc59413950e1abc9926',
+            to: CONTRACT,
+            value: '0x0',
+            gas: '0x0',
+            gasUsed: '0x0',
+            input: '0x'
+        } as unknown as rpc.DebugFrame)
+
+        expect(mapRpcBlock(block, {withTraces: true}).traces).toEqual([
+            {
+                transactionIndex: 0,
+                traceAddress: [],
+                subtraces: 0,
+                error: undefined,
+                revertReason: undefined,
+                type: 'call',
+                action: {
+                    callType: 'call',
+                    from: '0xb31fb3fd1b61e571a9709bc59413950e1abc9926',
+                    to: CONTRACT,
+                    value: '0x0',
+                    gas: '0x0',
+                    input: '0x'
+                },
+                result: {
+                    gasUsed: '0x0'
+                }
+            }
+        ])
+    })
+})
+
+
 describe('SELFDESTRUCT debug frame', () => {
     it('maps an intact frame', () => {
         let block = blockWithFrame({

--- a/evm/evm-normalization/src/mapping.ts
+++ b/evm/evm-normalization/src/mapping.ts
@@ -55,7 +55,7 @@ function* mapDebugFrame(
     transactionIndex: number,
     debugFrameResult: {result: rpc.DebugFrame}
 ): Iterable<Trace> {
-    if (debugFrameResult.result.type == 'STOP') {
+    if (debugFrameResult.result.type.toUpperCase() == 'STOP') {
         assert(!debugFrameResult.result.calls?.length)
         return
     }
@@ -100,9 +100,10 @@ function buildDebugFrameTrace(
     }
     let trace: Trace
 
-    switch(frame.type) {
+    // Node implementations serialize call kinds with inconsistent casing
+    // (geth `CALL`, some tracers `call`, zkSync-era `Call`), so match uppercased.
+    switch(frame.type.toUpperCase()) {
         case 'CREATE':
-        case 'create':
         case 'CREATE2': {
             trace = {
                 ...base,
@@ -132,10 +133,8 @@ function buildDebugFrameTrace(
             break
         }
         case 'CALL':
-        case 'call':
         case 'CALLCODE':
         case 'DELEGATECALL':
-        case 'delegateCall':
         case 'STATICCALL':
         case 'INVALID': {
             trace = {

--- a/evm/evm-rpc/src/verification.call-frame-tree.test.ts
+++ b/evm/evm-rpc/src/verification.call-frame-tree.test.ts
@@ -38,6 +38,22 @@ describe('checkDebugFrameStructure', () => {
         expect(checkDebugFrameStructure(INTACT)).toBeUndefined()
     })
 
+    // zkSync-era nodes (e.g. zklink-nova) serialize call kinds in PascalCase.
+    it('accepts PascalCase frame types', () => {
+        expect(checkDebugFrameStructure({
+            type: 'Call',
+            from: SENDER,
+            to: CONTRACT,
+            input: '0x',
+            calls: [{
+                type: 'DelegateCall',
+                from: CONTRACT,
+                to: CONTRACT,
+                input: '0x'
+            }]
+        })).toBeUndefined()
+    })
+
     it('requires targets and inputs for call frames', () => {
         expect(checkDebugFrameStructure({
             type: 'CALL',
@@ -164,6 +180,14 @@ describe('checkCallFrameTree', () => {
 
     it('accepts a root frame that halted on an invalid opcode', () => {
         let root: CallFrame = {type: 'INVALID', from: SENDER, to: CONTRACT, input: '0x'}
+
+        expect(checkDebugFrameStructure(root)).toBeUndefined()
+        expect(checkCallFrameTree(TX, root)).toBeUndefined()
+    })
+
+    // zkSync-era `Call` root frame - both gates must agree it is a valid call root.
+    it('accepts a PascalCase root call frame', () => {
+        let root: CallFrame = {type: 'Call', from: SENDER, to: CONTRACT, input: '0x'}
 
         expect(checkDebugFrameStructure(root)).toBeUndefined()
         expect(checkCallFrameTree(TX, root)).toBeUndefined()

--- a/evm/evm-rpc/src/verification.ts
+++ b/evm/evm-rpc/src/verification.ts
@@ -1106,19 +1106,26 @@ export async function withdrawalsRoot(withdrawals: Withdrawal[]) {
 }
 
 
+// Debug tracers serialize call kinds with inconsistent casing across node
+// implementations (geth `CALL`, some tracers `call`, zkSync-era `Call`), so every
+// membership test below compares the canonical upper-cased form.
+function canonicalFrameType(type: string): string {
+    return type.toUpperCase()
+}
+
 const CALL_FRAME_TYPES = new Set([
-    'CALL', 'call',
+    'CALL',
     'CALLCODE',
-    'DELEGATECALL', 'delegateCall',
+    'DELEGATECALL',
     'STATICCALL',
     'INVALID'
 ])
 
 // INVALID is a top-level execution outcome, not a nested-only call kind: unlike
 // DELEGATECALL/STATICCALL/CALLCODE it can legitimately appear as a root frame.
-const ROOT_CALL_FRAME_TYPES = new Set(['CALL', 'call', 'INVALID'])
+const ROOT_CALL_FRAME_TYPES = new Set(['CALL', 'INVALID'])
 const CREATE_FRAME_TYPES = new Set([
-    'CREATE', 'create',
+    'CREATE',
     'CREATE2'
 ])
 const SELFDESTRUCT_FRAME_TYPES = new Set(['SELFDESTRUCT'])
@@ -1153,17 +1160,18 @@ export function checkDebugFrameStructure(root: CallFrame): string | undefined {
 
 function checkFrameStructure(frame: CallFrame, traceAddress: number[]): string | undefined {
     let label = frameLabel(traceAddress)
+    let type = canonicalFrameType(frame.type)
 
     // Normalization treats a root STOP result as an empty trace list. The same
     // type nested in a tree has no mapper representation.
-    if (frame.type === 'STOP' && traceAddress.length === 0) {
+    if (type === 'STOP' && traceAddress.length === 0) {
         if (frame.calls?.length) {
             return 'root STOP frame has subcalls'
         }
         return
     }
 
-    if (!MAPPABLE_FRAME_TYPES.has(frame.type)) {
+    if (!MAPPABLE_FRAME_TYPES.has(type)) {
         return `${label} has unsupported type ${frame.type}`
     }
 
@@ -1175,14 +1183,14 @@ function checkFrameStructure(frame: CallFrame, traceAddress: number[]): string |
         return `${label} has invalid to address ${frame.to}`
     }
 
-    if (CALL_FRAME_TYPES.has(frame.type)) {
+    if (CALL_FRAME_TYPES.has(type)) {
         if (frame.to == null) {
             return `${callFrameLabel(traceAddress)} has no target`
         }
         if (frame.input == null) {
             return `${callFrameLabel(traceAddress)} has no input`
         }
-    } else if (CREATE_FRAME_TYPES.has(frame.type)) {
+    } else if (CREATE_FRAME_TYPES.has(type)) {
         if (frame.input == null) {
             return `${createFrameLabel(traceAddress)} has no init code`
         }
@@ -1191,7 +1199,7 @@ function checkFrameStructure(frame: CallFrame, traceAddress: number[]): string |
         if ((frame.to || frame.output) && !frame.gasUsed) {
             return `${createFrameLabel(traceAddress)} has a result but no gas used`
         }
-    } else if (SELFDESTRUCT_FRAME_TYPES.has(frame.type) && frame.to == null) {
+    } else if (SELFDESTRUCT_FRAME_TYPES.has(type) && frame.to == null) {
         return `${selfdestructFrameLabel(traceAddress)} has no beneficiary`
     }
 
@@ -1218,18 +1226,18 @@ export function checkCallFrameTree(
 ): string | undefined {
     // A root STOP maps to an empty trace list, so there is nothing to agree with the
     // transaction about. The structural check owns this shape.
-    if (root.type === 'STOP') return
+    if (canonicalFrameType(root.type) === 'STOP') return
 
     if (!sameAddress(root.from, tx.from)) {
         return `root frame is executed by ${root.from}, but the transaction is sent by ${tx.from}`
     }
 
     if (tx.to == null) {
-        if (!CREATE_FRAME_TYPES.has(root.type)) {
+        if (!CREATE_FRAME_TYPES.has(canonicalFrameType(root.type))) {
             return `root frame has type ${root.type}, but the transaction creates a contract`
         }
     } else {
-        if (!ROOT_CALL_FRAME_TYPES.has(root.type)) {
+        if (!ROOT_CALL_FRAME_TYPES.has(canonicalFrameType(root.type))) {
             return `root frame has type ${root.type}, but the transaction calls ${tx.to}`
         }
         if (!sameAddress(root.to, tx.to)) {
@@ -1255,14 +1263,14 @@ function checkSubcalls(parent: CallFrame, traceAddress: number[]): string | unde
             return `frame ${at.join('/')} is executed by ${call.from}, but ${executor} is on top of the call stack`
         }
 
-        if (SELFDESTRUCT_FRAME_TYPES.has(call.type) && call.to == null) {
+        if (SELFDESTRUCT_FRAME_TYPES.has(canonicalFrameType(call.type)) && call.to == null) {
             return `${selfdestructFrameLabel(at)} has no beneficiary`
         }
 
         // An unknown child type cannot define the execution context for its own
         // children. Keep validating independent ancestors and siblings, but leave
         // that subtree to the structural validator.
-        if (!MAPPABLE_FRAME_TYPES.has(call.type)) continue
+        if (!MAPPABLE_FRAME_TYPES.has(canonicalFrameType(call.type))) continue
 
         let violation = checkSubcalls(call, at)
         if (violation) return violation
@@ -1271,9 +1279,8 @@ function checkSubcalls(parent: CallFrame, traceAddress: number[]): string | unde
 
 
 function isContextPreserving(type: string): boolean {
-    switch(type) {
+    switch(canonicalFrameType(type)) {
         case 'DELEGATECALL':
-        case 'delegateCall':
         case 'CALLCODE':
             return true
         default:


### PR DESCRIPTION
## Cause (proven)

The `dump-zklink-nova-mainnet-0` pod has been crash-looping since ~20:21 UTC on 2026-09-05 (alert `ArchiveDumpRestarting`). Pod logs:

```
Error: invalid debug call frames for transaction 0xed925dd5e36a55d920d682b8e90904105bd69cc3e9406ba68c679bbc0f10c31e: root frame has unsupported type Call
    at getBlocks (/squid/evm/evm-rpc/lib/data-source/get-blocks.js:27:60)
rpcUrl: https://rpc.zklink.io/   failedBlocks: [8345775,8345777,8345779]  retries: 5
```

zklink-nova is a zkSync-Era-based L3. Its `debug_traceTransaction`/`debug_traceBlockByNumber` callTracer returns frame types in **PascalCase** (`"type": "Call"`), verified live against `https://rpc.zklink.io/`:

```json
{"type":"Call","from":"0x00..00","to":"0x00..8001", "calls":[{"type":"Call", ...}]}
```

The debug-frame verification introduced in #548 (`checkDebugFrameStructure` / `checkCallFrameTree` in `evm-rpc/src/verification.ts`) matches frame types against sets containing only `CALL`/`call` (and camelCase variants), not `Call`. So `checkDebugFrameStructure` returns `root frame has unsupported type Call`, the block is marked `_isInvalid`, and after 5 retries `getBlocks` throws → the dump process crashes → restart loop → no data written.

This shipped to production when the `evm-dump:ac90a36d` image (which contains the #548 verification) was deployed to zklink-nova at ~20:21 UTC on 2026-09-05; the code has been on `master` since 26f7703e, and the casing has always been zklink's format, so the trigger was the deploy, not a chain change. The normalization mapper (`evm-normalization/src/mapping.ts`) switches on the same exact strings and would throw `Unexpected case: Call` on the same data.

This is a legitimate on-chain format our own code fails to recognize — the fix is to support it, not to skip/disable the check.

## Fix

Match debug call-frame types **case-insensitively** in both the verifier and the mapper, so `CALL` / `call` / `Call` are all handled uniformly. This also folds the previously ad-hoc lowercase/camelCase entries into a single canonical (upper-cased) comparison.

## Tests (red → green)

- `evm/evm-rpc/src/verification.call-frame-tree.test.ts`: added `accepts PascalCase frame types` and `accepts a PascalCase root call frame`.
  Pre-fix: `expected 'root frame has unsupported type Call' to be undefined`. Post-fix: pass.
- `evm/evm-normalization/src/mapping.debug-frame.test.ts`: added `maps a Call frame`.
  Pre-fix: `Error: Unexpected case: Call`. Post-fix: pass.

Verified locally: `rush build` green (both packages compile), both package suites green (the one unrelated failure in `test/verification.test.ts > transaction sender recovery` is a 5s-timeout on slow ECDSA recovery in the sandbox and passes with `--testTimeout=60000`).

## Falsification

If zklink's dump still logs `unsupported type <X>` for a type `<X>` that is not a casing variant of CALL/CALLCODE/DELEGATECALL/STATICCALL/INVALID/CREATE/CREATE2/SELFDESTRUCT/STOP, then it is a genuinely new frame kind and this fix is insufficient.

Related to #548 (introduced the frame verification); this is a follow-up casing bug in that feature, not a duplicate.