### PR TITLE
Make the caught-up head poll interval configurable

### DIFF
--- a/common/changes/@subsquid/evm-dump/evm-dump-head-poll-interval_2026-09-08-18-05.json
+++ b/common/changes/@subsquid/evm-dump/evm-dump-head-poll-interval_2026-09-08-18-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-dump",
+      "comment": "Add `--head-poll-interval`, defaulting to 1000ms, so a caught-up dumper stops re-asking for the chain head ten times a second.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/evm-dump"
+}

--- a/common/changes/@subsquid/evm-rpc/evm-dump-head-poll-interval_2026-09-08-18-05.json
+++ b/common/changes/@subsquid/evm-rpc/evm-dump-head-poll-interval_2026-09-08-18-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/evm-rpc",
+      "comment": "Make the head poll interval configurable through `EvmRpcDataSourceOptions.headPollInterval`. Defaults to the previous hard-coded 100ms.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@subsquid/evm-rpc"
+}

--- a/evm/evm-dump/src/dumper.ts
+++ b/evm/evm-dump/src/dumper.ts
@@ -20,6 +20,7 @@ import {
 interface Options extends DumperOptions {
     retryInternalServerErrors?: boolean
     finalityConfirmation?: number
+    headPollInterval?: number
     withReceipts?: boolean
     withTraces?: boolean
     withStatediffs?: boolean
@@ -45,6 +46,12 @@ export class EvmDumper extends Dumper<RawBlock, Options> {
         program.description('Data archiving tool for EVM-based chains')
         program.option('--retry-internal-server-errors', 'If set, the internal server errors from the RPC endpoint will be treated as retryable')
         program.option('--finality-confirmation <number>', 'Finality offset from the head of a chain', positiveInt)
+        program.option(
+            '--head-poll-interval <ms>',
+            'How long to wait before asking for the chain head again, once caught up with it',
+            positiveInt,
+            1000
+        )
         program.option('--with-receipts', 'Fetch transaction receipt data')
         program.option('--with-traces', 'Fetch EVM call traces')
         program.option('--with-statediffs', 'Fetch EVM state updates')
@@ -116,6 +123,7 @@ export class EvmDumper extends Dumper<RawBlock, Options> {
                 checkCumulativeGasUsed: !this.options().skipCumulativeGasUsedCheck,
                 useGasUsedForReceiptsRoot: this.options().useGasUsedForReceiptsRoot,
             }),
+            headPollInterval: this.options().headPollInterval,
             req: {
                 transactions: true,
                 logs: !this.options().withReceipts,

--- a/evm/evm-rpc/src/data-source/ingest.test.ts
+++ b/evm/evm-rpc/src/data-source/ingest.test.ts
@@ -1,0 +1,67 @@
+import {wait} from '@subsquid/util-internal'
+import {describe, expect, it} from 'vitest'
+import type {Commitment, Rpc} from '../rpc'
+import type {Block} from '../types'
+import {ingest} from './ingest'
+
+const HEAD = 100
+
+// Once the stream has caught up, PollStream.next() asks the chain head on every
+// turn of the loop and returns nothing, so head calls are a direct count of how
+// often that loop spun.
+function mkRpc(): {rpc: Rpc; headCalls: () => number} {
+    let calls = 0
+    const rpc = {
+        getConcurrency: () => 1,
+        getLatestBlockhash: async (commitment: Commitment) => {
+            if (commitment === 'latest') calls += 1
+            return {number: HEAD, hash: '0xhead'}
+        },
+        getBlockBatch: async (numbers: number[]): Promise<Block[]> =>
+            numbers.map(number => ({
+                number,
+                hash: `0x${number}`,
+                block: {hash: `0x${number}`, parentHash: `0x${number - 1}`} as Block['block'],
+            })),
+    } as unknown as Rpc
+
+    return {rpc, headCalls: () => calls}
+}
+
+// Drain the one batch that sits at the head, then let the caught-up loop spin
+// untouched for `idleMs` and report how many head polls it made in that window.
+async function countIdleHeadPolls(headPollInterval: number, idleMs: number): Promise<number> {
+    const {rpc, headCalls} = mkRpc()
+
+    const stream = ingest({
+        rpc,
+        commitment: 'latest',
+        req: {},
+        range: {from: HEAD},
+        strideSize: 5,
+        strideConcurrency: 1,
+        headPollInterval,
+    })
+
+    const it = stream[Symbol.asyncIterator]()
+    await it.next()
+
+    const before = headCalls()
+    await wait(idleMs)
+    const polls = headCalls() - before
+
+    await it.return?.()
+    return polls
+}
+
+describe('ingest', () => {
+    it('spaces head polls by headPollInterval once caught up', async () => {
+        const polls = await countIdleHeadPolls(1000, 300)
+        expect(polls).toBeLessThanOrEqual(1)
+    })
+
+    it('polls far more often with a short interval', async () => {
+        const polls = await countIdleHeadPolls(20, 300)
+        expect(polls).toBeGreaterThan(4)
+    })
+})

--- a/evm/evm-rpc/src/data-source/ingest.ts
+++ b/evm/evm-rpc/src/data-source/ingest.ts
@@ -26,6 +26,8 @@ export interface IngestOptions {
     range: Range
     strideSize: number
     strideConcurrency: number
+    /** Pause before asking for the chain head again, once caught up with it. */
+    headPollInterval: number
 }
 
 
@@ -41,6 +43,7 @@ export function ingest(args: IngestOptions): AsyncIterable<IngestBatch> {
         req,
         strideConcurrency,
         strideSize,
+        headPollInterval,
     } = args
 
     let finalizedHeadTracker = new Throttler(
@@ -99,7 +102,7 @@ export function ingest(args: IngestOptions): AsyncIterable<IngestBatch> {
                 beg = poll.position()
 
                 if (blocks.length == 0) {
-                    await wait(100)
+                    await wait(headPollInterval)
                     continue
                 }
 

--- a/evm/evm-rpc/src/data-source/poll-stream.ts
+++ b/evm/evm-rpc/src/data-source/poll-stream.ts
@@ -8,7 +8,6 @@ export interface PollStreamOptions {
     from: number
     req?: DataRequest
     strideSize?: number
-    confirmationPauseMs?: number
 }
 
 

--- a/evm/evm-rpc/src/data-source/rpc-data-source.ts
+++ b/evm/evm-rpc/src/data-source/rpc-data-source.ts
@@ -11,6 +11,13 @@ export interface EvmRpcDataSourceOptions {
     req: DataRequest
     strideSize?: number
     strideConcurrency?: number
+    /**
+     * Pause before asking for the chain head again, once caught up with it.
+     *
+     * Defaults to 100ms, which suits head-following consumers.
+     * Archiving is not latency sensitive and should set this much higher.
+     */
+    headPollInterval?: number
 }
 
 
@@ -19,12 +26,14 @@ export class EvmRpcDataSource implements DataSource<Block> {
     public readonly req: DataRequest
     private strideSize: number
     private strideConcurrency: number
+    private headPollInterval: number
 
     constructor(options: EvmRpcDataSourceOptions) {
         this.rpc = options.rpc
         this.req = options.req
         this.strideSize = Math.max(1, options.strideSize ?? 5)
         this.strideConcurrency = Math.max(1, Math.min(options.strideConcurrency ?? 5, this.rpc.getConcurrency()))
+        this.headPollInterval = Math.max(0, options.headPollInterval ?? 100)
     }
 
     async getFinalizedHead(): Promise<BlockRef> {
@@ -117,6 +126,7 @@ export class EvmRpcDataSource implements DataSource<Block> {
             range,
             strideSize: this.strideSize,
             strideConcurrency: this.strideConcurrency,
+            headPollInterval: this.headPollInterval,
         })
     }
 }


### PR DESCRIPTION
## What

Once the EVM ingest loop catches up with the chain, `PollStream.next()` asks for the chain head on every turn and returns nothing, and the pause between turns was a hard-coded `await wait(100)` in `ingest.ts`. That is up to ten head requests per second regardless of the chain's block time, and for an archiving workload almost all of them re-fetch a header that is already known.

## Changes

- `IngestOptions.headPollInterval` replaces the hard-coded pause.
- `EvmRpcDataSourceOptions.headPollInterval` plumbs it through, defaulting to **100ms** — unchanged behaviour for head-following consumers such as `evm-data-service`.
- `evm-dump` gains `--head-poll-interval <ms>`, defaulting to **1000ms**. Archiving is not latency sensitive, so a caught-up dumper detects a new block up to a second later and makes an order of magnitude fewer head requests.
- `PollStreamOptions.confirmationPauseMs` was declared but never read by the constructor, and nothing in the EVM tree ever passed it. Removed, so the only pause knob is the live one. (The Solana equivalent is real and untouched.)

## Tests

New `ingest.test.ts` drives the ingest loop against a stubbed RPC parked at the head, and counts head polls during an idle window: at most one with a 1000ms interval, and many more with a 20ms interval. Both tests fail if the pause goes back to a constant — verified by reverting the line locally.

`rushx build` and `rushx test` pass for `@subsquid/evm-rpc`, and `rushx build` for `@subsquid/evm-dump`.

## Compatibility

The `evm-dump` default changes behaviour on upgrade. Nothing depends on head poll frequency for correctness — forks are caught in `ensureContinuity` by comparing `parentHash` on blocks already fetched, not by how often the head is polled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
