### PR TITLE
fix(rpc-client): retry transient 'upstream not synced' RPC errors

### DIFF
--- a/common/changes/@subsquid/rpc-client/alert-fix-jnodxt-dump-not-synced-retry_2026-09-07-01-41.json
+++ b/common/changes/@subsquid/rpc-client/alert-fix-jnodxt-dump-not-synced-retry_2026-09-07-01-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/rpc-client",
+      "comment": "retry transient \"upstream not synced\" errors from load-balancing RPC proxies instead of failing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/rpc-client"
+}

--- a/util/rpc-client/src/client.test.ts
+++ b/util/rpc-client/src/client.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest'
+import {isRetryableError} from './client'
+import {RetryError, RpcError} from './errors'
+
+describe('isRetryableError', () => {
+    it('retries the erpc "upstream not synced" JSON-RPC error', () => {
+        // Real shape seen from erpc when its finalized head is ahead of the
+        // upstream node's synced tip (code -32603, block available shortly).
+        let err = new RpcError({
+            code: -32603,
+            message: 'gave up retrying on network-level after 1.079449613s: 1 upstream not synced'
+        })
+        expect(isRetryableError(err)).toBe(true)
+    })
+
+    it('retries the plural "upstreams not synced" wording', () => {
+        let err = new RpcError({code: -32603, message: 'all upstream attempts failed (2 upstreams not synced)'})
+        expect(isRetryableError(err)).toBe(true)
+    })
+
+    it('retries "does not have the requested block yet"', () => {
+        let err = new RpcError({code: -32603, message: 'upstream does not have the requested block yet'})
+        expect(isRetryableError(err)).toBe(true)
+    })
+
+    it('does not retry a genuine execution error', () => {
+        let err = new RpcError({code: 3, message: 'execution reverted'})
+        expect(isRetryableError(err)).toBe(false)
+    })
+
+    it('still retries RetryError and rate limits', () => {
+        expect(isRetryableError(new RetryError())).toBe(true)
+        expect(isRetryableError(new RpcError({code: -32005, message: 'rate limit exceeded'}))).toBe(true)
+    })
+})

--- a/util/rpc-client/src/client.ts
+++ b/util/rpc-client/src/client.ts
@@ -530,26 +530,7 @@ export class RpcClient {
     }
 
     isConnectionError(err: Error): boolean {
-        if (err instanceof RetryError) return true
-        if (isRateLimitError(err)) return true
-        if (isExecutionTimeoutError(err)) return true
-        if (isRequestTimedOutError(err)) return true
-        if (err instanceof RpcConnectionError) return true
-        if (isHttpConnectionError(err)) return true
-        if (err instanceof HttpTimeoutError) return true
-        if (err instanceof HttpError) {
-            switch(err.response.status) {
-                case 408:
-                case 429:
-                case 502:
-                case 503:
-                case 504:
-                    return true
-                default:
-                    return false
-            }
-        }
-        return false
+        return isRetryableError(err)
     }
 
     reset(reason?: RpcConnectionError): void {
@@ -593,8 +574,46 @@ function getCallPriority(req: Req): number {
 }
 
 
+/**
+ * Classifies transient failures that should be retried rather than propagated.
+ * Exported so the retry policy can be unit-tested independently of a live connection.
+ */
+export function isRetryableError(err: unknown): boolean {
+    if (err instanceof RetryError) return true
+    if (isRateLimitError(err)) return true
+    if (isExecutionTimeoutError(err)) return true
+    if (isRequestTimedOutError(err)) return true
+    if (isUpstreamNotSyncedError(err)) return true
+    if (err instanceof RpcConnectionError) return true
+    if (isHttpConnectionError(err)) return true
+    if (err instanceof HttpTimeoutError) return true
+    if (err instanceof HttpError) {
+        switch (err.response.status) {
+            case 408:
+            case 429:
+            case 502:
+            case 503:
+            case 504:
+                return true
+            default:
+                return false
+        }
+    }
+    return false
+}
+
+
 function isRateLimitError(err: unknown): boolean {
     return err instanceof RpcError && /rate limit/i.test(err.message)
+}
+
+
+// erpc/load-balancing proxies briefly report a finalized head ahead of the
+// upstream node's synced tip; the block appears within seconds, so retry.
+function isUpstreamNotSyncedError(err: unknown): boolean {
+    return err instanceof RpcError &&
+        (/upstreams? not synced/i.test(err.message) ||
+            /does not have the requested block/i.test(err.message))
 }
 
 


### PR DESCRIPTION
## Cause (proven)

`dump-avalanche-mainnet-0` and `dump-binance-testnet-0` (image `subsquid/evm-dump:ac90a36d`, namespace `evm-archive`) are crash-looping — 1051 restarts each, exit code 1. The last line before every exit is a single fatal:

```
sqd:evm-dump  RpcError: gave up retrying on network-level after 1.48s: 1 upstream not synced
  at validateError (evm-rpc/lib/rpc.js:280)
  method=eth_getBlockReceipts params=[0x5a45347]  (block 94655303)
  ErrUpstreamBlockUnavailable: upstream does not have the requested block yet
  blockNumber=94655303 latestBlock=94655301 finalizedBlock=94655304
```

Both dumps talk to the shared `erpc` proxy. erpc momentarily reports a **finalized head (94655304) ahead of the upstream node's own latest (94655301)**. The dumper reads that finalized head, requests receipts for a block within it, and erpc answers with a JSON-RPC `-32503`/`-32603` "upstream not synced" error inside a 200 response.

Unlike a `429` (which arrives as an `HttpError` and is already retried), this error is a plain `RpcError`, so `RpcClient.isConnectionError` returns `false`, the error is not retried (despite `retryAttempts` being effectively infinite), it propagates out of the ingest loop, and `Dumper.run`'s handler logs it `fatal` and the process exits. The block becomes available within a couple of seconds — this is a transient condition that should be retried, not a fatal crash. The fatality is the bug (a single upstream hiccup should not crash-loop the dump).

## Fix

Classify the transient "upstream not synced" / "does not have the requested block yet" `RpcError` as retryable in `RpcClient.isConnectionError`, mirroring the existing `RetryError` paths (e.g. Hyperliquid "invalid block height"). Retry machinery already backs off, so the dump waits out the brief head/tip skew instead of crashing. The classification logic is extracted into an exported pure `isRetryableError()` so it is unit-testable.

## Tested

- `util/rpc-client` vitest suite green (12/12). New `client.test.ts` asserts the real erpc error shape (`1 upstream not synced`, plural, and `does not have the requested block yet`) is retryable, and that a genuine `execution reverted` is **not**.
- Regression test is a true red→green: with the new matcher removed, 3 tests fail; with it, all pass.
- `rush build --to @subsquid/rpc-client` and `--to @subsquid/evm-dump` both compile clean.

## Falsification

If `dump-avalanche-mainnet-0` / `dump-binance-testnet-0` keep exiting with `exitCode 1` on `... : N upstream(s) not synced` after this image ships, the classification did not catch the wording — capture the exact `RpcError.message` and widen the matcher. Separately, the underlying erpc/Alchemy anomaly (finalized head ahead of upstream latest) should be raised with whoever manages the erpc config; this change stops it from crash-looping the dump but does not fix the proxy inconsistency.