### PR TITLE
fix(hyperliquid-replica-cmds-ingest): resume archive listing instead of re-walking the whole bucket

### DIFF
--- a/common/changes/@subsquid/hyperliquid-replica-cmds-ingest/alert-fix-aTQwVg-hl-replica-relisting_2026-09-11-14-48.json
+++ b/common/changes/@subsquid/hyperliquid-replica-cmds-ingest/alert-fix-aTQwVg-hl-replica-relisting_2026-09-11-14-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/hyperliquid-replica-cmds-ingest",
+      "comment": "resume archive listing from the last served chunk instead of re-walking the whole bucket on every fetch",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/hyperliquid-replica-cmds-ingest"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
         version: file:projects/hyperliquid-replica-cmds-data-service.tgz
       '@rush-temp/hyperliquid-replica-cmds-ingest':
         specifier: file:./projects/hyperliquid-replica-cmds-ingest.tgz
-        version: file:projects/hyperliquid-replica-cmds-ingest.tgz
+        version: file:projects/hyperliquid-replica-cmds-ingest.tgz(esbuild@0.27.7)(tsx@4.21.0)
       '@rush-temp/hyperliquid-replica-cmds-normalization':
         specifier: file:./projects/hyperliquid-replica-cmds-normalization.tgz
         version: file:projects/hyperliquid-replica-cmds-normalization.tgz
@@ -1370,7 +1370,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/bitcoin-data-service@file:projects/bitcoin-data-service.tgz':
-    resolution: {integrity: sha512-xIaEJzOsdHgKfvycHKR+DVNfWUxIx5+1Ig42UL1m5X2R3KDHKzpmzgr4rcJZtmMLhSkli8HT3DWUDnGFkc3hzA==, tarball: file:projects/bitcoin-data-service.tgz}
+    resolution: {integrity: sha512-GecZDjbevG4+dtNAUgVfvTxgkflTqq2dMuFsHK99KkypQfHZj6k2T/WzZbbqCVgl7LmFge36BEdP5hc4+9dfuQ==, tarball: file:projects/bitcoin-data-service.tgz}
     version: 0.0.0
 
   '@rush-temp/bitcoin-dump@file:projects/bitcoin-dump.tgz':
@@ -1386,7 +1386,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/bitcoin-rpc@file:projects/bitcoin-rpc.tgz':
-    resolution: {integrity: sha512-GeatX4q35ZEzd+xhyY1bN5Z221zgdzA3g16qCHLichJJPZcDl3wkyJRrxm4PLV63Eg2VRJjXaXbGWP01DhIxnQ==, tarball: file:projects/bitcoin-rpc.tgz}
+    resolution: {integrity: sha512-N9Z+qxXWFOo2judqkzgILvXueELpbN0OR8dh8K4nvXvwZU5MeReXPnPgVknzGOd125hKICYBvYkrrJRnMIvOgw==, tarball: file:projects/bitcoin-rpc.tgz}
     version: 0.0.0
 
   '@rush-temp/borsh-bench@file:projects/borsh-bench.tgz':
@@ -1402,11 +1402,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/data-test@file:projects/data-test.tgz':
-    resolution: {integrity: sha512-1JZHqndnx7nvlXwuzQrD+/il32/AxpL6BMoBjUApMSrvrz7p+QR4mj7VTJgTORNjCVf5SWBIhBt+FoMBAWFQsw==, tarball: file:projects/data-test.tgz}
+    resolution: {integrity: sha512-6nB1L2/Sw8NYu/7ABj4q5Fw9cTwlhiRmPDx5JlqyrOOwgljIHrgjOJhrKgTNlv8eObeB14Bqxs6bPSdngsgtcA==, tarball: file:projects/data-test.tgz}
     version: 0.0.0
 
   '@rush-temp/erc20-transfers@file:projects/erc20-transfers.tgz':
-    resolution: {integrity: sha512-sfFMVVCQnQzi+TRLKj++LGtouUBk+tBrDAk+0TCsVhN7nc8pehpHdXosBdldm23/eeSTfJkmb2HginWNQH1B4A==, tarball: file:projects/erc20-transfers.tgz}
+    resolution: {integrity: sha512-Z3l4C67AH0WstLlj+8gsMfLxg25RXDJ8qoiGLPLxh2O9lkKXYZL/wtpg2s/i1cl8QN3QgXAT8zHaLhAQQa1kVA==, tarball: file:projects/erc20-transfers.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-abi@file:projects/evm-abi.tgz':
@@ -1422,7 +1422,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/evm-data-service@file:projects/evm-data-service.tgz':
-    resolution: {integrity: sha512-mWC3w+W++tphBRDudwkABMmiJvAWD8OEx94puND/U25w8wB6sKYrPQw1i2UTi/PkvlLf0YKEVcHsflGwovfaew==, tarball: file:projects/evm-data-service.tgz}
+    resolution: {integrity: sha512-59ffCu5eNpNqvIeGkB42CPOTx6kzwH6E14v6VSlWTZwoIyOrCnPmcwviTqOkqLVtQWh3JOQmNRL0EAMTe0pNJg==, tarball: file:projects/evm-data-service.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-dump@file:projects/evm-dump.tgz':
@@ -1438,23 +1438,23 @@ packages:
     version: 0.0.0
 
   '@rush-temp/evm-objects@file:projects/evm-objects.tgz':
-    resolution: {integrity: sha512-5PZSbLrYWfn6KkLvoH7UYZ1wCGC9X5zFNgtJqFPS52in6z7aKo2lG0C9n2YNnljiEUnkvOPlHUuV1ARd4r9rlQ==, tarball: file:projects/evm-objects.tgz}
+    resolution: {integrity: sha512-NLH+PK2nJU6XQgmRVPDT7C6SOVq+tqlPrc3Mo8/3BzH15WkO7MVYt9TWoRzMuCBbf3zZHNdqgGGDbRmM9Re7ng==, tarball: file:projects/evm-objects.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-processor@file:projects/evm-processor.tgz':
-    resolution: {integrity: sha512-kIIuMY608SIEG30q8kYck1ufP3xj3z18OQIgZrPQKU0BprzI4qpSReNIrPN6TT/6Ug5wTCymO0kbi/U/9DWUuw==, tarball: file:projects/evm-processor.tgz}
+    resolution: {integrity: sha512-skWbmh6IXlXg6c3CFAW0iyS8Sjb2WO9RGpiM0f5/vXsAUyMoUfqj+O/gHGlzq0ZU1muad8iVX8T6sECofKYO8w==, tarball: file:projects/evm-processor.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-rpc@file:projects/evm-rpc.tgz':
-    resolution: {integrity: sha512-/kmLbEwz06k++f2RtW5fg8N3iLdStzW60yCx+x0r9v7o39XA5wfXDhcSsapAkXs1jfNViRlnDEoqJ/xaM6Vk5Q==, tarball: file:projects/evm-rpc.tgz}
+    resolution: {integrity: sha512-r14s4mgVk/EiP1mghX7hKX6IG8tp7xld87m4QeEFr20XS5fsMelHYz9vxrnzHFAleL4g9SCbo12f1v1QZ0/avQ==, tarball: file:projects/evm-rpc.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-stream@file:projects/evm-stream.tgz':
-    resolution: {integrity: sha512-UAKXbBD6Ufw6L65czTuk5I0kOKMh8ZQQ/2U1NhywoRqIakXebC6OUz+qqK35IruPkKPlvU3hpuH+lubfvb42vg==, tarball: file:projects/evm-stream.tgz}
+    resolution: {integrity: sha512-ADnuiSK5enWAir4+G5F0Wf7SSTbCqmJrt/0eQ+Lxdn/j3tIJRnfNltVGn5Jbb36HfVoS7EOhjFMBBKzx6r/cZQ==, tarball: file:projects/evm-stream.tgz}
     version: 0.0.0
 
   '@rush-temp/evm-typegen@file:projects/evm-typegen.tgz':
-    resolution: {integrity: sha512-VXu42g/lHgQqlQ8FxreD115b6Hqpm4osbQj/SFTNjluXkYE2e//ZGAGgGgdsO3vgFPqEVFcWw3TEwHU33W2tgA==, tarball: file:projects/evm-typegen.tgz}
+    resolution: {integrity: sha512-oiKPjfTzM7Zw+Z5Dp2058nw5DTULMWKJPGiokSMj+e/EpCCpEt8GN53oJJLwXpyByjs0JDbTKyIkZRaKxjRkKA==, tarball: file:projects/evm-typegen.tgz}
     version: 0.0.0
 
   '@rush-temp/frontier@file:projects/frontier.tgz':
@@ -1466,7 +1466,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/fuel-dump@file:projects/fuel-dump.tgz':
-    resolution: {integrity: sha512-4aSbcJtDuwrBnYB+lhurYsoKEtD74HsxZkJymx+Q7mXKty4Ilx+DHaCeL+8nMbslYSInc/HzIod/RY64IRo+Rg==, tarball: file:projects/fuel-dump.tgz}
+    resolution: {integrity: sha512-155CzzlLbmJGEjNGm1NBSp0ZCSxNh5zeKQ5WVCJwX1do+p4n0DlpTktPJCOx4AatQ+yiibmKSAHDDQTEGpgIuw==, tarball: file:projects/fuel-dump.tgz}
     version: 0.0.0
 
   '@rush-temp/fuel-ingest@file:projects/fuel-ingest.tgz':
@@ -1482,11 +1482,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/fuel-stream@file:projects/fuel-stream.tgz':
-    resolution: {integrity: sha512-D5HgmyhAcfqH/zXTYArRxfYPnh03bT8XlymkWnQP3twdWIAVAAU8NlJIi6YfDL72RlUzhPoBdmvCEiW4w0lFbw==, tarball: file:projects/fuel-stream.tgz}
+    resolution: {integrity: sha512-X624MLtQ9kmo+r+ziysXg5P070qa+3q/M4Fjc7naemNGD+bBPHlPl/AA65Rm3x56dLCXsHDwAAzqODl4uzFaoA==, tarball: file:projects/fuel-stream.tgz}
     version: 0.0.0
 
   '@rush-temp/gql-test-client@file:projects/gql-test-client.tgz':
-    resolution: {integrity: sha512-J/xUYlBjRrh1gisgwQZpDsV46SqRsjtJoiesgwN0RLTSFZgg4jBUoH0xrfDKmloC3RHDLi4mP8wXpVezvSRE+g==, tarball: file:projects/gql-test-client.tgz}
+    resolution: {integrity: sha512-xYTfdKgnK7KRn39Sh4VY0t/r9J62Kv94gWi6L4s90DgHc3OXRwsMOnxa4eD2kXTF2DENEai9/py2qbntDAvtrg==, tarball: file:projects/gql-test-client.tgz}
     version: 0.0.0
 
   '@rush-temp/graphql-server@file:projects/graphql-server.tgz':
@@ -1498,7 +1498,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/hyperliquid-fills-data-service@file:projects/hyperliquid-fills-data-service.tgz':
-    resolution: {integrity: sha512-T6ku9vbR0uUEUauZNExs10UFsPuuzfUo/rYSkVXloaRZ+01DWRaXEs1a05g/uHT3I6cCrgkyKjAd/GWNHkFJfQ==, tarball: file:projects/hyperliquid-fills-data-service.tgz}
+    resolution: {integrity: sha512-drYZNt6BMIcMnPwO590bbOFRU9hCDqZ4t7SgxqdDIyyanhmhTfrK8FbakEXVuGg7NXyVEd7BqN/SprEhcSZroA==, tarball: file:projects/hyperliquid-fills-data-service.tgz}
     version: 0.0.0
 
   '@rush-temp/hyperliquid-fills-data@file:projects/hyperliquid-fills-data.tgz':
@@ -1514,7 +1514,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/hyperliquid-replica-cmds-data-service@file:projects/hyperliquid-replica-cmds-data-service.tgz':
-    resolution: {integrity: sha512-Qyi3zvWSqKnSTcvQrs/pOZN3yHtO77UsYtJ/MaXFuAzuRL4uyvuzP25UiCUrJ/5QiNGBNDEroRVRc3AAAxO4LA==, tarball: file:projects/hyperliquid-replica-cmds-data-service.tgz}
+    resolution: {integrity: sha512-7uK3Re669RALs8Amkn2Pw7P2D1JcTjKFIHxMJZcv9xDGURKu055vdV/O2DLcBM7luuXE3Xo94Q4rWhlK2CiPaw==, tarball: file:projects/hyperliquid-replica-cmds-data-service.tgz}
     version: 0.0.0
 
   '@rush-temp/hyperliquid-replica-cmds-data@file:projects/hyperliquid-replica-cmds-data.tgz':
@@ -1522,7 +1522,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/hyperliquid-replica-cmds-ingest@file:projects/hyperliquid-replica-cmds-ingest.tgz':
-    resolution: {integrity: sha512-wKU6EeRKrcJXXbUD8xTDHt0cnZbZ7+gJwDqFn/dePTdwW8ZLDTeJ5qcwzoTdqwfYOjupf1lBhc47x1ArnWUmqg==, tarball: file:projects/hyperliquid-replica-cmds-ingest.tgz}
+    resolution: {integrity: sha512-mrge+02vLbTx1Vfp6EqpM4+WnhzdNiqMobwn0zy+KXe2fD1jIy5tZyZhARha9BiUo75vTc3Ie+tw5ACuSfQ+lw==, tarball: file:projects/hyperliquid-replica-cmds-ingest.tgz}
     version: 0.0.0
 
   '@rush-temp/hyperliquid-replica-cmds-normalization@file:projects/hyperliquid-replica-cmds-normalization.tgz':
@@ -1554,11 +1554,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/portal-client@file:projects/portal-client.tgz':
-    resolution: {integrity: sha512-DRHvP1aSfx28Vw9uY99qcjb2Q+crOHbc3Wmg9Ynkup7Fj6lOIPXHd9NXS10nUVOYRsmjSPM5Iq2bBXMO1/kiXA==, tarball: file:projects/portal-client.tgz}
+    resolution: {integrity: sha512-T5/5j6k2Zb6qDEbDiX82MjrL109MDgOrnjyxK/ebhIYwFClqqhRPcyAQlOhg03rh5L/q2+ApvJoXx23dI+8SEg==, tarball: file:projects/portal-client.tgz}
     version: 0.0.0
 
   '@rush-temp/rpc-client@file:projects/rpc-client.tgz':
-    resolution: {integrity: sha512-K8Kvjux5qNebvJ1E8PP4tK0NDS7ygTYI+UsoOe1pHgrrYXOx31weW9FsaLxfUFg5BLrllaf3bIJ2QG52TnNqOg==, tarball: file:projects/rpc-client.tgz}
+    resolution: {integrity: sha512-OiPmHAAIqej1o9YqvhON2yedDEpGv5KUNGyPdQD0CPJijl4glNrWzlboWjmHbEmrxW1/ZkE9aMqhE6jI+Z8Oog==, tarball: file:projects/rpc-client.tgz}
     version: 0.0.0
 
   '@rush-temp/scale-codec@file:projects/scale-codec.tgz':
@@ -1578,15 +1578,15 @@ packages:
     version: 0.0.0
 
   '@rush-temp/solana-data-service@file:projects/solana-data-service.tgz':
-    resolution: {integrity: sha512-W18VMHinxHlEcs2pGPfrICd8DWZ6ch8boTC4L1K/Qmuzo+vInOf+6f5sJx+bDP6UYmKAxgWzIgnGMMbatD37iA==, tarball: file:projects/solana-data-service.tgz}
+    resolution: {integrity: sha512-7yeVX9AKxkmg2drQAzHkRPaQ41VXuLoNuEwjy6baLlgVhGS7Axv2wqUq7Cgxfv+Gdpuufu3Nu/zTWLtCTbd+VA==, tarball: file:projects/solana-data-service.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-dump@file:projects/solana-dump.tgz':
-    resolution: {integrity: sha512-lF2su6x9Pn94owildDPeg/ym/Mar2ZeQ1L/YMihoySPjXEAXoPqvnVVA060AfiYl2eA9AoPq7+lcjX+7xfF+8g==, tarball: file:projects/solana-dump.tgz}
+    resolution: {integrity: sha512-SpAMMa2t7MhSDoE3Ou9acwt28OP9Z3+FbTiZzoAV1YFfvHbi+5a4f7ZyKIuHcGVVOt50gtxy2MeGk1cYScBhsw==, tarball: file:projects/solana-dump.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-example@file:projects/solana-example.tgz':
-    resolution: {integrity: sha512-l8HZ7nJRo4qJ1iit80K3cJasr116DYghdFihVcXJy5ijHCEDWMjRlzdpvjmMZ5wNXUwgAVEy5ZwyFuRR9A7QzA==, tarball: file:projects/solana-example.tgz}
+    resolution: {integrity: sha512-agvLgduN1o9+rfe4EG4O3gc71EABsgyZYU6b5NOIYCJa5aF4X66PEPDDylqCvpByLQA0O4/hd65qvpXZSQbLHQ==, tarball: file:projects/solana-example.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-ingest@file:projects/solana-ingest.tgz':
@@ -1598,7 +1598,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/solana-objects@file:projects/solana-objects.tgz':
-    resolution: {integrity: sha512-gGDhKsEqK3ABTmY3nKCWKV4ARD5hudWeZlZT0h8zlMnVm3MRP+FoSjI94I6ZOhKxXxtVub3VcrC7CWcc1q1dlw==, tarball: file:projects/solana-objects.tgz}
+    resolution: {integrity: sha512-2Xe+QP08kGlWXK6/h8tSa8bkwIScaPYQ2G3PX9/fAjnROpmt7yZRNgyOOucvyIcGwytZBUjCRjnsWGWeZvg+lw==, tarball: file:projects/solana-objects.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-rpc-data@file:projects/solana-rpc-data.tgz':
@@ -1606,23 +1606,23 @@ packages:
     version: 0.0.0
 
   '@rush-temp/solana-rpc@file:projects/solana-rpc.tgz':
-    resolution: {integrity: sha512-hDAS5MjkXwuUazA5m/zPohhjJW54mHXRrt/66mXiyyzQL3rf1tPnrXfqdHgRM9QFK89WHiaNHpjZlmpare3OBQ==, tarball: file:projects/solana-rpc.tgz}
+    resolution: {integrity: sha512-Xq20ZBx/BmbTHRgWDmflammvs5NzyiMz3LJtZt7guhz+VruR88UvbedWG56HHyPXAP1ocANzr0VWbPQyiMmPlQ==, tarball: file:projects/solana-rpc.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-spray@file:projects/solana-spray.tgz':
-    resolution: {integrity: sha512-ElbO8ljJ47P02EtOp0nPPIycy5UfrPmaRhebE2G0lN+CZZmzZpF6g90Fv/KLGMdoWbzuoNLDZ7F8ZYLhaLj5DA==, tarball: file:projects/solana-spray.tgz}
+    resolution: {integrity: sha512-qVk0s34e+tWYHYnpWI08IDwt8sVHGcyKyWniAAFUmcVeECE+PYgToXUlsllqZ88tKD7ZoE4ngsWThnb+8cOrkA==, tarball: file:projects/solana-spray.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-stream@file:projects/solana-stream.tgz':
-    resolution: {integrity: sha512-N4GMpo07KOUG5hYSV/JkRzbTS2wfX9gxiv9o0ony3xVjjndQiQWjIW7YJaGNfsSdc5xXBrKdT6Nut3ShNSELWA==, tarball: file:projects/solana-stream.tgz}
+    resolution: {integrity: sha512-X3IyY5Y2luRScS0LwVd6LwRFNtINDv2vAs721BuM/VrOeVqVCj7dd2D9vQHwuHKynD/GXWcnF24Z22LOfHTpeA==, tarball: file:projects/solana-stream.tgz}
     version: 0.0.0
 
   '@rush-temp/solana-typegen@file:projects/solana-typegen.tgz':
-    resolution: {integrity: sha512-rMEFBHlorT/BZ7c/hknis5kFOc8lpDj8qFMiKQQKm1EQb0axSVHPOHLpMeeCKF0m+xwLT8YS10hjtHIghlPN4g==, tarball: file:projects/solana-typegen.tgz}
+    resolution: {integrity: sha512-Nk4xlg7/zhRaWwj79GLtVGQDedv72hKtDr2sSC0ZR76oDSGjGj4XfsE+p2nuszJzFhZBootVXOw/amD76Zjlog==, tarball: file:projects/solana-typegen.tgz}
     version: 0.0.0
 
   '@rush-temp/squid-sdk@file:projects/squid-sdk.tgz':
-    resolution: {integrity: sha512-oyriOCURY/lv7KOebPc52aLYEmmOE3bNjoJuj4Y6s/6bIYJeuwcsN7HBgWylds0HI0awPapbaTYrtaS3lQ1lBg==, tarball: file:projects/squid-sdk.tgz}
+    resolution: {integrity: sha512-M1MnLNTQSBb1vucPw+9PyV0oLa2zSM6T5Tr+gf6yvPVUz1o3LBEvm5FJ53c7GmpKp5hccGl5x8ba3+HiNekqtg==, tarball: file:projects/squid-sdk.tgz}
     version: 0.0.0
 
   '@rush-temp/ss58-codec@file:projects/ss58-codec.tgz':
@@ -1646,19 +1646,19 @@ packages:
     version: 0.0.0
 
   '@rush-temp/starknet-rpc@file:projects/starknet-rpc.tgz':
-    resolution: {integrity: sha512-ALbi6XMXlSFRVEQ/xZjq3aOgR1Dw8s7Clfv5Nr7y0qRIq4jAn51dLFfNj4XVSVQdwqYlD8Snqt4K9jl1ula0dQ==, tarball: file:projects/starknet-rpc.tgz}
+    resolution: {integrity: sha512-0pWD49gM+2GJ24CRPZ78oXGJtoNR1O6UVwV1M3dag9bWe5XsjIvPZpUvxrP9n+WM3M92KoelCkt9ken3y+zglQ==, tarball: file:projects/starknet-rpc.tgz}
     version: 0.0.0
 
   '@rush-temp/starknet-stream@file:projects/starknet-stream.tgz':
-    resolution: {integrity: sha512-HnGiwNW3ey2CWKXH+TmcVH7PKGytbu3e2x74rwU30okz3/zgFzJO4kjivPydpxGlVHqY1Ei/YmwlrZd8Xoeqyg==, tarball: file:projects/starknet-stream.tgz}
+    resolution: {integrity: sha512-55Njjzq6T8lWn/n4Hz/2DPfflT10g35aWRS99CIu72iwAIS/O50UtG8dxXN/Up6lOFTbIR/1sGt0dQxZHa/b1Q==, tarball: file:projects/starknet-stream.tgz}
     version: 0.0.0
 
   '@rush-temp/substrate-data-raw@file:projects/substrate-data-raw.tgz':
-    resolution: {integrity: sha512-WBGOlM3yBiQCliPkUaqPIPw4hAjLP82XzKzLg1OH/hX4A09fkIuQ1ZpZRiENMWUloHOtiCobwv27k0vkSMfSvw==, tarball: file:projects/substrate-data-raw.tgz}
+    resolution: {integrity: sha512-2UcHF/0/vaDmIHXN9rcyVu2co8r8dLs3lc3wsjY1mba5Xki9OWWhH33J6Ch65obN0ODgbH5fjf/oshDpmbHk2g==, tarball: file:projects/substrate-data-raw.tgz}
     version: 0.0.0
 
   '@rush-temp/substrate-data@file:projects/substrate-data.tgz':
-    resolution: {integrity: sha512-wFwE8eKVPrexqh6i9PESDAaF9wlL0Ht0H8zG4bLQmSbkVlpbm0xnE/XMOXEMQBeciz3yiopzfKoUzWAqLOCqIg==, tarball: file:projects/substrate-data.tgz}
+    resolution: {integrity: sha512-Yce1HQ0+rNZWUmy+asFhmLvcQAxtH8bXl1OYDopdIJV/k89cQntP5p03IXq9p/KW8/mHovEgwRd1iGke5qVSaw==, tarball: file:projects/substrate-data.tgz}
     version: 0.0.0
 
   '@rush-temp/substrate-dump@file:projects/substrate-dump.tgz':
@@ -1666,11 +1666,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/substrate-ingest@file:projects/substrate-ingest.tgz':
-    resolution: {integrity: sha512-mdoUwjRSZA/VhzSQz3XdV+fcRuGoCMfD5UUlA1yfb+4TvnTjFApJscgE5HmRCiIjX8f26TZQOVcwsO8y9BEU2g==, tarball: file:projects/substrate-ingest.tgz}
+    resolution: {integrity: sha512-SXMvXmtEIHR1Gyq8didM8oRLq0cGSlQGqY6tODrz0Kjqcn7UVxVvHDqOTkHq9QPoOFxl/1rK6rDLRNMbV3NgtQ==, tarball: file:projects/substrate-ingest.tgz}
     version: 0.0.0
 
   '@rush-temp/substrate-metadata-explorer@file:projects/substrate-metadata-explorer.tgz':
-    resolution: {integrity: sha512-gVjG6O5cOOFPkGyk+zjW3bdbiDOmX1gymaX2Yswf4T/1X7UcK3P77Jls0ZVWXVcQiB4COWc2neiWJdNyRbYoxA==, tarball: file:projects/substrate-metadata-explorer.tgz}
+    resolution: {integrity: sha512-SjYKcIoSp9M3eY20eP2HXt0i3F7iWybSqr8tlsolX7pxUlXD2B3Vrpbp89/vSuDgaiR20gZSNNUeRn2LKbmLYg==, tarball: file:projects/substrate-metadata-explorer.tgz}
     version: 0.0.0
 
   '@rush-temp/substrate-metadata-service@file:projects/substrate-metadata-service.tgz':
@@ -1678,7 +1678,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/substrate-processor@file:projects/substrate-processor.tgz':
-    resolution: {integrity: sha512-r9CDbbnzkvyU3nRxLJQbqzCWbX2c7+rX7342CWN0YsdSlCmQfr9IjwZNVM4XZFVESByYV6/GTnnywi/hYkK57w==, tarball: file:projects/substrate-processor.tgz}
+    resolution: {integrity: sha512-auZ0qsN9DQjrIgh+XSJbgEUH7TUmCSdoH1kxa0oJRN1tcYNIY1DrVGiDy5CyllKE/+zkEe1socOr/BzOTgOs9w==, tarball: file:projects/substrate-processor.tgz}
     version: 0.0.0
 
   '@rush-temp/substrate-runtime@file:projects/substrate-runtime.tgz':
@@ -1686,7 +1686,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/substrate-typegen@file:projects/substrate-typegen.tgz':
-    resolution: {integrity: sha512-+A3UzAvdYzMjhowP36qKFnNkn4QGtluDRP7xs12ft2Uxo7fUd6GujijXP7Q92m1yj3IsQ5ZIOlGhJpPd560fVg==, tarball: file:projects/substrate-typegen.tgz}
+    resolution: {integrity: sha512-PUN2stisZ+dJHe3JjeXsYFW8W74+jyg6236e4g9m0VxJcGbSNEzVLyPTfneGHXTPoaCPu9jq05N1mj8Ga9OhWQ==, tarball: file:projects/substrate-typegen.tgz}
     version: 0.0.0
 
   '@rush-temp/tron-data-service@file:projects/tron-data-service.tgz':
@@ -1694,7 +1694,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/tron-data@file:projects/tron-data.tgz':
-    resolution: {integrity: sha512-70pE3qXd2Bi7BSxTclNY+bKHnfbXjVYux26JK4btxiqyMnIImv5Lq2FaWGYCF3L/qCIZe5p/5oqz/S3BaoxpCA==, tarball: file:projects/tron-data.tgz}
+    resolution: {integrity: sha512-A96mBoYf6G6NbBYRs7lc0UUZsiR89AATa5uZVBlcVzvLxbaqUMCch0pzRj9m88ZcW6WT0aeL3dmnp/EG7O7J+Q==, tarball: file:projects/tron-data.tgz}
     version: 0.0.0
 
   '@rush-temp/tron-dump@file:projects/tron-dump.tgz':
@@ -1710,7 +1710,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/tron-processor@file:projects/tron-processor.tgz':
-    resolution: {integrity: sha512-Q6JWtgsApedgQF+AerlY4CbCRVKQnTOuOUri13ILu6uvZpI3gqHEkcoeYbpNHyqRo35hwZP44e/jupElLhMmPA==, tarball: file:projects/tron-processor.tgz}
+    resolution: {integrity: sha512-NatSoKl/UI/jb63ZYHYzk5GDkIPVMbCvDt84ZV/gksQwtOzGqXp/AojOcWvCbsluIBAolBwKrVjaGHNse43bkQ==, tarball: file:projects/tron-processor.tgz}
     version: 0.0.0
 
   '@rush-temp/tron-usdt@file:projects/tron-usdt.tgz':
@@ -1738,7 +1738,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/util-internal-archive-client@file:projects/util-internal-archive-client.tgz':
-    resolution: {integrity: sha512-pfW0I6pwt8EqJHgMKHZ/e/2Hm+jQeoiT5NkD34wjAusLaRbddsZytWixRno/uwGsbwHReB4OkwLcmvYA+VLd3w==, tarball: file:projects/util-internal-archive-client.tgz}
+    resolution: {integrity: sha512-rjJkWte1BtysiLqXicrl1B53U4jH8PRFnplTautTpLSrQQP447ddhjCeldREQkUQgSoNwnVrH/eGSvooIuORyQ==, tarball: file:projects/util-internal-archive-client.tgz}
     version: 0.0.0
 
   '@rush-temp/util-internal-archive-layout@file:projects/util-internal-archive-layout.tgz':
@@ -1774,7 +1774,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/util-internal-dump-cli@file:projects/util-internal-dump-cli.tgz':
-    resolution: {integrity: sha512-xrOi8t2DQYfCePeFNdRf8Kvr/1vxEyI0D0KTacWyuJ65I5dA0iOatgHJnsmGo9/BwOysY6bj3FERRuSHNR2Z+A==, tarball: file:projects/util-internal-dump-cli.tgz}
+    resolution: {integrity: sha512-8HsFUejXd4xmOTf9621xwWGxo4BFzKodJ8xUsCqeY3CjehBpf0CSJjUtcbIouvoA9HJ4/+sPiXLiWtb6aCuNaw==, tarball: file:projects/util-internal-dump-cli.tgz}
     version: 0.0.0
 
   '@rush-temp/util-internal-fs@file:projects/util-internal-fs.tgz':
@@ -1790,7 +1790,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/util-internal-ingest-cli@file:projects/util-internal-ingest-cli.tgz':
-    resolution: {integrity: sha512-z1AMGjRoL/tFwRcERLytL+jJGPe1BlA9zJqEwzeLEWhfsL14fNUqLV3jX0hwQMA2iv9N14U75h0G9FKxeRmaYg==, tarball: file:projects/util-internal-ingest-cli.tgz}
+    resolution: {integrity: sha512-AiPTisyRSPSDpzfbLKHtlDchMkPx1awk0chMhah6GNjiK70N2lBtLrAjEWaNsNiDI6S59Ng4gFbtVNd+jZWmjg==, tarball: file:projects/util-internal-ingest-cli.tgz}
     version: 0.0.0
 
   '@rush-temp/util-internal-ingest-tools@file:projects/util-internal-ingest-tools.tgz':
@@ -6236,15 +6236,38 @@ snapshots:
       '@types/node': 24.0.15
       typescript: 5.5.4
 
-  '@rush-temp/hyperliquid-replica-cmds-ingest@file:projects/hyperliquid-replica-cmds-ingest.tgz':
+  '@rush-temp/hyperliquid-replica-cmds-ingest@file:projects/hyperliquid-replica-cmds-ingest.tgz(esbuild@0.27.7)(tsx@4.21.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.462.0
       '@types/lz4': 0.6.4
       '@types/node': 24.0.15
       lz4: 0.6.5
       typescript: 5.5.4
+      vitest: 4.1.5(@types/node@24.0.15)(esbuild@0.27.7)(tsx@4.21.0)
     transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitejs/devtools'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
       - aws-crt
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   '@rush-temp/hyperliquid-replica-cmds-normalization@file:projects/hyperliquid-replica-cmds-normalization.tgz':
     dependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "165e0a759de47cb454e31123aacfee9ec299ed58"
+  "pnpmShrinkwrapHash": "e1dc838cafca4801451d0e906014d7c0a3c5ac46"
 }

--- a/hyperliquid/hyperliquid-replica-cmds-ingest/package.json
+++ b/hyperliquid/hyperliquid-replica-cmds-ingest/package.json
@@ -16,7 +16,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.462.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@types/lz4": "^0.6.4",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "4.1.5"
   }
 }

--- a/hyperliquid/hyperliquid-replica-cmds-ingest/src/archive.test.ts
+++ b/hyperliquid/hyperliquid-replica-cmds-ingest/src/archive.test.ts
@@ -1,0 +1,86 @@
+import {describe, it, expect} from 'vitest'
+import type {Logger} from '@subsquid/logger'
+import type {Fs} from '@subsquid/util-internal-fs'
+import {HyperliquidArchive} from './archive'
+
+
+// In-memory archive layout: top (ISO-8601) -> subfolder (YYYYMMDD) -> chunk files.
+// A file named `<n>.lz4` holds blocks starting at n + 1.
+const LAYOUT: Record<string, Record<string, string[]>> = {
+    '2025-01-01T00:00:00Z': {'20250101': ['0.lz4', '100.lz4'], '20250102': ['200.lz4', '300.lz4']},
+    '2025-06-01T00:00:00Z': {'20250601': ['400.lz4', '500.lz4']},
+    '2026-01-01T00:00:00Z': {'20260101': ['600.lz4', '700.lz4']},
+}
+
+function mockFs(listed: string[]): Fs {
+    return {
+        async ls(...path: string[]): Promise<string[]> {
+            listed.push(path.join('/'))
+            if (path.length === 0) return Object.keys(LAYOUT)
+            if (path.length === 1) return Object.keys(LAYOUT[path[0]] ?? {})
+            if (path.length === 2) return [...(LAYOUT[path[0]]?.[path[1]] ?? [])]
+            return []
+        },
+    } as unknown as Fs
+}
+
+const log = {debug() {}, child() {return log}} as unknown as Logger
+
+async function collect(archive: HyperliquidArchive, range: {from: number; to: number}): Promise<string[]> {
+    let out: string[] = []
+    for await (let c of (archive as any).getRawChunks(range) as AsyncIterable<any>) {
+        out.push(`${c.top}/${c.subfolder}/${c.filename}`)
+    }
+    return out
+}
+
+describe('HyperliquidArchive.getRawChunks', () => {
+    it('does not re-list already-consumed folders on a forward fetch', async () => {
+        let listed: string[] = []
+        let archive = new HyperliquidArchive(mockFs(listed), log)
+
+        // Consume everything so the cursor advances to the head.
+        await collect(archive, {from: 1, to: Infinity})
+
+        listed.length = 0
+        // A subsequent forward fetch must resume near the head instead of
+        // re-walking the whole archive from the root.
+        await collect(archive, {from: 701, to: Infinity})
+
+        expect(listed).not.toContain('2025-01-01T00:00:00Z')
+        expect(listed).not.toContain('2025-06-01T00:00:00Z')
+        expect(listed.some(p => p.startsWith('2025-01-01T00:00:00Z/'))).toBe(false)
+        expect(listed.some(p => p.startsWith('2025-06-01T00:00:00Z/'))).toBe(false)
+    })
+
+    it('yields the same chunks with or without a warm cursor', async () => {
+        let cold = await collect(new HyperliquidArchive(mockFs([]), log), {from: 450, to: 650})
+
+        let warm = new HyperliquidArchive(mockFs([]), log)
+        await collect(warm, {from: 1, to: 250}) // warm the cursor on an earlier range
+        let warmChunks = await collect(warm, {from: 450, to: 650})
+
+        expect(warmChunks).toEqual(cold)
+        expect(cold).toEqual([
+            '2025-06-01T00:00:00Z/20250601/400.lz4',
+            '2025-06-01T00:00:00Z/20250601/500.lz4',
+            '2026-01-01T00:00:00Z/20260101/600.lz4',
+        ])
+    })
+
+    it('falls back to a full walk when the range moves backwards', async () => {
+        let listed: string[] = []
+        let archive = new HyperliquidArchive(mockFs(listed), log)
+
+        await collect(archive, {from: 601, to: 700}) // cursor now near the head
+        listed.length = 0
+        let chunks = await collect(archive, {from: 1, to: 150}) // rewind
+
+        // A backward request must re-list from the root to find the old chunk.
+        expect(listed).toContain('2025-01-01T00:00:00Z')
+        expect(chunks).toEqual([
+            '2025-01-01T00:00:00Z/20250101/0.lz4',
+            '2025-01-01T00:00:00Z/20250101/100.lz4',
+        ])
+    })
+})

--- a/hyperliquid/hyperliquid-replica-cmds-ingest/src/archive.ts
+++ b/hyperliquid/hyperliquid-replica-cmds-ingest/src/archive.ts
@@ -17,6 +17,10 @@ interface RawChunk {
 
 
 export class HyperliquidArchive {
+    // Last chunk we served. Lets a subsequent forward fetch resume near the
+    // head instead of re-listing the whole archive from the root every time.
+    private cursor?: RawChunk
+
     constructor(private fs: Fs, private log: Logger) { }
 
     async *getRawBlocks(range?: Range): AsyncIterable<Block[]> {
@@ -52,17 +56,26 @@ export class HyperliquidArchive {
     }
 
     private async *getRawChunks(range: FiniteRange): AsyncIterable<RawChunk> {
+        // Folders are chronologically ordered (tops are ISO-8601, subfolders are
+        // YYYYMMDD) and block numbers grow monotonically, so when the request
+        // moves forward we can resume from the last served chunk and skip listing
+        // all the already-consumed folders. Fall back to a full walk otherwise.
+        let resume = this.cursor
+        if (resume != null && resume.block > range.from) resume = undefined
+
         this.log.debug('listing root folder')
         let tops = await this.fs.ls()
 
-        let prevChunk: RawChunk | undefined
+        let prevChunk: RawChunk | undefined = resume
         for (let i = 0; i < tops.length; i++) {
             let top = tops[i]
+            if (resume != null && top < resume.top) continue
 
             this.log.debug(`listing ${top} folder`)
             let subfolders = await this.fs.ls(`${top}`)
             for (let j = 0; j < subfolders.length; j++) {
                 let subfolder = subfolders[j]
+                if (resume != null && top == resume.top && subfolder < resume.subfolder) continue
 
                 this.log.debug(`listing ${top}/${subfolder} folder`)
                 let files = await this.fs.ls(`${top}`, `${subfolder}`)
@@ -71,13 +84,16 @@ export class HyperliquidArchive {
                     let block = parseFile(filename) + 1 // first block in each file it is filename + 1
                     let rawChunk = { filename, subfolder, top, block }
                     if (block == range.from) {
+                        this.cursor = rawChunk
                         yield rawChunk
                     } else if (block > range.from) {
                         let lastChunk = assertNotNull(prevChunk, `block ${range.from} is not supported`)
                         if (lastChunk.block < range.from) {
+                            this.cursor = lastChunk
                             yield lastChunk
                         }
                         if (block > range.to) return
+                        this.cursor = rawChunk
                         yield rawChunk
                     }
 

--- a/hyperliquid/hyperliquid-replica-cmds-ingest/tsconfig.json
+++ b/hyperliquid/hyperliquid-replica-cmds-ingest/tsconfig.json
@@ -16,6 +16,7 @@
   },
   "include": ["src"],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "src/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## Problem

The `hyperliquid-replica-cmds` ingest fell ~30% behind its 24h baseline and kept growing (lag reached ~54 min). The ingest pod had not restarted in 7 days, CPU was low (~0.45 cores) and memory flat — it was **I/O-bound on S3**. Live pod logs showed the ingest doing **599 S3 `ls` operations and processing only 1 chunk in 164 s**, walking every folder back to `2025-05-25` (65+ weekly top folders).

Root cause is in `HyperliquidArchive.getRawChunks`: it re-listed the **entire bucket from the root** (`fs.ls()` → every top → every subfolder → every file) on **every** range fetch. The ingest runs as a service and the writer pulls ranges continuously, so each pull triggered a full walk. As the bucket grew to ~15 months of data, a walk grew to hundreds of sequential list calls and its fixed per-fetch cost overtook the chain's block rate, so ingest could no longer keep up.

This is data-growth-driven degradation, not a deploy regression. The sibling `hyperliquid-fills-ingest` archive already avoids the full re-walk with a `lastProcessedChunk` cache; this package had no such optimization.

## Fix

Cache the last served chunk (`cursor`). When the requested range moves **forward** (`cursor.block <= range.from`), resume the walk from the cursor's top/subfolder and skip already-consumed folders — safe because tops are ISO-8601 and subfolders are `YYYYMMDD`, both lexicographically == chronologically ordered, and block numbers grow monotonically. A backward range (rollback / re-request) falls back to a full walk. The set of yielded chunks is unchanged.

Effect in the added test's layout: a forward fetch drops from listing all 8 folders to 3 (root + head top + its subfolder). In production this turns an O(bucket-size) walk per fetch into O(new-folders-near-head).

## Tests

`src/archive.test.ts` (vitest):
- **does not re-list already-consumed folders on a forward fetch** — the regression test. Fails on pre-fix code (re-lists `2025-*` tops), passes after.
- **yields the same chunks with or without a warm cursor** — correctness / behaviour preservation.
- **falls back to a full walk when the range moves backwards.**

Verified locally: `rush build` green; `vitest --run` 3/3 green post-fix; the regression test is **red on pre-fix** source and **green after** (confirmed by stashing the change and re-running).

## Falsification

If, after deploy, `ingest-hyperliquid-replica-cmds-0` logs still show long runs of `listing … folder` back to old dates between `processing chunk` markers (many `ls` per chunk), or `time() - sqd_latest_processed_block_timestamp` keeps climbing, then the listing walk was not the bottleneck and the cause lies elsewhere (e.g. upstream S3 read latency or chunk read/write throughput).